### PR TITLE
Set the GitHub release name (title) in repo.yml

### DIFF
--- a/repo.yml
+++ b/repo.yml
@@ -1,2 +1,4 @@
 type: node-cli
 release: github
+github_release:
+  name: 'balena-CLI %{version}'


### PR DESCRIPTION
This keeps the release name (title) unchanged compared to previous releases created before the transition to balena CI.

Depends-on: https://github.com/balena-io/resin-concourse/pull/405
Change-type: patch
Signed-off-by: Paulo Castro <paulo@balena.io>
