### PR TITLE
Update unzip2 dependency

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -8623,11 +8623,6 @@
       "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE=",
       "dev": true
     },
-    "natives": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.6.tgz",
-      "integrity": "sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA=="
-    },
     "natural-orderby": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/natural-orderby/-/natural-orderby-2.0.3.tgz",
@@ -16764,37 +16759,17 @@
       }
     },
     "unzip2": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/unzip2/-/unzip2-0.2.5.tgz",
-      "integrity": "sha1-TveleaeMFcUfVQ9qBT2xlBSciZI=",
+      "version": "github:balena-io-library/node-unzip-2#bcb8887500d7d82bfb60a398285397c6826618c8",
+      "from": "github:balena-io-library/node-unzip-2#v0.2.8",
       "requires": {
         "binary": "~0.3.0",
-        "fstream": "~0.1.21",
+        "fstream": "~1.0.12",
         "match-stream": "~0.0.2",
         "pullstream": "~0.4.0",
         "readable-stream": "~1.0.0",
         "setimmediate": "~1.0.1"
       },
       "dependencies": {
-        "fstream": {
-          "version": "0.1.31",
-          "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
-          "integrity": "sha1-czfwWPu7vvqMn1YaKMqwhJICyYg=",
-          "requires": {
-            "graceful-fs": "~3.0.2",
-            "inherits": "~2.0.0",
-            "mkdirp": "0.5",
-            "rimraf": "2"
-          }
-        },
-        "graceful-fs": {
-          "version": "3.0.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
-          "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
-          "requires": {
-            "natives": "^1.1.0"
-          }
-        },
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -205,7 +205,7 @@
     "tmp": "0.0.31",
     "typed-error": "^3.1.0",
     "umount": "^1.1.6",
-    "unzip2": "^0.2.5",
+    "unzip2": "balena-io-library/node-unzip-2#v0.2.8",
     "update-notifier": "^2.2.0",
     "window-size": "^1.1.0"
   },


### PR DESCRIPTION
That dependency has been updated upstream, but not published to npm, thus we are pulling the latest (0.2.8) version by commit hash on GitHub.

Fixes: #1373
Change-type: patch
Signed-off-by: Gergely Imreh <gergely@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Introduces security considerations
- [ ] Affects the development, build or deployment processes of the component
