### PR TITLE
Add case-insensitive checking for application names in balena push

### DIFF
--- a/lib/actions/push.ts
+++ b/lib/actions/push.ts
@@ -57,7 +57,7 @@ async function getAppOwner(sdk: BalenaSDK, appName: string) {
 			},
 		},
 		$filter: {
-			app_name: appName,
+			$eq: [{ $tolower: { $: 'app_name' } }, appName.toLowerCase()],
 		},
 		$select: ['id'],
 	});

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "balena-device-init": "^5.0.0",
     "balena-image-manager": "^6.0.0",
     "balena-preload": "^8.0.0",
-    "balena-sdk": "^11.0.0",
+    "balena-sdk": "^11.2.0",
     "balena-settings-client": "^4.0.0",
     "balena-sync": "^10.0.0",
     "bash": "0.0.1",


### PR DESCRIPTION
The filter is added with an `as any`, as the typings dont yet support
using $eq and $ne.

Change-type: patch
Signed-off-by: Cameron Diver <cameron@balena.io>