### PR TITLE
cli.markdown: Fixed typo in env add section

### DIFF
--- a/doc/cli.markdown
+++ b/doc/cli.markdown
@@ -635,7 +635,7 @@ device
 
 ## env add &#60;key&#62; [value]
 
-Use this command to add an enviroment or config variable to an application
+Use this command to add an environment or config variable to an application
 or device.
 
 If value is omitted, the tool will attempt to use the variable's value


### PR DESCRIPTION
There was a small spelling mistake on line 638.

Changelog-entry: changed spelling of enviroment from docs to environment
Signed-off-by: Sharvin Shah <sharvinshah51@gmail.com>
