### PR TITLE
ssh: add flag not to suggest devices to connect to

### DIFF
--- a/doc/cli.markdown
+++ b/doc/cli.markdown
@@ -975,6 +975,7 @@ Examples:
 	$ balena ssh 7cf02a6 --port 8080
 	$ balena ssh 7cf02a6 -v
 	$ balena ssh 7cf02a6 -s
+	$ balena ssh 7cf02a6 --noninteractive
 
 ### Options
 
@@ -993,6 +994,10 @@ access host OS (for devices with balenaOS >= 2.0.0+rev1)
 #### --noproxy
 
 don't use the proxy configuration for this connection. Only makes sense if you've configured proxy globally.
+
+#### --noninteractive
+
+run command non-interactively, do not automatically suggest devices to connect to if UUID not found
 
 # Notes
 

--- a/lib/actions/ssh.coffee
+++ b/lib/actions/ssh.coffee
@@ -35,6 +35,7 @@ module.exports =
 			$ balena ssh 7cf02a6 --port 8080
 			$ balena ssh 7cf02a6 -v
 			$ balena ssh 7cf02a6 -s
+			$ balena ssh 7cf02a6 --noninteractive
 	'''
 	permission: 'user'
 	primary: true
@@ -53,6 +54,10 @@ module.exports =
 			boolean: true
 			description: "don't use the proxy configuration for this connection.
 				Only makes sense if you've configured proxy globally."
+	,
+			signature: 'noninteractive'
+			boolean: true
+			description: 'run command non-interactively, do not automatically suggest devices to connect to if UUID not found'
 	]
 	action: (params, options, done) ->
 		normalizeUuidProp(params)
@@ -103,6 +108,9 @@ module.exports =
 			return balena.models.device.has(params.uuid)
 		.then (uuidExists) ->
 			return params.uuid if uuidExists
+			if options.noninteractive
+				console.error("Could not find device: #{params.uuid}")
+				process.exit(1)
 			return patterns.inferOrSelectDevice()
 		.then (uuid) ->
 			console.info("Connecting to: #{uuid}")


### PR DESCRIPTION
The suggestion happens if the UUID supplied is not found. Because of that function, it's impossible to do an atomic connect to a device in non-interactive mode. The auto-suggestion results connecting to the first available device, which is likely not the intended action. The current workaround is running a `balena device UUID` and check its exit code before running `balena ssh UUID`, but since these are independent steps, still can connect to another device, if between the two commands anything changes. With this flag used, one could never connect accidentally to the wrong device due to suggestions.

The `--nosuggest` flag name chosen similarly to the `--noproxy` flag in the same command.

<!-- You can remove tags that do not apply. -->
Change-type: minor
Signed-off-by: Gergely Imreh <gergely@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Introduces security considerations
- [ ] Affects the development, build or deployment processes of the component
