### PR TITLE
Fix warnings when executing CLI without arguments.

### DIFF
--- a/lib/app-capitano.coffee
+++ b/lib/app-capitano.coffee
@@ -25,8 +25,8 @@ capitano.permission 'user', (done) ->
 
 capitano.command
 	signature: '*'
-	action: ->
-		capitano.execute(command: 'help')
+	action: (params, options, done) ->
+		capitano.execute(command: 'help', done)
 
 capitano.globalOption
 	signature: 'help'

--- a/tests/commands/help.spec.ts
+++ b/tests/commands/help.spec.ts
@@ -134,4 +134,20 @@ describe('balena help', function() {
 
 		chai.expect(err.join('')).to.equal('');
 	});
+
+	it('should print simple help text when no arguments present', async () => {
+		const { out, err } = await runCommand('');
+
+		chai
+			.expect(cleanOutput(out))
+			.to.deep.equal(
+				cleanOutput([
+					SIMPLE_HELP,
+					'Run `balena help --verbose` to list additional commands',
+					GLOBAL_OPTIONS,
+				]),
+			);
+
+		chai.expect(err.join('')).to.equal('');
+	});
 });


### PR DESCRIPTION
An edge case call to `capitano.execute` was not promisified, which was generating warnings in Node 12.

Note that the test will not catch the problem until we stop sentry masking errors/warnings.  Has been tested with sentry disabled though.


Change-type: patch
Signed-off-by: Scott Lowe <scott@balena.io>
Resolves: #1491

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Introduces security considerations
- [ ] Affects the development, build or deployment processes of the component
