### PR TITLE
Add missing oclif-based commands to mixpanel tracking

### DIFF
--- a/lib/app-capitano.coffee
+++ b/lib/app-capitano.coffee
@@ -154,5 +154,17 @@ exports.run = (argv) ->
 		else
 			capitanoExecuteAsync(cli)
 
-	Promise.all([events.trackCommand(cli), runCommand()])
+	trackCommand = ->
+		getMatchCommandAsync = Promise.promisify(capitano.state.getMatchCommand)
+		getMatchCommandAsync(cli.command)
+		.then (command) ->
+			# cmdSignature is literally a string like, for example:
+			#     "push <applicationOrDevice>"
+			# ("applicationOrDevice" is NOT replaced with its actual value)
+			# In case of failures like an inexistent or invalid command,
+			# command.signature.toString() returns '*'
+			cmdSignature = command.signature.toString()
+			events.trackCommand(cmdSignature)
+
+	Promise.all([trackCommand(), runCommand()])
 	.catch(require('./errors').handleError)

--- a/lib/app.ts
+++ b/lib/app.ts
@@ -20,7 +20,7 @@ import { exitWithExpectedError } from './utils/patterns';
 
 export interface AppOptions {
 	// Prevent the default behaviour of flushing stdout after running a command
-	noFlush: boolean;
+	noFlush?: boolean;
 }
 
 /**
@@ -160,7 +160,7 @@ function isOclifCommand(argvSlice: string[]): [boolean, boolean] {
  * CLI entrypoint, but see also `bin/balena` and `bin/balena-dev` which
  * call this function.
  */
-export function run(cliArgs = process.argv, options: AppOptions): void {
+export function run(cliArgs = process.argv, options: AppOptions = {}): void {
 	// globalInit() must be called very early on (before other imports) because
 	// it sets up Sentry error reporting, global HTTP proxy settings, balena-sdk
 	// shared options, and performs node version requirement checks.

--- a/lib/hooks/prerun/track.ts
+++ b/lib/hooks/prerun/track.ts
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * Copyright 2019 Balena Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Hook } from '@oclif/config';
+
+// note: trackPromise is subject to a Bluebird.timeout, defined in events.ts
+export let trackPromise: PromiseLike<void>;
+
+/**
+ * This is an oclif 'prerun' hook. This hook runs after the command line is
+ * parsed by oclif, but before the command's run() function is called.
+ * See: https://oclif.io/docs/hooks
+ *
+ * This hook is used to track CLI command signatures with mixpanel. This
+ * is the oclif version of what is already done for Capitano commands.
+ *
+ * A command signature is something like "env add NAME [VALUE]". That's
+ * literally so: 'NAME' and 'VALUE' are NOT replaced with actual values.
+ */
+const hook: Hook<'prerun'> = async function(options) {
+	const events = await import('../../events');
+	const usage: string | string[] | undefined = options.Command.usage;
+	const cmdSignature =
+		usage == null ? '*' : typeof usage === 'string' ? usage : usage.join(' ');
+
+	// Intentionally do not await for the track promise here, in order to
+	// run the command tracking and the command itself in parallel.
+	trackPromise = events.trackCommand(cmdSignature);
+};
+
+export default hook;

--- a/package.json
+++ b/package.json
@@ -71,6 +71,9 @@
   "oclif": {
     "bin": "balena",
     "commands": "./build/actions-oclif",
+    "hooks": {
+      "prerun": "./build/hooks/prerun/track"
+    },
     "macos": {
       "identifier": "io.balena.cli",
       "sign": "Developer ID Installer: Rulemotion Ltd (66H43P8FRG)"


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Paulo Castro <paulo@balena.io>
