### PR TITLE
Remove intermediate containers when doing a local push

### DIFF
--- a/lib/utils/device/deploy.ts
+++ b/lib/utils/device/deploy.ts
@@ -356,6 +356,7 @@ async function assignDockerBuildOpts(
 			},
 			t: generateImageName(task.serviceName),
 			nocache: opts.nocache,
+			forcerm: true,
 		};
 		if (task.external) {
 			task.dockerOpts.authconfig = await getAuthConfigObj(


### PR DESCRIPTION
We now pass the `forcerm` flag to docker, to tell it to cleanup intermediate containers, without taking into account if the build was successful or not. This shouldn't have any impact on workflow, as caching will still work and these intermediate containers are not used for anything.

Change-type: patch
Closes: #1236
Signed-off-by: Cameron Diver <cameron@balena.io>


---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Introduces security considerations
- [ ] Affects the development, build or deployment processes of the component
