### PR TITLE
Hide discontinued device types in `balena devices supported`, `balena app create`.

### DIFF
--- a/doc/cli.markdown
+++ b/doc/cli.markdown
@@ -100,7 +100,6 @@ If you come across any problems or would like to get in touch:
 
 	- [devices](#devices)
 	- [device &#60;uuid&#62;](#device-uuid)
-	- [devices supported](#devices-supported)
 	- [device register &#60;application&#62;](#device-register-application)
 	- [device rm &#60;uuid&#62;](#device-rm-uuid)
 	- [device identify &#60;uuid&#62;](#device-identify-uuid)
@@ -114,6 +113,7 @@ If you come across any problems or would like to get in touch:
 	- [device move &#60;uuid&#62;](#device-move-uuid)
 	- [device init](#device-init)
 	- [device os-update &#60;uuid&#62;](#device-os-update-uuid)
+	- [devices supported](#devices-supported)
 
 - Environment Variables
 
@@ -374,14 +374,6 @@ Examples:
 
 	$ balena device 7cf02a6
 
-## devices supported
-
-Use this command to get the list of all supported devices
-
-Examples:
-
-	$ balena devices supported
-
 ## device register &#60;application&#62;
 
 Use this command to register a device to an application.
@@ -576,6 +568,14 @@ a balenaOS version
 #### --yes, -y
 
 confirm non interactively
+
+## devices supported
+
+Use this command to get the list of all supported devices.
+
+Examples:
+
+	$ balena devices supported
 
 # Environment Variables
 

--- a/lib/actions/device.coffee
+++ b/lib/actions/device.coffee
@@ -115,25 +115,6 @@ exports.info =
 				]
 		.nodeify(done)
 
-exports.supported =
-	signature: 'devices supported'
-	description: 'list all supported devices'
-	help: '''
-		Use this command to get the list of all supported devices
-
-		Examples:
-
-			$ balena devices supported
-	'''
-	action: (params, options, done) ->
-		balena = require('balena-sdk').fromSharedOptions()
-		visuals = require('resin-cli-visuals')
-
-		balena.models.config.getDeviceTypes().then (deviceTypes) ->
-			fields = ['slug', 'name']
-			console.log visuals.table.horizontal(_.sortBy(deviceTypes, fields), fields)
-		.nodeify(done)
-
 exports.register =
 	signature: 'device register <application>'
 	description: 'register a device'
@@ -465,4 +446,6 @@ exports.init =
 
 		.nodeify(done)
 
-exports.osUpdate = require('./device_ts').osUpdate
+tsActions = require('./device_ts')
+exports.osUpdate = tsActions.osUpdate
+exports.supported = tsActions.supported

--- a/lib/actions/device_ts.ts
+++ b/lib/actions/device_ts.ts
@@ -19,6 +19,31 @@ import { stripIndent } from 'common-tags';
 import { normalizeUuidProp } from '../utils/normalization';
 import * as commandOptions from './command-options';
 
+export const supported: CommandDefinition<{}, {}> = {
+	signature: 'devices supported',
+	description: 'list all supported devices',
+	help: stripIndent`
+		Use this command to get the list of all supported devices.
+
+		Examples:
+
+			$ balena devices supported
+	`,
+	async action(_params, _options) {
+		const sdk = (await import('balena-sdk')).fromSharedOptions();
+		const visuals = await import('resin-cli-visuals');
+		const _ = await import('lodash');
+
+		let deviceTypes = await sdk.models.config.getDeviceTypes();
+		const fields = ['slug', 'name'];
+		deviceTypes = _.sortBy(deviceTypes, fields).filter(
+			dt => dt.state !== 'DISCONTINUED',
+		);
+		const output = await visuals.table.horizontal(deviceTypes, fields);
+		console.log(output);
+	},
+};
+
 // tslint:disable-next-line:no-namespace
 namespace OsUpdate {
 	export interface Args {

--- a/lib/utils/patterns.ts
+++ b/lib/utils/patterns.ts
@@ -130,7 +130,9 @@ export function selectDeviceType() {
 	return getBalenaSdk()
 		.models.config.getDeviceTypes()
 		.then(deviceTypes => {
-			deviceTypes = _.sortBy(deviceTypes, 'name');
+			deviceTypes = _.sortBy(deviceTypes, 'name').filter(
+				dt => dt.state !== 'DISCONTINUED',
+			);
 			return getForm().ask({
 				message: 'Device Type',
 				type: 'list',

--- a/tests/auth/utils.spec.ts
+++ b/tests/auth/utils.spec.ts
@@ -1,5 +1,5 @@
 import * as Promise from 'bluebird';
-import * as chai from 'chai';
+import { expect } from 'chai';
 import rewire = require('rewire');
 import * as sinon from 'sinon';
 import * as url from 'url';
@@ -14,7 +14,7 @@ describe('Utils:', function() {
 			utils
 				.getDashboardLoginURL('https://127.0.0.1:3000/callback')
 				.then((loginUrl: string) =>
-					chai.expect(() => url.parse(loginUrl)).to.not.throw(Error),
+					expect(() => url.parse(loginUrl)).to.not.throw(Error),
 				));
 
 		it('should eventually contain an https protocol', () =>
@@ -23,7 +23,7 @@ describe('Utils:', function() {
 				loginUrl: utils.getDashboardLoginURL('https://127.0.0.1:3000/callback'),
 			}).then(function({ dashboardUrl, loginUrl }) {
 				const { protocol } = url.parse(loginUrl);
-				return chai.expect(protocol).to.equal(url.parse(dashboardUrl).protocol);
+				return expect(protocol).to.equal(url.parse(dashboardUrl).protocol);
 			}));
 
 		it('should correctly escape a callback url without a path', () =>
@@ -32,7 +32,7 @@ describe('Utils:', function() {
 				loginUrl: utils.getDashboardLoginURL('http://127.0.0.1:3000'),
 			}).then(function({ dashboardUrl, loginUrl }) {
 				const expectedUrl = `${dashboardUrl}/login/cli/http%253A%252F%252F127.0.0.1%253A3000`;
-				return chai.expect(loginUrl).to.equal(expectedUrl);
+				return expect(loginUrl).to.equal(expectedUrl);
 			}));
 
 		return it('should correctly escape a callback url with a path', () =>
@@ -41,29 +41,29 @@ describe('Utils:', function() {
 				loginUrl: utils.getDashboardLoginURL('http://127.0.0.1:3000/callback'),
 			}).then(function({ dashboardUrl, loginUrl }) {
 				const expectedUrl = `${dashboardUrl}/login/cli/http%253A%252F%252F127.0.0.1%253A3000%252Fcallback`;
-				return chai.expect(loginUrl).to.equal(expectedUrl);
+				return expect(loginUrl).to.equal(expectedUrl);
 			}));
 	});
 
 	return describe('.loginIfTokenValid()', function() {
 		it('should eventually be false if token is undefined', function() {
 			const promise = utils.loginIfTokenValid(undefined);
-			return chai.expect(promise).to.eventually.be.false;
+			return expect(promise).to.eventually.be.false;
 		});
 
 		it('should eventually be false if token is null', function() {
 			const promise = utils.loginIfTokenValid(null);
-			return chai.expect(promise).to.eventually.be.false;
+			return expect(promise).to.eventually.be.false;
 		});
 
 		it('should eventually be false if token is an empty string', function() {
 			const promise = utils.loginIfTokenValid('');
-			return chai.expect(promise).to.eventually.be.false;
+			return expect(promise).to.eventually.be.false;
 		});
 
 		it('should eventually be false if token is a string containing only spaces', function() {
 			const promise = utils.loginIfTokenValid('     ');
-			return chai.expect(promise).to.eventually.be.false;
+			return expect(promise).to.eventually.be.false;
 		});
 
 		describe('given the token does not authenticate with the server', function() {
@@ -78,7 +78,7 @@ describe('Utils:', function() {
 
 			it('should eventually be false', function() {
 				const promise = utils.loginIfTokenValid(tokens.johndoe.token);
-				return chai.expect(promise).to.eventually.be.false;
+				return expect(promise).to.eventually.be.false;
 			});
 
 			describe('given there was a token already', function() {
@@ -88,12 +88,12 @@ describe('Utils:', function() {
 					balena.auth
 						.getToken()
 						.then(function(originalToken: string) {
-							chai.expect(originalToken).to.equal(tokens.janedoe.token);
+							expect(originalToken).to.equal(tokens.janedoe.token);
 							return utils.loginIfTokenValid(tokens.johndoe.token);
 						})
 						.then(balena.auth.getToken)
 						.then((currentToken: string) =>
-							chai.expect(currentToken).to.equal(tokens.janedoe.token),
+							expect(currentToken).to.equal(tokens.janedoe.token),
 						));
 			});
 
@@ -104,9 +104,7 @@ describe('Utils:', function() {
 					utils
 						.loginIfTokenValid(tokens.johndoe.token)
 						.then(() => balena.auth.isLoggedIn())
-						.then((isLoggedIn: boolean) =>
-							chai.expect(isLoggedIn).to.equal(false),
-						));
+						.then((isLoggedIn: boolean) => expect(isLoggedIn).to.equal(false)));
 			});
 		});
 
@@ -122,7 +120,7 @@ describe('Utils:', function() {
 
 			return it('should eventually be true', function() {
 				const promise = utils.loginIfTokenValid(tokens.johndoe.token);
-				return chai.expect(promise).to.eventually.be.true;
+				return expect(promise).to.eventually.be.true;
 			});
 		});
 	});

--- a/tests/commands/app/create.spec.ts
+++ b/tests/commands/app/create.spec.ts
@@ -1,0 +1,35 @@
+import { expect } from 'chai';
+import * as _ from 'lodash';
+import { cleanOutput, runCommand } from '../../helpers';
+
+const HELP_MESSAGE = `
+Usage: app create <name>
+
+Use this command to create a new balena application.
+
+You can specify the application device type with the \`--type\` option.
+Otherwise, an interactive dropdown will be shown for you to select from.
+
+You can see a list of supported device types with
+
+\t$ balena devices supported
+
+Examples:
+
+\t$ balena app create MyApp
+\t$ balena app create MyApp --type raspberry-pi
+
+Options:
+
+    --type, -t <type>                   application device type (Check available types with \`balena devices supported\`)
+`;
+
+describe('balena app create', function() {
+	it('should print help text with the -h flag', async () => {
+		const { out, err } = await runCommand('app create -h');
+
+		expect(cleanOutput(out)).to.deep.equal(cleanOutput([HELP_MESSAGE]));
+
+		expect(err).to.have.lengthOf(0);
+	});
+});

--- a/tests/commands/device/supported.spec.ts
+++ b/tests/commands/device/supported.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import * as _ from 'lodash';
-import { runCommand } from '../../helpers';
+import { cleanOutput, runCommand } from '../../helpers';
 
 const HELP = `
 Usage: devices supported
@@ -11,18 +11,6 @@ Examples:
 
 \t$ balena devices supported
 `;
-
-const cleanOutput = (output: string[] | string) => {
-	return _(_.castArray(output))
-		.map(log => {
-			return log.split('\n').map(line => {
-				return line.trim();
-			});
-		})
-		.flatten()
-		.compact()
-		.value();
-};
 
 describe('balena devices supported', function() {
 	it('should list currently supported devices', async () => {

--- a/tests/commands/device/supported.spec.ts
+++ b/tests/commands/device/supported.spec.ts
@@ -1,0 +1,47 @@
+import { expect } from 'chai';
+import * as _ from 'lodash';
+import { runCommand } from '../../helpers';
+
+const HELP = `
+Usage: devices supported
+
+Use this command to get the list of all supported devices.
+
+Examples:
+
+\t$ balena devices supported
+`;
+
+const cleanOutput = (output: string[] | string) => {
+	return _(_.castArray(output))
+		.map(log => {
+			return log.split('\n').map(line => {
+				return line.trim();
+			});
+		})
+		.flatten()
+		.compact()
+		.value();
+};
+
+describe('balena devices supported', function() {
+	it('should list currently supported devices', async () => {
+		const { out, err } = await runCommand('devices supported');
+
+		const lines = cleanOutput(out);
+
+		expect(lines[0].replace(/  +/g, ' ')).to.equal('SLUG NAME');
+		expect(lines).to.have.lengthOf.at.least(2);
+		expect(lines.some(l => l.includes('DISCONTINUED'))).to.be.false;
+
+		expect(err).to.have.lengthOf(0);
+	});
+
+	it('should print help text with the -h flag', async () => {
+		const { out, err } = await runCommand('devices supported -h');
+
+		expect(cleanOutput(out)).to.deep.equal(cleanOutput([HELP]));
+
+		expect(err).to.have.lengthOf(0);
+	});
+});

--- a/tests/commands/env/add.spec.ts
+++ b/tests/commands/env/add.spec.ts
@@ -1,4 +1,4 @@
-import * as chai from 'chai';
+import { expect } from 'chai';
 import { balenaAPIMock, runCommand } from '../../helpers';
 
 describe('balena env add', function() {
@@ -20,8 +20,8 @@ describe('balena env add', function() {
 
 		const { out, err } = await runCommand(`env add TEST 1 -d ${deviceId}`);
 
-		chai.expect(out.join('')).to.equal('');
-		chai.expect(err.join('')).to.equal('');
+		expect(out.join('')).to.equal('');
+		expect(err.join('')).to.equal('');
 
 		// @ts-ignore
 		mock.remove();

--- a/tests/commands/env/rename.spec.ts
+++ b/tests/commands/env/rename.spec.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import * as chai from 'chai';
+import { expect } from 'chai';
 import { balenaAPIMock, runCommand } from '../../helpers';
 
 describe('balena env rename', function() {
@@ -25,8 +25,8 @@ describe('balena env rename', function() {
 
 		const { out, err } = await runCommand('env rename 376 emacs --device');
 
-		chai.expect(out.join('')).to.equal('');
-		chai.expect(err.join('')).to.equal('');
+		expect(out.join('')).to.equal('');
+		expect(err.join('')).to.equal('');
 
 		// @ts-ignore
 		mock.remove();

--- a/tests/commands/env/rm.spec.ts
+++ b/tests/commands/env/rm.spec.ts
@@ -1,4 +1,4 @@
-import * as chai from 'chai';
+import { expect } from 'chai';
 import { balenaAPIMock, runCommand } from '../../helpers';
 
 describe('balena env rm', function() {
@@ -8,8 +8,8 @@ describe('balena env rm', function() {
 
 		const { out, err } = await runCommand('env rm 144690 -d -y');
 
-		chai.expect(out.join('')).to.equal('');
-		chai.expect(err.join('')).to.equal('');
+		expect(out.join('')).to.equal('');
+		expect(err.join('')).to.equal('');
 
 		// @ts-ignore
 		mock.remove();

--- a/tests/commands/help.spec.ts
+++ b/tests/commands/help.spec.ts
@@ -1,6 +1,6 @@
-import * as chai from 'chai';
+import { expect } from 'chai';
 import * as _ from 'lodash';
-import { runCommand } from '../helpers';
+import { cleanOutput, runCommand } from '../helpers';
 
 const SIMPLE_HELP = `
 Usage: balena [COMMAND] [OPTIONS]
@@ -92,62 +92,44 @@ const GLOBAL_OPTIONS = `
 		--version, -v
 `;
 
-const cleanOutput = (output: string[] | string) => {
-	return _(_.castArray(output))
-		.map(log => {
-			return log.split('\n').map(line => {
-				return line.trim();
-			});
-		})
-		.flatten()
-		.compact()
-		.value();
-};
-
 describe('balena help', function() {
 	it('should print simple help text', async () => {
 		const { out, err } = await runCommand('help');
 
-		chai
-			.expect(cleanOutput(out))
-			.to.deep.equal(
-				cleanOutput([
-					SIMPLE_HELP,
-					'Run `balena help --verbose` to list additional commands',
-					GLOBAL_OPTIONS,
-				]),
-			);
+		expect(cleanOutput(out)).to.deep.equal(
+			cleanOutput([
+				SIMPLE_HELP,
+				'Run `balena help --verbose` to list additional commands',
+				GLOBAL_OPTIONS,
+			]),
+		);
 
-		chai.expect(err.join('')).to.equal('');
+		expect(err.join('')).to.equal('');
 	});
 
 	it('should print additional commands with the -v flag', async () => {
 		const { out, err } = await runCommand('help -v');
 
-		chai
-			.expect(cleanOutput(out))
-			.to.deep.equal(
-				cleanOutput([SIMPLE_HELP, ADDITIONAL_HELP, GLOBAL_OPTIONS]),
-			);
+		expect(cleanOutput(out)).to.deep.equal(
+			cleanOutput([SIMPLE_HELP, ADDITIONAL_HELP, GLOBAL_OPTIONS]),
+		);
 
-		chai.expect(err.join('')).to.equal('');
+		expect(err.join('')).to.equal('');
 
-		chai.expect(err.join('')).to.equal('');
+		expect(err.join('')).to.equal('');
 	});
 
 	it('should print simple help text when no arguments present', async () => {
 		const { out, err } = await runCommand('');
 
-		chai
-			.expect(cleanOutput(out))
-			.to.deep.equal(
-				cleanOutput([
-					SIMPLE_HELP,
-					'Run `balena help --verbose` to list additional commands',
-					GLOBAL_OPTIONS,
-				]),
-			);
+		expect(cleanOutput(out)).to.deep.equal(
+			cleanOutput([
+				SIMPLE_HELP,
+				'Run `balena help --verbose` to list additional commands',
+				GLOBAL_OPTIONS,
+			]),
+		);
 
-		chai.expect(err.join('')).to.equal('');
+		expect(err.join('')).to.equal('');
 	});
 });

--- a/tests/commands/version.spec.ts
+++ b/tests/commands/version.spec.ts
@@ -1,4 +1,4 @@
-import * as chai from 'chai';
+import { expect } from 'chai';
 import * as fs from 'fs';
 import { runCommand } from '../helpers';
 
@@ -11,13 +11,13 @@ describe('balena version', function() {
 	it('should print the installed version of the CLI', async () => {
 		const { out } = await runCommand('version');
 
-		chai.expect(out.join('')).to.equal(`${packageJSON.version}\n`);
+		expect(out.join('')).to.equal(`${packageJSON.version}\n`);
 	});
 
 	it('should print additional version information with the -a flag', async () => {
 		const { out } = await runCommand('version -a');
 
-		chai.expect(out.join('')).to.equal(
+		expect(out.join('')).to.equal(
 			`balena-cli version "${packageJSON.version}"
 Node.js version "${nodeVersion}"
 `,
@@ -29,7 +29,7 @@ Node.js version "${nodeVersion}"
 
 		const json = JSON.parse(out.join(''));
 
-		chai.expect(json).to.deep.equal({
+		expect(json).to.deep.equal({
 			'balena-cli': packageJSON.version,
 			'Node.js': nodeVersion,
 		});

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -16,6 +16,7 @@
  */
 
 import intercept = require('intercept-stdout');
+import * as _ from 'lodash';
 import * as nock from 'nock';
 import * as path from 'path';
 
@@ -78,3 +79,15 @@ export const balenaAPIMock = () => {
 			configVarSchema: [],
 		});
 };
+
+export function cleanOutput(output: string[] | string) {
+	return _(_.castArray(output))
+		.map(log => {
+			return log.split('\n').map(line => {
+				return line.trim();
+			});
+		})
+		.flatten()
+		.compact()
+		.value();
+}


### PR DESCRIPTION
Hide discontinued device types in `balena devices supported`, `balena app create`.
Additionally:
 - Add tests for actions.
 - Convert devices supported action to TypeScript.

Resolves: #1485
Change-type: patch
Signed-off-by: Scott Lowe <scott@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Introduces security considerations
- [ ] Affects the development, build or deployment processes of the component
