### PR TITLE
Update to qemu version 3.0.0 and support aarch64 emulation

### DIFF
--- a/lib/utils/compose.coffee
+++ b/lib/utils/compose.coffee
@@ -166,7 +166,7 @@ exports.buildProject = (
 		renderer = new BuildProgressUI(tty, imageDescriptors)
 	renderer.start()
 
-	qemu.installQemuIfNeeded(emulated, logger)
+	qemu.installQemuIfNeeded(emulated, logger, arch)
 	.tap (needsQemu) ->
 		return if not needsQemu
 		logger.logInfo('Emulation is enabled')

--- a/lib/utils/compose.coffee
+++ b/lib/utils/compose.coffee
@@ -173,7 +173,7 @@ exports.buildProject = (
 		# Copy qemu into all build contexts
 		Promise.map imageDescriptors, (d) ->
 			return if not d.image.context? # external image
-			return qemu.copyQemu(path.join(projectPath, d.image.context))
+			return qemu.copyQemu(path.join(projectPath, d.image.context), arch)
 	.then (needsQemu) ->
 		# Tar up the directory, ready for the build stream
 		tarDirectory(projectPath)

--- a/lib/utils/qemu.coffee
+++ b/lib/utils/qemu.coffee
@@ -80,21 +80,19 @@ installQemu = (arch) ->
 			downloadArchiveName = "qemu-3.0.0+resin-#{arch}.tar.gz"
 			qemuUrl = "https://github.com/balena-io/qemu/releases/download/#{QEMU_VERSION}/#{downloadArchiveName}"
 			extract = tar.extract()
-			extract.on('entry', (header, stream, next) ->
+			extract.on 'entry', (header, stream, next) ->
 				stream.on('end', next)
 				if header.name.includes("qemu-#{arch}-static")
 					stream.pipe(installStream)
 				else
 					stream.resume()
-			)
 			request(qemuUrl)
 			.on('error', reject)
 			.pipe(zlib.createGunzip())
 			.on('error', reject)
 			.pipe(extract)
 			.on('error', reject)
-			.on('finish', ->
+			.on 'finish', ->
 				# make qemu binary executable
 				fs.chmodSync(qemuPath, '755')
 				resolve()
-			)

--- a/package.json
+++ b/package.json
@@ -168,6 +168,7 @@
     "split": "^1.0.1",
     "string-width": "^2.1.1",
     "strip-ansi-stream": "^1.0.0",
+    "tar": "^4.4.6",
     "tar-stream": "^1.5.5",
     "through2": "^2.0.3",
     "tmp": "0.0.31",

--- a/package.json
+++ b/package.json
@@ -168,7 +168,6 @@
     "split": "^1.0.1",
     "string-width": "^2.1.1",
     "strip-ansi-stream": "^1.0.0",
-    "tar": "^4.4.6",
     "tar-stream": "^1.5.5",
     "through2": "^2.0.3",
     "tmp": "0.0.31",


### PR DESCRIPTION
Disclaimer: I've never written anything for node before, so if I'm not following some best practices, please correct me.

I found that when trying to build a Jetson TX2 project locally, using the `--emulated` flag, the builds always failed with the error "Invalid ELF image for this architecture". This is because the version of qemu downloaded by Resin is built for arm, rather than aarch64 (which Jetson uses).

This PR updates the qemu version to 3.0.0, both because it's the latest version for which Resin has a release and because there are binaries built for both arm and aarch64. I've updated the qemu installation functions to accept an `arch` parameter and use that to download and install the correct binary. I've updated the extraction code because the archive format has changed.

While this change works for my current purposes, it introduces a potential design problem if a single user is building projects for both arm and aarch64. Since the binary is only downloaded once, if the user has previously built an aarch64 project and now wants to build an arm project, they will need to manually remove the `~/.resin/bin/qemu-execve` file before running the build command, in order to force the download of the correct binary.

I can think of two ways to resolve this:

1) Instead of simply checking for the binary's existence, check the binary version and initiate a download if it doesn't match the desired architecture; or

2) Store each binary separately (as `~/.resin/bin/qemu-execve-aarch64`, for instance) and copy the correct version into the Docker container when building.

I think 2 is preferable because it avoids unnecessary downloads and works with concurrent builds with different architectures, but I am not sure where to make that change.