### PR TITLE
Moving docs from PR #1055

### DIFF
--- a/capitanodoc.ts
+++ b/capitanodoc.ts
@@ -18,9 +18,9 @@ Before installing the Balena CLI from npm, make sure you have the following depe
 
 For example, to install these packages on a Debian-based Linux operating systems:
 
-```
+\`\`\`
 $ sudo apt-get install g++ make python git --yes
-```
+\`\`\`
 
 **NOTE**: If you are installing the stand-alone binary CLI, you will not need to install these dependencies.
 

--- a/capitanodoc.ts
+++ b/capitanodoc.ts
@@ -7,6 +7,23 @@ Please make sure your system meets the requirements as specified in the [README]
 
 ## Install the CLI
 
+### Dependencies
+
+Before installing the Balena CLI from npm, make sure you have the following dependencies installed:
+
+* make
+* g++ compiler
+* Python 2.7
+* git
+
+For example, to install these packages on a Debian-based Linux operating systems:
+
+```
+$ sudo apt-get install g++ make python git --yes
+```
+
+**NOTE**: If you are installing the stand-alone binary CLI, you will not need to install these dependencies.
+
 ### Npm install
 
 The best supported way to install the CLI is from npm:


### PR DESCRIPTION
- Doc addition was originally made in: https://github.com/balena-io/balena-cli/pull/1055
- Moving docs to `capitanodoc.ts` instead, as it's used to generate the `/doc` directory via the `npm run build:doc` command

Change-type: minor
Signed-off-by: Trevor Sullivan <trevor@balena.io>

<!-- You can remove tags that do not apply. -->
Resolves: # <!-- Refer an issue of this repository that this PR fixes -->
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->
Change-type: major|minor|patch <!-- The change type of this PR -->

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Introduces security considerations
- [ ] Affects the development, build or deployment processes of the component
