### PR TITLE
[WIP] ssh: option to send command through SSH to the host OS and return exit code

### DIFF
--- a/doc/cli.markdown
+++ b/doc/cli.markdown
@@ -966,7 +966,7 @@ installed in your shell environment. For more information (including Windows
 support) please check the README here: https://github.com/balena-io/balena-cli
 
 Use this command to get a shell into the running application container of
-your device.
+your device, and you can also run commands in the host OS
 
 Examples:
 

--- a/doc/cli.markdown
+++ b/doc/cli.markdown
@@ -975,6 +975,7 @@ Examples:
 	$ balena ssh 7cf02a6 --port 8080
 	$ balena ssh 7cf02a6 -v
 	$ balena ssh 7cf02a6 -s
+	$ balena ssh 7cf02a6 -s -c 'date'
 
 ### Options
 
@@ -993,6 +994,10 @@ access host OS (for devices with balenaOS >= 2.0.0+rev1)
 #### --noproxy
 
 don't use the proxy configuration for this connection. Only makes sense if you've configured proxy globally.
+
+#### --command, -c &#60;command&#62;
+
+command to run after connecting to the device (only in the host OS)
 
 # Notes
 

--- a/doc/cli.markdown
+++ b/doc/cli.markdown
@@ -154,7 +154,7 @@ environment variable (in the same standard URL format).
 
 - SSH
 
-	- [ssh [uuid]](#ssh-uuid)
+	- [ssh [uuid] [command]](#ssh-uuid-command)
 
 - Notes
 
@@ -959,7 +959,7 @@ increase verbosity
 
 # SSH
 
-## ssh [uuid]
+## ssh [uuid] [command]
 
 Warning: 'balena ssh' requires an openssh-compatible client to be correctly
 installed in your shell environment. For more information (including Windows
@@ -975,7 +975,7 @@ Examples:
 	$ balena ssh 7cf02a6 --port 8080
 	$ balena ssh 7cf02a6 -v
 	$ balena ssh 7cf02a6 -s
-	$ balena ssh 7cf02a6 -s -c 'date'
+	$ balena ssh 7cf02a6 'date' -s
 
 ### Options
 
@@ -994,10 +994,6 @@ access host OS (for devices with balenaOS >= 2.0.0+rev1)
 #### --noproxy
 
 don't use the proxy configuration for this connection. Only makes sense if you've configured proxy globally.
-
-#### --command, -c &#60;command&#62;
-
-command to run after connecting to the device (only in the host OS)
 
 # Notes
 

--- a/lib/actions/ssh.coffee
+++ b/lib/actions/ssh.coffee
@@ -18,15 +18,15 @@ commandOptions = require('./command-options')
 { normalizeUuidProp } = require('../utils/normalization')
 
 module.exports =
-	signature: 'ssh [uuid]'
-	description: '(beta) get a shell into the running app container of a device'
+	signature: 'ssh [uuid] [command]'
+	description: '(beta) get a shell into the host OS or running app container of a device'
 	help: '''
 		Warning: 'balena ssh' requires an openssh-compatible client to be correctly
 		installed in your shell environment. For more information (including Windows
 		support) please check the README here: https://github.com/balena-io/balena-cli
 
 		Use this command to get a shell into the running application container of
-		your device.
+		your device, and you can also run commands in the host OS
 
 		Examples:
 
@@ -35,7 +35,7 @@ module.exports =
 			$ balena ssh 7cf02a6 --port 8080
 			$ balena ssh 7cf02a6 -v
 			$ balena ssh 7cf02a6 -s
-			$ balena ssh 7cf02a6 -s -c 'date'
+			$ balena ssh 7cf02a6 'date' -s
 	'''
 	permission: 'user'
 	primary: true
@@ -54,11 +54,6 @@ module.exports =
 			boolean: true
 			description: "don't use the proxy configuration for this connection.
 				Only makes sense if you've configured proxy globally."
-	,
-			signature: 'command'
-			parameter: 'command'
-			description: 'command to run after connecting to the device (only in the host OS)'
-			alias: 'c'
 	]
 	action: (params, options, done) ->
 		normalizeUuidProp(params)
@@ -130,11 +125,12 @@ module.exports =
 					sshProxyCommand = getSshProxyCommand(hasTunnelBin)
 					sshCommand = ''
 
+					console
 					if options.host
 						accessCommand = "host #{uuid}"
-						if options.command
+						if params.command
 							# Quote the command so it doesn't get broken up by the SSH connection
-							sshCommand = "'#{options.command}'"
+							sshCommand = "'#{params.command}'"
 					else
 						accessCommand = "enter #{uuid} #{containerId}"
 

--- a/lib/actions/ssh.coffee
+++ b/lib/actions/ssh.coffee
@@ -125,7 +125,6 @@ module.exports =
 					sshProxyCommand = getSshProxyCommand(hasTunnelBin)
 					sshCommand = ''
 
-					console
 					if options.host
 						accessCommand = "host #{uuid}"
 						if params.command
@@ -133,7 +132,6 @@ module.exports =
 							sshCommand = "'#{params.command}'"
 					else
 						accessCommand = "enter #{uuid} #{containerId}"
-
 
 					command = "ssh #{verbose} -t \
 						-o LogLevel=ERROR \


### PR DESCRIPTION
* Have an option to run commands over ssh on the device. Due to
  Capitano limitations, it seems to need to be a flag, so a new flag
  of `-c` is introduced.
* Exit the CLI with the exit code from the SSH connection, so that
  we can correctly catch errors
* Due to the limitations of connecting to the device, this command
  flag only seem to work with the host OS

Change-type: minor

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Introduces security considerations
- [ ] Affects the development, build or deployment processes of the component
