### PR TITLE
Fix 'unauthorized' error for additional members of legacy apps

### DIFF
--- a/lib/actions/deploy.coffee
+++ b/lib/actions/deploy.coffee
@@ -84,7 +84,8 @@ deployProject = (docker, logger, composeOpts, opts) ->
 					sdk.auth.whoami()
 					sdk.settings.get('balenaUrl')
 					{
-						appName: opts.app.app_name
+						# opts.appName may be prefixed by 'owner/', unlike opts.app.app_name
+						appName: opts.appName
 						imageName: images[0].name
 						buildLogs: images[0].logs
 						shouldUploadLogs: opts.shouldUploadLogs
@@ -184,6 +185,7 @@ module.exports =
 
 		logger.logDebug('Parsing input...')
 
+		appName = undefined
 		Promise.try ->
 			{ appName, image } = params
 
@@ -218,6 +220,7 @@ module.exports =
 				(docker, buildOpts, composeOpts) ->
 					deployProject(docker, logger, composeOpts, {
 						app
+						appName  # may be prefixed by 'owner/', unlike app.app_name
 						image
 						shouldPerformBuild
 						shouldUploadLogs


### PR DESCRIPTION
Please see description of issue #1102 for what this PR aims at. On investigation, I've gathered that since a refactoring about a year ago, the CLI was discarding the 'owner' part of 'owner/appName' for legacy applications when creating the builder endpoint URL.

Resolves: #1102
Change-type: patch
Signed-off-by: Paulo Castro <paulo@balena.io>
