### PR TITLE
Fix Travis release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,16 +8,13 @@ script:
   - node --version
   - npm --version
   - npm run ci
+  - npm run build:standalone
+  - npm run build:installer
 notifications:
   email: false
 deploy:
   - provider: script
-    script:
-      - node --version
-      - npm --version
-      - npm run build:standalone
-      - npm run build:installer
-      - npm run release
+    script: npm run release
     skip_cleanup: true
     on:
       tags: true


### PR DESCRIPTION
Attempt to fix this Travis release error:
https://travis-ci.org/balena-io/balena-cli/jobs/541370483
```
Installing deploy dependencies
Successfully installed dpl-script-1.10.11
1 gem installed
/Users/travis/.rvm/gems/ruby-2.4.3/gems/dpl-1.10.11/lib/dpl/cli.rb:54:in `system': wrong first argument (ArgumentError)
	from /Users/travis/.rvm/gems/ruby-2.4.3/gems/dpl-1.10.11/lib/dpl/cli.rb:54:in `shell'
	from /Users/travis/.rvm/gems/ruby-2.4.3/gems/dpl-script-1.10.11/lib/dpl/provider/script.rb:19:in `push_app'
	from /Users/travis/.rvm/gems/ruby-2.4.3/gems/dpl-1.10.11/lib/dpl/provider.rb:199:in `block in deploy'
	from /Users/travis/.rvm/gems/ruby-2.4.3/gems/dpl-1.10.11/lib/dpl/cli.rb:41:in `fold'
	from /Users/travis/.rvm/gems/ruby-2.4.3/gems/dpl-1.10.11/lib/dpl/provider.rb:199:in `deploy'
	from /Users/travis/.rvm/gems/ruby-2.4.3/gems/dpl-1.10.11/lib/dpl/cli.rb:32:in `run'
	from /Users/travis/.rvm/gems/ruby-2.4.3/gems/dpl-1.10.11/lib/dpl/cli.rb:7:in `run'
	from /Users/travis/.rvm/gems/ruby-2.4.3/gems/dpl-1.10.11/bin/dpl:5:in `<top (required)>'
	from /Users/travis/.rvm/gems/ruby-2.4.3/bin/dpl:23:in `load'
	from /Users/travis/.rvm/gems/ruby-2.4.3/bin/dpl:23:in `<main>'
```

Not really sure if the changes are effective (sadly not very easy to test), but these changes revert `travis.yml` to a closer state to what it used to be.

Change-type: patch
Signed-off-by: Paulo Castro <paulo@balena.io>
