### PR TITLE
Patch 'pkg' package to resolve 'preload' issue in standalone installations

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "gulp-mocha": "^2.0.0",
     "gulp-shell": "^0.5.2",
     "mochainon": "^2.0.0",
-    "pkg": "~4.3.8",
+    "pkg": "4.4.0",
     "prettier": "1.17.0",
     "publish-release": "^1.6.0",
     "resin-lint": "^3.0.1",

--- a/patches/pkg+4.4.0.patch
+++ b/patches/pkg+4.4.0.patch
@@ -1,0 +1,37 @@
+diff --git a/node_modules/pkg/lib-es5/packer.js b/node_modules/pkg/lib-es5/packer.js
+index 7295bb6..76805a3 100644
+--- a/node_modules/pkg/lib-es5/packer.js
++++ b/node_modules/pkg/lib-es5/packer.js
+@@ -128,6 +128,7 @@ function _default({
+           const newStat = Object.assign({}, value);
+           newStat.isFileValue = value.isFile();
+           newStat.isDirectoryValue = value.isDirectory();
++          newStat.isSocketValue = value.isSocket();
+           const buffer = Buffer.from(JSON.stringify(newStat));
+           stripes.push({
+             snap,
+diff --git a/node_modules/pkg/prelude/bootstrap.js b/node_modules/pkg/prelude/bootstrap.js
+index 216579e..4904726 100644
+--- a/node_modules/pkg/prelude/bootstrap.js
++++ b/node_modules/pkg/prelude/bootstrap.js
+@@ -866,8 +866,10 @@ function payloadFileSync (pointer) {
+ 
+     var isFileValue = s.isFileValue;
+     var isDirectoryValue = s.isDirectoryValue;
++    var isSocketValue = s.isSocketValue;
+     delete s.isFileValue;
+     delete s.isDirectoryValue;
++    delete s.isSocketValue;
+ 
+     s.isFile = function () {
+       return isFileValue;
+@@ -875,6 +877,9 @@ function payloadFileSync (pointer) {
+     s.isDirectory = function () {
+       return isDirectoryValue;
+     };
++    s.isSocket = function () {
++      return isSocketValue;
++    };
+     s.isSymbolicLink = function () {
+       return false;
+     };


### PR DESCRIPTION
We've been waiting for 10 days for the upstream dependency to consider Alexis' PR to fix issue #1306:
https://github.com/zeit/pkg/pull/720/files
... but they are yet to answer. This PR pins and patches the `pkg` package as a mitigation until it is fixed upstream.

Resolves: #1306
Change-type: patch
Signed-off-by: Paulo Castro <paulo@balena.io>
