### PR TITLE
Add Windows-specific hint to 'balena scan' output

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -170,6 +170,14 @@ especially if you're using a user-managed node install such as [nvm](https://git
     Windows, check the [FAQ item "Docker seems to be
     unavailable"](https://github.com/balena-io/balena-cli/blob/master/TROUBLESHOOTING.md#docker-seems-to-be-unavailable-error-when-using-windows-subsystem-for-linux-wsl).
 
+* The `balena scan` command requires a multicast DNS (mDNS) service like Bonjour or Avahi:
+  * On Windows, check if 'Bonjour' is installed (Control Panel > Programs and Features).
+    If not, you can download Bonjour for Windows from https://support.apple.com/kb/DL999
+  * Most 'desktop' Linux distributions ship with [Avahi](https://en.wikipedia.org/wiki/Avahi_(software)).
+    Search for the installation command for your distribution. E.g. for Ubuntu:
+    `sudo apt-get install avahi-daemon`
+  * macOS comes with [Bonjour](https://en.wikipedia.org/wiki/Bonjour_(software)) built-in.
+
 ## Configuring SSH keys
 
 The `balena ssh` command requires an SSH key to be added to your balena account. If you had

--- a/lib/actions/scan.coffee
+++ b/lib/actions/scan.coffee
@@ -32,6 +32,20 @@ dockerVersionProperties = [
 	'ApiVersion'
 ]
 
+scanErrorMessage = 'Could not find any balenaOS devices in the local network.'
+
+winScanErrorMessage = scanErrorMessage + """
+\n
+Note for Windows users:
+  The 'scan' command relies on the Bonjour service. Check whether Bonjour is
+  installed (Control Panel > Programs and Features). If not, you can download
+  Bonjour for Windows (included with Bonjour Print Services) from here:
+  https://support.apple.com/kb/DL999
+
+  After installing Bonjour, restart your PC and run the 'balena scan' command
+  again.
+"""
+
 module.exports =
 	signature: 'scan'
 	description: 'Scan for balenaOS devices in your local network'
@@ -82,7 +96,7 @@ module.exports =
 			.catchReturn(false)
 		.tap (devices) ->
 			if _.isEmpty(devices)
-				exitWithExpectedError('Could not find any balenaOS devices in the local network')
+				exitWithExpectedError(if process.platform == 'win32' then winScanErrorMessage else scanErrorMessage)
 		.map ({ host, address }) ->
 			docker = dockerUtils.createClient(host: address, port: dockerPort, timeout: dockerTimeout)
 			Promise.props


### PR DESCRIPTION
Resolves: #1562
See: [Flowdock thread](https://www.flowdock.com/app/rulemotion/resin-frontend/threads/NDa-lsYyHT3TiYnJBCd3oO7Vwx6)
Change-type: patch

---
An extra Windows-specific message is now appended to the 'Could not find any balenaOS devices' message - if the OS is Windows.

Also updated the INSTALL instructions with details of the dependency on Bonjour.