### PR TITLE
Allow newline characters in build/deploy --buildArg values

### DIFF
--- a/lib/utils/docker.coffee
+++ b/lib/utils/docker.coffee
@@ -130,7 +130,8 @@ parseBuildArgs = (args) ->
 		args = [ args ]
 	buildArgs = {}
 	args.forEach (arg) ->
-		pair = /^([^\s]+?)=(.*)$/.exec(arg)
+		# note: [^] matches any character, including line breaks
+		pair = /^([^\s]+?)=([^]*)$/.exec(arg)
 		if pair?
 			buildArgs[pair[1]] = pair[2] ? ''
 		else


### PR DESCRIPTION
Issue raised in the forums:
https://forums.balena.io/t/unable-to-pass-a-custom-variable-in-balena-deploy-build-args/12352

Change-type: patch
Signed-off-by: Paulo Castro <paulo@balena.io>
