### PR TITLE
Use the open-balena-api endpoints for device type & version info

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "balena-device-init": "^5.0.0",
     "balena-image-manager": "^6.0.0",
     "balena-preload": "^8.1.3",
-    "balena-sdk": "^11.15.0",
+    "balena-sdk": "^11.17.0",
     "balena-settings-client": "^4.0.0",
     "balena-sync": "^10.0.3",
     "bash": "0.0.1",


### PR DESCRIPTION
New CLI installs will actually get the latest SDK version, but older CLI upgrades might not.
This just allows us to be sure that CLI installations > vx.x.x will not be using the img maker for fetching device types & OS versions.

Resolves: #1177
HQ: https://github.com/balena-io/balena/issues/1744
Change-type: minor
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Introduces security considerations
- [ ] Affects the development, build or deployment processes of the component
