### PR TITLE
Pin moment-duration-format package (ReferenceError: window is not defined)

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "mixpanel": "^0.10.1",
     "mkdirp": "^0.5.1",
     "moment": "^2.24.0",
-    "moment-duration-format": "^2.2.1",
+    "moment-duration-format": "~2.2.2",
     "mz": "^2.6.0",
     "node-cleanup": "^2.1.2",
     "opn": "^5.5.0",


### PR DESCRIPTION
Connects-to: #1281
Change-type: patch
Signed-off-by: Paulo Castro <paulo@balena.io>
