### PR TITLE
Filter files relative to the .gitignore file to ensure the parent pat…

### DIFF
--- a/lib/utils/ignore.ts
+++ b/lib/utils/ignore.ts
@@ -87,7 +87,7 @@ export class FileIgnorer {
 	// Pass this function as a predicate to a filter function, and it will filter
 	// any ignored files
 	public filter = (filename: string): boolean => {
-		const relFile = path.relative(this.basePath, filename);
+		let relFile = path.relative(this.basePath, filename);
 
 		// Don't ignore any metadata files
 		const baseDir = path.dirname(relFile).split(path.sep)[0];
@@ -114,6 +114,7 @@ export class FileIgnorer {
 		_.each(ignoreTypes, ({ handle, entries }) => {
 			_.each(entries, ({ pattern, filePath }) => {
 				if (FileIgnorer.contains(path.posix.dirname(filePath), filename)) {
+					relFile = path.relative(path.posix.dirname(filePath), filename);
 					handle.add(pattern);
 				}
 			});

--- a/tests/utils/ignore.spec.coffee
+++ b/tests/utils/ignore.spec.coffee
@@ -133,3 +133,17 @@ describe 'File ignorer', ->
 			'vendor/another/package/vendor/file'
 			'vendor/user/package/file'
 		])
+
+	it 'should filter properly when two gitignore files match', ->
+
+		ignore = new FileIgnorer('.' + path.sep)
+		ignore.gitIgnoreEntries = [
+			{ pattern: 'c', filePath: 'a/b/.gitignore' }
+			{ pattern: 'delete-me', filePath: 'a/b/c/.gitignore' }
+		]
+		files = [
+			'a/b/c/deleted-due-to-parent-gitignore'
+			'a/b/c/delete-me'
+		]
+		expect(_.filter(files, ignore.filter.bind(ignore))).to.deep.equal([
+		])

--- a/tests/utils/ignore.spec.coffee
+++ b/tests/utils/ignore.spec.coffee
@@ -83,3 +83,53 @@ describe 'File ignorer', ->
 			'root.ignore'
 			'lib/normal-file'
 		])
+
+	it 'should filter absolute paths starting from subdirectories', ->
+
+		ignore = new FileIgnorer('.' + path.sep)
+		ignore.gitIgnoreEntries = [
+			{ pattern: '/ignore', filePath: 'app/.gitignore' }
+		]
+		files = [
+			'app/ignore'
+			'app/ignore/file'
+			'app/keep'
+			'app/keep/file'
+		]
+		expect(_.filter(files, ignore.filter.bind(ignore))).to.deep.equal([
+			'app/keep'
+			'app/keep/file'
+		])
+
+	it 'should not filter entries with an exclamation mark', ->
+
+		ignore = new FileIgnorer('.' + path.sep)
+		ignore.gitIgnoreEntries = [
+			{ pattern: '*', filePath: 'app/.gitignore' }
+			{ pattern: '!keep-me', filePath: 'app/.gitignore' }
+		]
+		files = [
+			'app/remove-me'
+			'app/keep-me'
+		]
+		expect(_.filter(files, ignore.filter.bind(ignore))).to.deep.equal([
+			'app/keep-me'
+		])
+
+	it 'should filter directories only from subdirectories', ->
+
+		ignore = new FileIgnorer('.' + path.sep)
+		ignore.gitIgnoreEntries = [
+			{ pattern: 'vendor/', filePath: 'vendor/user/package/.gitignore' }
+		]
+		files = [
+			'vendor/another/package/file'
+			'vendor/another/package/vendor/file'
+			'vendor/user/package/file'
+			'vendor/user/package/vendor/file'
+		]
+		expect(_.filter(files, ignore.filter.bind(ignore))).to.deep.equal([
+			'vendor/another/package/file'
+			'vendor/another/package/vendor/file'
+			'vendor/user/package/file'
+		])


### PR DESCRIPTION
All `.gitignore` files in the file tree are used to filter files. Files deeper in the file tree specify rules that only apply to files and subfiles from that point onwards. This patch makes sure only the relative path from the specific `.gitignore` file is compared to the rules inside the `.gitignore` file.

This ensures that parts from the parent path cannot trigger the rules.

<!-- You can remove tags that do not apply. -->
Resolves: # <!-- Refer an issue of this repository that this PR fixes -->
See: https://github.com/balena-io/balena-cli/issues/1032 (issue not resolved, as .gitignore files may stil need to be treated differently
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
Change-type: patch <!-- The change type of this PR -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Introduces security considerations
- [ ] Affects the development, build or deployment processes of the component
