### PR TITLE
ssh: correct the minimum OS version that allows host OS connection

### DIFF
--- a/doc/cli.markdown
+++ b/doc/cli.markdown
@@ -988,7 +988,7 @@ increase verbosity
 
 #### --host, -s
 
-access host OS (for devices with balenaOS >= 2.7.5)
+access host OS (for devices with balenaOS >= 2.0.0+rev1)
 
 #### --noproxy
 

--- a/lib/actions/command-options.ts
+++ b/lib/actions/command-options.ts
@@ -142,6 +142,6 @@ export const advancedConfig = {
 export const hostOSAccess = {
 	signature: 'host',
 	boolean: true,
-	description: 'access host OS (for devices with balenaOS >= 2.7.5)',
+	description: 'access host OS (for devices with balenaOS >= 2.0.0+rev1)',
 	alias: 's',
 };


### PR DESCRIPTION
Since openBalena API v0.11.0 (downstream API 9.16.0) the minimum
OS version has been lowered from 2.7.5 to 2.0.0 for host OS access.

Change-type: patch
Signed-off-by: Gergely Imreh <imrehg@gmail.com>

