### PR TITLE
Handle 'unknown blob' errors and retry image pushing

### DIFF
--- a/lib/actions/push.ts
+++ b/lib/actions/push.ts
@@ -194,11 +194,11 @@ export const push: CommandDefinition<
 		switch (buildTarget) {
 			case BuildTarget.Cloud:
 				const app = appOrDevice;
-				Bluebird.join(
+				await Bluebird.join(
 					sdk.auth.getToken(),
 					sdk.settings.get('balenaUrl'),
 					getAppOwner(sdk, app),
-					(token, baseUrl, owner) => {
+					async (token, baseUrl, owner) => {
 						const opts = {
 							emulated: options.emulated,
 							nocache: options.nocache,
@@ -214,14 +214,14 @@ export const push: CommandDefinition<
 							opts,
 						};
 
-						return remote.startRemoteBuild(args);
+						return await remote.startRemoteBuild(args);
 					},
 				).nodeify(done);
 				break;
 			case BuildTarget.Device:
 				const device = appOrDevice;
 				// TODO: Support passing a different port
-				Bluebird.resolve(
+				await Bluebird.resolve(
 					deviceDeploy.deployToDevice({
 						source,
 						deviceHost: device,

--- a/lib/utils/compose_ts.ts
+++ b/lib/utils/compose_ts.ts
@@ -35,7 +35,8 @@ export interface RegistrySecrets {
 export async function parseRegistrySecrets(
 	secretsFilename: string,
 ): Promise<RegistrySecrets> {
-	const { fs } = require('mz');
+	const { fs } = await import('mz');
+	const { exitWithExpectedError } = await import('../utils/patterns');
 	try {
 		let isYaml = false;
 		if (/.+\.ya?ml$/i.test(secretsFilename)) {
@@ -50,10 +51,11 @@ export async function parseRegistrySecrets(
 		MultiBuild.addCanonicalDockerHubEntry(registrySecrets);
 		return registrySecrets;
 	} catch (error) {
-		error.message =
-			`Error validating registry secrets file "${secretsFilename}":\n` +
-			error.message;
-		throw error;
+		return exitWithExpectedError(
+			`Error validating registry secrets file "${secretsFilename}":\n${
+				error.message
+			}`,
+		);
 	}
 }
 

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "columnify": "^1.5.2",
     "common-tags": "^1.7.2",
     "denymount": "^2.2.0",
-    "docker-progress": "^3.0.1",
+    "docker-progress": "^3.0.4",
     "docker-qemu-transpose": "^0.5.3",
     "docker-toolbelt": "^3.3.5",
     "dockerode": "^2.5.5",


### PR DESCRIPTION
This PR bumps `docker-progress` to improved detection of 'unknown blob' errors, add image push retry (including in case of an 'unknown blob' error) for the `balena deploy` command as requested in issue #1010, and in a separate commit also hardens error handling for the `balena push` command (`remote-build.ts`).

Resolves: #1010 
HQ: balena-io/balena#1531
Depends-on: balena-io-modules/docker-progress/pull/46
Change-type: patch
