### PR TITLE
qemu: use v4.0.0

### DIFF
--- a/lib/utils/qemu.coffee
+++ b/lib/utils/qemu.coffee
@@ -1,6 +1,6 @@
 Promise = require('bluebird')
 
-exports.QEMU_VERSION = QEMU_VERSION = 'v3.0.0+resin'
+exports.QEMU_VERSION = QEMU_VERSION = 'v4.0.0-balena'
 exports.QEMU_BIN_NAME = QEMU_BIN_NAME = 'qemu-execve'
 
 exports.installQemuIfNeeded = Promise.method (emulated, logger, arch) ->
@@ -63,7 +63,7 @@ getQemuPath = (arch) ->
 		Promise.resolve(fs.mkdir(binDir))
 		.catch(code: 'EEXIST', ->)
 		.then ->
-			path.join(binDir, "#{QEMU_BIN_NAME}-#{arch}")
+			path.join(binDir, "#{QEMU_BIN_NAME}-#{arch}-#{QEMU_VERSION}")
 
 platformNeedsQemu = ->
 	os = require('os')
@@ -81,7 +81,7 @@ installQemu = (arch) ->
 			installStream = fs.createWriteStream(qemuPath)
 
 			qemuArch = balenaArchToQemuArch(arch)
-			downloadArchiveName = "qemu-3.0.0+resin-#{qemuArch}.tar.gz"
+			downloadArchiveName = "qemu-#{QEMU_VERSION.replace(/^v/, '')}-#{qemuArch}.tar.gz"
 			qemuUrl = "https://github.com/balena-io/qemu/releases/download/#{QEMU_VERSION}/#{downloadArchiveName}"
 
 			extract = tar.extract()


### PR DESCRIPTION
Also append the QEMU version to the locally cached copy, so the CLI can correctly bump version whenever QEMU_VERSION is bumped in the future.

Change-type: minor
Signed-off-by: Gergely Imreh <imrehg@gmail.com>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
