### PR TITLE
actions/config: Fix examples to include --version as required

### DIFF
--- a/doc/cli.markdown
+++ b/doc/cli.markdown
@@ -1138,13 +1138,13 @@ that will be asked for the relevant device type.
 
 Examples:
 
-	$ balena config generate --device 7cf02a6
-	$ balena config generate --device 7cf02a6 --generate-device-api-key
-	$ balena config generate --device 7cf02a6 --device-api-key <existingDeviceKey>
-	$ balena config generate --device 7cf02a6 --output config.json
-	$ balena config generate --app MyApp
-	$ balena config generate --app MyApp --output config.json
-	$ balena config generate --app MyApp --network wifi --wifiSsid mySsid --wifiKey abcdefgh --appUpdatePollInterval 1
+	$ balena config generate --device 7cf02a6 --version 2.12.7
+	$ balena config generate --device 7cf02a6 --version 2.12.7 --generate-device-api-key
+	$ balena config generate --device 7cf02a6 --version 2.12.7 --device-api-key <existingDeviceKey>
+	$ balena config generate --device 7cf02a6 --version 2.12.7 --output config.json
+	$ balena config generate --app MyApp --version 2.12.7
+	$ balena config generate --app MyApp --version 2.12.7 --output config.json
+	$ balena config generate --app MyApp --version 2.12.7 --network wifi --wifiSsid mySsid --wifiKey abcdefgh --appUpdatePollInterval 1
 
 ### Options
 

--- a/lib/actions/config.coffee
+++ b/lib/actions/config.coffee
@@ -231,17 +231,17 @@ exports.generate =
 
 		Examples:
 
-			$ balena config generate --device 7cf02a6
-			$ balena config generate --device 7cf02a6 --generate-device-api-key
-			$ balena config generate --device 7cf02a6 --device-api-key <existingDeviceKey>
-			$ balena config generate --device 7cf02a6 --output config.json
-			$ balena config generate --app MyApp
-			$ balena config generate --app MyApp --output config.json
-			$ balena config generate --app MyApp \
+			$ balena config generate --device 7cf02a6 --version 2.12.7
+			$ balena config generate --device 7cf02a6 --version 2.12.7 --generate-device-api-key
+			$ balena config generate --device 7cf02a6 --version 2.12.7 --device-api-key <existingDeviceKey>
+			$ balena config generate --device 7cf02a6 --version 2.12.7 --output config.json
+			$ balena config generate --app MyApp --version 2.12.7
+			$ balena config generate --app MyApp --version 2.12.7 --output config.json
+			$ balena config generate --app MyApp --version 2.12.7 \
 				--network wifi --wifiSsid mySsid --wifiKey abcdefgh --appUpdatePollInterval 1
 	'''
 	options: [
-		commandOptions.optionalOsVersion
+		commandOptions.osVersion
 		commandOptions.optionalApplication
 		commandOptions.optionalDevice
 		commandOptions.optionalDeviceApiKey


### PR DESCRIPTION
This is currently required by the SDK's `os.os.getConfig()` which throws `An OS version is required when calling os.getConfig` when it isn't provided.

Connects-to: #1007
Change-type: patch
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Introduces security considerations
- [ ] Affects the development, build or deployment processes of the component
