### PR TITLE
Fix build & deploy commands in standalone build

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "scripts": [
       "node_modules/balena-sync/build/capitano/*.js",
       "node_modules/balena-sync/build/sync/*.js",
-      "node_modules/resin-compose-parse/src/schemas/*.json",
+      "node_modules/resin-compose-parse/build/schemas/*.json",
       "node_modules/raven/lib/instrumentation/*.js"
     ],
     "assets": [


### PR DESCRIPTION
As part of some of the v2 changes in resin-compose-parse, we stopped depending on the schemas from the src directory, and started using them directly from the build directory instead. 

Unfortunately, these schemas aren't automatically bundled into the standalone by pkg - we have to do so explicitly, and we didn't update the paths that did that so when the CLI upgraded to v2 a few weeks ago, this wasn't updated.

Change-type: patch