### PR TITLE
Allow mixing armv7 & aarch64 devices in RPi 1 / zero apps

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1988,9 +1988,9 @@
       }
     },
     "balena-sdk": {
-      "version": "12.10.0",
-      "resolved": "https://registry.npmjs.org/balena-sdk/-/balena-sdk-12.10.0.tgz",
-      "integrity": "sha512-nE3zJ5heZPVYBnoQPUo/uEFXyCtaDXOItIDcMAMBaCBurTQDHlbfg1d/C62ahBti2mowI927eIHqAQ4Huyrglw==",
+      "version": "12.11.0",
+      "resolved": "https://registry.npmjs.org/balena-sdk/-/balena-sdk-12.11.0.tgz",
+      "integrity": "sha512-KLEX+dttLkhPSVmrRPL/Rb4ZyvVyXPH6IBBFcG2qJyV3H+fpocCIXTeOwpMUZqaKKKT1fkD210rqTxyfBjW5og==",
       "requires": {
         "@types/bluebird": "3.5.21",
         "@types/common-tags": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "balena-device-status": "^3.1.2",
     "balena-image-manager": "^6.0.0",
     "balena-preload": "^8.2.1",
-    "balena-sdk": "^12.10.0",
+    "balena-sdk": "^12.11.0",
     "balena-settings-client": "^4.0.0",
     "balena-sync": "^10.0.3",
     "bash": "0.0.1",


### PR DESCRIPTION
Resolves: #1448
HQ: https://github.com/balena-io/balena/issues/1905
See: https://github.com/balena-io/resin-ui/pull/2979#issuecomment-517050871
See: https://www.flowdock.com/app/rulemotion/r-beginners/threads/A4a3CALEDol4WIUXZZIlv-ZD3v0
Change-type: minor
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Introduces security considerations
- [ ] Affects the development, build or deployment processes of the component
