### PR TITLE
Move npm version check from npm 'preinstall' to git 'pre-commit' hook

### DIFF
--- a/automation/check-npm-version.js
+++ b/automation/check-npm-version.js
@@ -52,9 +52,22 @@ function checkNpmVersion() {
 		.trim();
 	const requiredVersion = '6.9.0';
 	if (!semverGte(npmVersion, requiredVersion)) {
+		// In case you take issue with the error message below:
+		//   "At this point, however, your 'npm-shrinkwrap.json' file has
+		//    already been damaged"
+		// ... and think: "why not add the check to the 'preinstall' hook?",
+		// the reason is that it would unnecessarily prevent end users from
+		// using npm v6.4.1 that ships with Node 8.  (It is OK for the
+		// shrinkwrap file to get damaged if it is not going to be reused.)
 		console.error(`\
+-------------------------------------------------------------------------------
 Error: npm version '${npmVersion}' detected. Please upgrade to npm v${requiredVersion} or later
-because of a bug affecting older versions in relation to the npm-shrinkwrap.json file.`);
+because of a bug that causes the 'npm-shrinkwrap.json' file to be damaged.
+At this point, however, your 'npm-shrinkwrap.json' file has already been
+damaged. Please revert it to the master branch state with a command such as:
+"git checkout master -- npm-shrinkwrap.json"
+Then re-run "npm install" using npm version ${requiredVersion} or later.
+-------------------------------------------------------------------------------`);
 		process.exit(1);
 	}
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   },
   "preferGlobal": true,
   "files": [
-    "automation/check-npm-version.js",
     "bin/",
     "build/",
     "doc/",
@@ -40,7 +39,6 @@
     ]
   },
   "scripts": {
-    "preinstall": "node automation/check-npm-version.js",
     "postinstall": "patch-package",
     "prebuild": "rimraf build/ build-bin/",
     "build": "npm run build:src",
@@ -73,6 +71,11 @@
   "license": "Apache-2.0",
   "engines": {
     "node": ">=8.0"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "node automation/check-npm-version.js"
+    }
   },
   "oclif": {
     "bin": "balena",
@@ -130,6 +133,7 @@
     "gulp-coffee": "^2.2.0",
     "gulp-inline-source": "^2.1.0",
     "gulp-shell": "^0.5.2",
+    "husky": "^3.0.9",
     "intercept-stdout": "^0.1.2",
     "mocha": "^6.2.0",
     "nock": "^10.0.6",


### PR DESCRIPTION
This should allow end users to use npm v6.4.1 that ships with Node 8, while still "probabilistically" requiring CLI developers to use npm v6.9.0 or later.

Change-type: patch
Signed-off-by: Paulo Castro <paulo@balena.io>
