### PR TITLE
Change the balena app action to present the slug instead of the git_repository

### DIFF
--- a/lib/actions/app.coffee
+++ b/lib/actions/app.coffee
@@ -128,7 +128,7 @@ exports.info =
 				"$#{application.app_name}$"
 				'id'
 				'device_type'
-				'git_repository'
+				'slug'
 				'commit'
 			]
 		.nodeify(done)


### PR DESCRIPTION
The `git_repository` field was replaced in the v5 endpoint with
the `slug` field. As a result the CLI atm never shows the
`git_repository` in the printed visual.
![image](https://user-images.githubusercontent.com/1295829/72392820-ab033880-3739-11ea-8bcc-3906017a93f7.png)

while after this PR it will show:
![image](https://user-images.githubusercontent.com/1295829/72392936-046b6780-373a-11ea-97ad-3702f5a0cd06.png)

Change-type: patch

---
##### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Introduces security considerations
- [ ] Affects the development, build or deployment processes of the component
