### PR TITLE
Fix 'npm help' SyntaxError on Node 8 (invalid 's' regex flag)

### DIFF
--- a/lib/actions/help_ts.ts
+++ b/lib/actions/help_ts.ts
@@ -27,7 +27,9 @@ export function getOclifHelpLinePairs(): [[string, string]] {
 function getCmdUsageDescriptionLinePair(cmd: typeof Command): [string, string] {
 	const usage = (cmd.usage || '').toString().toLowerCase();
 	let description = '';
-	const matches = /\s*(.+?)\n.*/s.exec(cmd.description || '');
+	// note: [^] matches any characters (including line breaks), achieving the
+	// same effect as the 's' regex flag which is only supported by Node 9+
+	const matches = /\s*([^]+?)\n[^]*/.exec(cmd.description || '');
 	if (matches && matches.length > 1) {
 		description = _.lowerFirst(_.trimEnd(matches[1], '.'));
 	}


### PR DESCRIPTION
Resolves: #1291 
Change-type: patch
Signed-off-by: Paulo Castro <paulo@balena.io>
