### PR TITLE
Fix "Error: Cannot find module 'web-streams-polyfill'"

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1721,7 +1721,7 @@
         "fetch-ponyfill": "^4.0.0",
         "fetch-readablestream": "^0.2.0",
         "lodash": "^4.6.1",
-        "node-web-streams": "github:resin-io-modules/node-web-streams#46f98300b69090bde3f6b4983877ccfe283a892c",
+        "node-web-streams": "github:resin-io-modules/node-web-streams#emit-errors",
         "progress-stream": "^2.0.0",
         "qs": "^6.3.0",
         "rindle": "^1.3.1"
@@ -1865,7 +1865,7 @@
         "lodash": "^4.13.1",
         "resin-cli-form": "^2.0.0",
         "resin-cli-visuals": "^1.2.8",
-        "resin-discoverable-services": "git+https://github.com/resin-io-modules/resin-discoverable-services.git#afca9e4700ec5ef82aa897f14bd5a46f06518061",
+        "resin-discoverable-services": "git+https://github.com/resin-io-modules/resin-discoverable-services.git#find-on-all-interfaces",
         "resin-semver": "^1.4.0",
         "revalidator": "^0.3.1",
         "rindle": "^1.3.0",
@@ -2221,7 +2221,7 @@
         "deep-equal": "^1.0.1",
         "dns-equal": "^1.0.0",
         "dns-txt": "^2.0.2",
-        "multicast-dns": "git+https://github.com/resin-io-modules/multicast-dns.git#a15c63464eb43e8925b187ed5cb9de6892e8aacc",
+        "multicast-dns": "git+https://github.com/resin-io-modules/multicast-dns.git#listen-on-all-interfaces",
         "multicast-dns-service-types": "^1.1.0"
       }
     },
@@ -5227,12 +5227,12 @@
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
     },
     "fs-extra": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.0.1.tgz",
-      "integrity": "sha512-W+XLrggcDzlle47X/XnS7FXrXu9sDo+Ze9zpndeBxdgv88FHLm1HtmkhEwavruS6koanBjp098rUpHs65EmG7A==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
+        "graceful-fs": "^4.2.0",
         "jsonfile": "^4.0.0",
         "universalify": "^0.1.0"
       }
@@ -5277,7 +5277,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5295,11 +5296,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5312,15 +5315,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5423,7 +5429,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5433,6 +5440,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5445,17 +5453,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5472,6 +5483,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5544,7 +5556,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5554,6 +5567,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5629,7 +5643,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5659,6 +5674,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5676,6 +5692,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5714,11 +5731,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -9140,7 +9159,8 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "optional": true
         },
         "nise": {
           "version": "1.4.2",
@@ -9198,6 +9218,7 @@
               "version": "0.1.4",
               "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
               "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+              "optional": true,
               "requires": {
                 "kind-of": "^3.0.2",
                 "longest": "^1.0.1",
@@ -10380,7 +10401,8 @@
             "longest": {
               "version": "1.0.1",
               "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-              "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
+              "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+              "optional": true
             },
             "loose-envify": {
               "version": "1.3.1",
@@ -11834,6 +11856,7 @@
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/ref-napi/-/ref-napi-1.4.0.tgz",
           "integrity": "sha512-wPSvH8QHPEZCIPNSUmcLvxKIf4o04W3tYvhsXhoHMH23qcco+62OO6vUtbZEyUXGf+VsfZMNtwYrSC/RcSjX8Q==",
+          "optional": true,
           "requires": {
             "bindings": "^1.3.0",
             "debug": "^3.1.0",
@@ -11843,19 +11866,22 @@
             "bindings": {
               "version": "1.3.0",
               "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
-              "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw=="
+              "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw==",
+              "optional": true
             },
             "debug": {
               "version": "3.1.0",
               "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
               "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+              "optional": true,
               "requires": {
                 "ms": "2.0.0"
               }
             },
             "node-addon-api": {
               "version": "https://github.com/nodejs/node-addon-api/archive/82656bb.tar.gz",
-              "integrity": "sha512-hVXYx8KHOnSva6EH010YqII0JaVW6+UDC7OOZE1+DN0Evu4jL5KEf9ZFCwjRPFN0y/biYbMJKOCqukYpb5DIzw=="
+              "integrity": "sha512-hVXYx8KHOnSva6EH010YqII0JaVW6+UDC7OOZE1+DN0Evu4jL5KEf9ZFCwjRPFN0y/biYbMJKOCqukYpb5DIzw==",
+              "optional": true
             }
           }
         },
@@ -12131,7 +12157,7 @@
         "@types/node": "^6.0.112",
         "@types/usb": "^1.5.1",
         "debug": "^3.1.0",
-        "usb": "github:resin-io/node-usb#8cad6c9ecd1597af16af435bf629fc462b08c1a5"
+        "usb": "github:resin-io/node-usb#v1.3.10"
       },
       "dependencies": {
         "@types/node": {
@@ -12219,9 +12245,9 @@
       }
     },
     "npm-packlist": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.2.tgz",
-      "integrity": "sha512-pyJclkNoBBckB6K/XPcMp8fP60MaqSZBPQVsNY7Yyc9VP1TUnPMYwck5YaBejf0L7xYr8f4l16+IENeZ0by+yw==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.4.tgz",
+      "integrity": "sha512-zTLo8UcVYtDU3gdeaFu2Xu0n0EvelfHDGuqtNIn5RO7yQj4H1TqNdBc/yZjxnWA0PVB8D3Woyp0i5B43JwQ6Vw==",
       "requires": {
         "ignore-walk": "^3.0.1",
         "npm-bundled": "^1.0.1"
@@ -14172,9 +14198,9 @@
           }
         },
         "semver": {
-          "version": "6.1.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.1.2.tgz",
-          "integrity": "sha512-z4PqiCpomGtWj8633oeAdXm1Kn1W++3T8epkZYnwiVgIYIJ0QHszhInYSJTYxebByQH7KVCEAn8R9duzZW2PhQ=="
+          "version": "6.1.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.1.3.tgz",
+          "integrity": "sha512-aymF+56WJJMyXQHcd4hlK4N75rwj5RQpfW8ePlQnJsTYOBLlLbcIErR/G1s9SkIvKBqOudR3KAx4wEqP+F1hNQ=="
         },
         "tar-stream": {
           "version": "2.1.0",
@@ -14545,7 +14571,7 @@
       "from": "git+https://github.com/resin-io-modules/resin-discoverable-services.git#find-on-all-interfaces",
       "requires": {
         "bluebird": "^3.0.0",
-        "bonjour": "git+https://github.com/resin-io/bonjour.git#e018851dc823b4b3f670f658f71d0c1c7f3e637c",
+        "bonjour": "git+https://github.com/resin-io/bonjour.git#fixed-mdns",
         "ip": "^1.1.4",
         "lodash": "^4.17.4"
       }


### PR DESCRIPTION
Fix `npm-shrinkwrap.json` produced by npm v6.4.1, by using npm v6.9.0.
See issue #1332 for a full description.

Resolves: #1332
Change-type: patch
Signed-off-by: Paulo Castro <paulo@balena.io>
