### PR TITLE
Update resin-compose-parse to 2.0.4 to fix an error with extra_hosts

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "request": "^2.81.0",
     "resin-cli-form": "^2.0.1",
     "resin-cli-visuals": "^1.4.0",
-    "resin-compose-parse": "^2.0.3",
+    "resin-compose-parse": "^2.0.4",
     "resin-doodles": "0.0.1",
     "resin-image-fs": "^5.0.2",
     "resin-multibuild": "^2.1.5",

--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
     "resin-compose-parse": "^2.0.3",
     "resin-doodles": "0.0.1",
     "resin-image-fs": "^5.0.2",
-    "resin-multibuild": "^2.1.4",
+    "resin-multibuild": "^2.1.5",
     "resin-release": "^1.2.0",
     "resin-semver": "^1.4.0",
     "resin-stream-logger": "^0.1.2",


### PR DESCRIPTION

Change-type: patch

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Introduces security considerations
- [ ] Affects the development, build or deployment processes of the component
