### PR TITLE
Fix CI build error (missing @types/mz)

### DIFF
--- a/doc/cli.markdown
+++ b/doc/cli.markdown
@@ -1406,6 +1406,13 @@ Disables check for matching architecture in image and application
 
 Pin the preloaded device (not application) to the preloaded release on provision
 
+#### --add-certificate &#60;certificate.crt&#62;
+
+Add the given certificate (in PEM format) to /etc/ssl/certs in the preloading container.
+The file name must end with '.crt' and must not be already contained in the preloader's
+/etc/ssl/certs folder.
+Can be repeated to add multiple certificates.
+
 #### --docker, -P &#60;docker&#62;
 
 Path to a local docker socket (e.g. /var/run/docker.sock)

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "@types/lodash": "4.14.112",
     "@types/mixpanel": "2.14.0",
     "@types/mkdirp": "0.5.2",
+    "@types/mz": "0.0.32",
     "@types/net-keepalive": "^0.4.0",
     "@types/node": "6.14.2",
     "@types/prettyjson": "0.0.28",


### PR DESCRIPTION
Standalone zip assets are missing in the releases page because the last PR into master (#1262) was merged with build errors (the GitHub repo was misconfigured in relation to required tests, and this has also been changed now).

Change-type: patch
Signed-off-by: Paulo Castro <paulo@balena.io>
