### PR TITLE
Prevent file ignorer from ignoring Dockerfile, docker-compose.yml

### DIFF
--- a/lib/utils/ignore.ts
+++ b/lib/utils/ignore.ts
@@ -115,6 +115,11 @@ export class FileIgnorer {
 			return true;
 		}
 
+		// Don't ignore Dockerfile (with or without extension) or docker-compose.yml
+		if (/^Dockerfile$|^Dockerfile\.\S+/.test(path.basename(relFile)) || path.basename(relFile) === 'docker-compose.yml') {
+			return true;
+		}
+
 		const dockerIgnoreHandle = dockerIgnore();
 		const gitIgnoreHandle = ignore();
 


### PR DESCRIPTION
Prevent file ignorer from ignoring `Dockerfile`, `docker-compose.yml`, even if listed in `.dockerignore`

Previously: 
- If `Dockerfile` was included in `.dockerignore`, then then push/build would fail with the message `Error: package.json: engines.node must be specified`.  This was due to `Dockerfile` being missing from the bundle, and `resin-bundle-resolve` matching on the 'node' resolver, rather than docker.
- If `docker-compose.yml` was included in `.dockerignore`, then the push/build would fail due to the default `docker-compose` file being used rather than the real one.

Note, including `Dockerfile` in `.dockerignore` is valid according to docker docs (not sure about `docker-compose.yml` but we should protect against it anyway). 
 https://docs.docker.com/engine/reference/builder/#dockerignore-file


Change-type: patch
Resolves: #1445
Signed-off-by: Scott Lowe <scott@balena.io>

