### PR TITLE
Better livepush dockerfile change restart

### DIFF
--- a/lib/utils/device/api.ts
+++ b/lib/utils/device/api.ts
@@ -67,6 +67,7 @@ const deviceEndpoints = {
 	ping: 'ping',
 	version: 'v2/version',
 	status: 'v2/state/status',
+	containerId: 'v2/containerId',
 };
 
 export class DeviceAPI {
@@ -122,6 +123,29 @@ export class DeviceAPI {
 		).then(body => {
 			return body.info;
 		});
+	}
+
+	public async getContainerId(serviceName: string): Promise<string> {
+		const url = this.getUrlForAction('containerId');
+
+		const body = await DeviceAPI.promisifiedRequest(
+			request.get,
+			{
+				url,
+				json: true,
+				qs: {
+					serviceName,
+				},
+			},
+			this.logger,
+		);
+
+		if (body.status !== 'success') {
+			throw new ApiErrors.DeviceAPIError(
+				'Non-successful response from supervisor containerId endpoint',
+			);
+		}
+		return body.containerId;
 	}
 
 	public async ping(): Promise<void> {


### PR DESCRIPTION
Instead of messing around trying to generate a new target state which doesn't cause restarts (even in the case of depends on), we instead just delete the container, and ping the supervisor to get the state back to the target. Anecdotally it's much faster.

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Introduces security considerations
- [ ] Affects the development, build or deployment processes of the component
