### PR TITLE
Remove --dockerPort's -p alias for `balena preload`

### DIFF
--- a/doc/cli.markdown
+++ b/doc/cli.markdown
@@ -1423,7 +1423,7 @@ Path to a local docker socket (e.g. /var/run/docker.sock)
 
 Docker daemon hostname or IP address (dev machine or balena device) 
 
-#### --dockerPort, -p &#60;dockerPort&#62;
+#### --dockerPort &#60;dockerPort&#62;
 
 Docker daemon TCP port number (hint: 2375 for balena devices)
 

--- a/lib/actions/preload.coffee
+++ b/lib/actions/preload.coffee
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ###
 
+_ = require('lodash')
+
 dockerUtils = require('../utils/docker')
 
 LATEST = 'latest'
@@ -130,6 +132,43 @@ offerToDisableAutomaticUpdates = (application, commit, pinDevice) ->
 			body:
 				should_track_latest_release: false
 
+preloadOptions = dockerUtils.appendConnectionOptions [
+	{
+		signature: 'app'
+		parameter: 'appId'
+		description: 'id of the application to preload'
+		alias: 'a'
+	}
+	{
+		signature: 'commit'
+		parameter: 'hash'
+		description: '''
+			the commit hash for a specific application release to preload, use "latest" to specify the latest release
+			(ignored if no appId is given)
+		'''
+		alias: 'c'
+	}
+	{
+		signature: 'splash-image'
+		parameter: 'splashImage.png'
+		description: 'path to a png image to replace the splash screen'
+		alias: 's'
+	}
+	{
+		signature: 'dont-check-arch'
+		boolean: true
+		description: 'Disables check for matching architecture in image and application'
+	}
+	{
+		signature: 'pin-device-to-release'
+		boolean: true
+		description: 'Pin the preloaded device to the preloaded release on provision'
+		alias: 'p'
+	}
+]
+# Remove dockerPort `-p` alias as it conflicts with pin-device-to-release
+delete _.find(preloadOptions, signature: 'dockerPort').alias
+
 module.exports =
 	signature: 'preload <image>'
 	description: 'preload an app on a disk image (or Edison zip archive)'
@@ -148,40 +187,7 @@ module.exports =
 	'''
 	permission: 'user'
 	primary: true
-	options: dockerUtils.appendConnectionOptions [
-		{
-			signature: 'app'
-			parameter: 'appId'
-			description: 'id of the application to preload'
-			alias: 'a'
-		}
-		{
-			signature: 'commit'
-			parameter: 'hash'
-			description: '''
-				the commit hash for a specific application release to preload, use "latest" to specify the latest release
-				(ignored if no appId is given)
-			'''
-			alias: 'c'
-		}
-		{
-			signature: 'splash-image'
-			parameter: 'splashImage.png'
-			description: 'path to a png image to replace the splash screen'
-			alias: 's'
-		}
-		{
-			signature: 'dont-check-arch'
-			boolean: true
-			description: 'Disables check for matching architecture in image and application'
-		}
-		{
-			signature: 'pin-device-to-release'
-			boolean: true
-			description: 'Pin the preloaded device to the preloaded release on provision'
-			alias: 'p'
-		}
-	]
+	options: preloadOptions
 	action: (params, options, done) ->
 		_ = require('lodash')
 		Promise = require('bluebird')


### PR DESCRIPTION
Remove --dockerPort's -p alias for `balena preload`

It was conflicting with --pin-device-to-release -p alias

Changelog-entry: Remove --dockerPort's -p alias for `balena preload`
Change-type: major