### PR TITLE
Introduce workaround for windows dns issue on local `balena push`

### DIFF
--- a/lib/utils/helpers.ts
+++ b/lib/utils/helpers.ts
@@ -338,3 +338,21 @@ function windowsCmdExeEscapeArg(arg: string): string {
 	// duplicate internal double quotes, and double quote overall
 	return `"${arg.replace(/["]/g, '""')}"`;
 }
+
+/*
+ * Workaround a window system bug which causes multiple rapid DNS lookups
+ * to fail for mDNS.
+ *
+ * It introduces a simple pause, and should be used between operations that
+ * trigger mDNS resolutions.
+ *
+ * Windows bug: https://support.microsoft.com/en-gb/help/4057932/getaddrinfo-failed-with-wsahost-not-found-11001-error
+ */
+export async function workaroundWindowsDnsIssue(ipOrHostname: string) {
+	// 300ms seemed to be the smallest delay that worked reliably but may
+	// vary between systems.
+	const delay = 500;
+	if (process.platform === 'win32' && ipOrHostname.includes('.local')) {
+		await new Promise(r => setTimeout(r, delay));
+	}
+}


### PR DESCRIPTION
Introduce workaround for windows dns issue on `balena push` using .local device names.
Improve error handling in deployToDevice so that versionErrors don't mask other errors.

Resolves:#1518
See:https://support.microsoft.com/en-gb/help/4057932/getaddrinfo-failed-with-wsahost-not-found-11001-error
Change-type:patch
Signed-off-by:Scott Lowe <scott@balena.io>

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Introduces security considerations
- [ ] Affects the development, build or deployment processes of the component
