### PR TITLE
Don't show list of devices when UUID is not found when doing an SSH

### DIFF
--- a/lib/actions/ssh.coffee
+++ b/lib/actions/ssh.coffee
@@ -99,10 +99,13 @@ module.exports =
 			return "-o #{bash.args({ ProxyCommand: proxyCommand }, '', '=')}"
 
 		Promise.try ->
-			return false if not params.uuid
-			return balena.models.device.has(params.uuid)
-		.then (uuidExists) ->
-			return params.uuid if uuidExists
+			return { provided: false } if not params.uuid
+			return { provided: true, uuid: balena.models.device.has(params.uuid) }
+		.then ({ provided, uuidExists }) ->
+			if provided
+				return params.uuid if uuidExists
+				# We got a UUID but it doesn't exist or is not accessible
+				patterns.exitWithExpectedError('Could not find or access a device with that UUID')
 			return patterns.inferOrSelectDevice()
 		.then (uuid) ->
 			console.info("Connecting to: #{uuid}")


### PR DESCRIPTION
If the user provides a UUID which is not found or not accessible, the CLI will proceed to show a list of accessible devices. This doesn't make sense from both a UX and a automation POV.

Change-type: patch
Signed-off-by: Cameron Diver <cameron@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Introduces security considerations
- [ ] Affects the development, build or deployment processes of the component
