### PR TITLE
Support managing tags using release commit hashes

### DIFF
--- a/doc/cli.markdown
+++ b/doc/cli.markdown
@@ -743,6 +743,7 @@ Example:
 	$ balena tags --application MyApp
 	$ balena tags --device 7cf02a6
 	$ balena tags --release 1234
+	$ balena tags --release b376b0e544e9429483b656490e5b9443b4349bd6
 
 ### Options
 
@@ -771,8 +772,10 @@ Examples:
 	$ balena tag set mySimpleTag --application MyApp
 	$ balena tag set myCompositeTag myTagValue --application MyApp
 	$ balena tag set myCompositeTag myTagValue --device 7cf02a6
+	$ balena tag set myCompositeTag "my tag value with whitespaces" --device 7cf02a6
 	$ balena tag set myCompositeTag myTagValue --release 1234
-	$ balena tag set myCompositeTag "my tag value with whitespaces" --release 1234
+	$ balena tag set myCompositeTag --release 1234
+	$ balena tag set myCompositeTag --release b376b0e544e9429483b656490e5b9443b4349bd6
 
 ### Options
 
@@ -797,6 +800,7 @@ Examples:
 	$ balena tag rm myTagKey --application MyApp
 	$ balena tag rm myTagKey --device 7cf02a6
 	$ balena tag rm myTagKey --release 1234
+	$ balena tag rm myTagKey --release b376b0e544e9429483b656490e5b9443b4349bd6
 
 ### Options
 

--- a/lib/utils/normalization.ts
+++ b/lib/utils/normalization.ts
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import { BalenaSDK } from 'balena-sdk';
 import _ = require('lodash');
 
 export function normalizeUuidProp(
@@ -25,3 +26,26 @@ export function normalizeUuidProp(
 			params[propName + '_raw'] || _.toString(params[propName]);
 	}
 }
+
+export async function disambiguateReleaseParam(
+	balena: BalenaSDK,
+	param: string | number,
+	paramRaw: string | undefined,
+) {
+	// the user has passed an argument that was parsed as a string
+	if (!_.isNumber(param)) {
+		return param;
+	}
+
+	// check whether the argument was indeed an ID
+	return balena.models.release
+		.get(param, { $select: 'id' })
+		.catch(error => {
+			// we couldn't find a release by id,
+			// try whether it was a commit with all numeric digits
+			return balena.models.release
+				.get(paramRaw || _.toString(param), { $select: 'id' })
+				.catchThrow(error);
+		})
+		.then(({ id }) => id);
+};


### PR DESCRIPTION
The sdk version in the shrinkwrap already supports setting tags by commit hashes and as a result this already works in the cli as of v11.9.6. This PR just adds some docs and some extra handling when the commit param prefix is all numeric.

Resolves: #1064
Change-type: minor
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Introduces security considerations
- [ ] Affects the development, build or deployment processes of the component
