### PR TITLE
Debug mode can now be disabled with DEBUG=0 env var

### DIFF
--- a/automation/run.ts
+++ b/automation/run.ts
@@ -28,6 +28,13 @@ import {
 } from './deploy-bin';
 import { fixPathForMsys, ROOT, runUnderMsys } from './utils';
 
+// DEBUG set to falsy for negative values else is truthy
+process.env.DEBUG = ['0', 'no', 'false', '', undefined].includes(
+	process.env.DEBUG?.toLowerCase(),
+)
+	? ''
+	: '1';
+
 function exitWithError(error: Error | string): never {
 	console.error(`Error: ${error}`);
 	process.exit(1);

--- a/lib/app.ts
+++ b/lib/app.ts
@@ -23,6 +23,13 @@ export async function run(
 	cliArgs = process.argv,
 	options: import('./preparser').AppOptions = {},
 ) {
+	// DEBUG set to falsy for negative values else is truthy
+	process.env.DEBUG = ['0', 'no', 'false', '', undefined].includes(
+		process.env.DEBUG?.toLowerCase(),
+	)
+		? ''
+		: '1';
+
 	// The 'pkgExec' special/internal command provides a Node.js interpreter
 	// for use of the standalone zip package. See pkgExec function.
 	if (cliArgs.length > 3 && cliArgs[2] === 'pkgExec') {


### PR DESCRIPTION
Added `isDebugModeEnabled` to evaluate if debug mode is enabled, debug mode can now be disabled with DEBUG=0
Updated all conditional usages of `process.env.DEBUG` to use `isDebugModeEnabled`

Resolves: #1502
Change-type: patch
Signed-off-by: Thomas Manning <thomasm@balena.io>