### PR TITLE
Stop validating device config, now that it's API-generated

### DIFF
--- a/lib/actions/config.coffee
+++ b/lib/actions/config.coffee
@@ -285,7 +285,6 @@ exports.generate =
 		writeFileAsync = Promise.promisify(require('fs').writeFile)
 		balena = require('balena-sdk').fromSharedOptions()
 		form = require('resin-cli-form')
-		deviceConfig = require('resin-device-config')
 		prettyjson = require('prettyjson')
 
 		{ generateDeviceConfig, generateApplicationConfig } = require('../utils/config')
@@ -319,7 +318,6 @@ exports.generate =
 				else
 					generateApplicationConfig(resource, answers)
 		.then (config) ->
-			deviceConfig.validate(config)
 			if options.output?
 				return writeFileAsync(options.output, JSON.stringify(config))
 

--- a/lib/utils/config.ts
+++ b/lib/utils/config.ts
@@ -32,8 +32,6 @@ type ImgConfig = {
 	vpnEndpoint: string;
 	registryEndpoint: string;
 	deltaEndpoint: string;
-	pubnubSubscribeKey: string;
-	pubnubPublishKey: string;
 	mixpanelToken: string;
 	wifiSsid?: string;
 	wifiKey?: string;

--- a/package.json
+++ b/package.json
@@ -155,7 +155,6 @@
     "resin-cli-form": "^2.0.0",
     "resin-cli-visuals": "^1.4.0",
     "resin-compose-parse": "^2.0.0",
-    "resin-device-config": "^5.0.0",
     "resin-device-init": "^4.0.0",
     "resin-doodles": "0.0.1",
     "resin-image-fs": "^5.0.2",

--- a/typings/resin-device-config.d.ts
+++ b/typings/resin-device-config.d.ts
@@ -1,1 +1,0 @@
-declare module 'resin-device-config';


### PR DESCRIPTION
No need any more since it's generated elsewhere nowadays, and this causes problems as we can't change the API output format if existing CLI installs depend on this fixed validation schema.

This appears to have been causing `Validation: pubnubSubscribeKey not recognized` in production for the last couple of days, which should be resolved with this change.