### PR TITLE
Switch from opn to its new name of open

### DIFF
--- a/automation/build-bin.ts
+++ b/automation/build-bin.ts
@@ -97,7 +97,7 @@ async function buildPkg() {
 
 	const xpaths: Array<[string, string[]]> = [
 		// [platform, [path, to, file]]
-		['*', ['opn', 'xdg-open']],
+		['*', ['open', 'xdg-open']],
 		['darwin', ['denymount', 'bin', 'denymount']],
 	];
 	await Bluebird.map(xpaths, ([platform, xpath]) => {

--- a/lib/actions/auth.coffee
+++ b/lib/actions/auth.coffee
@@ -103,7 +103,7 @@ exports.login	=
 
 				if loginType is 'register'
 					signupUrl = 'https://dashboard.balena-cloud.com/signup'
-					require('opn')(signupUrl, { wait: false })
+					require('open')(signupUrl, { wait: false })
 					patterns.exitWithExpectedError("Please sign up at #{signupUrl}")
 
 				options[loginType] = true

--- a/lib/auth/index.coffee
+++ b/lib/auth/index.coffee
@@ -18,7 +18,7 @@ limitations under the License.
 # @module auth
 ###
 
-open = require('opn')
+open = require('open')
 balena = require('balena-sdk').fromSharedOptions()
 server = require('./server')
 utils = require('./utils')

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -7805,6 +7805,11 @@
         }
       }
     },
+    "is-docker": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.0.0.tgz",
+      "integrity": "sha512-pJEdRugimx4fBMra5z2/5iRdZ63OhYV0vr0Dwm5+xtW4D1FvRkB8hamMIhnWfyJeDdyr/aa7BDyNbtG38VxgoQ=="
+    },
     "is-elevated": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-elevated/-/is-elevated-3.0.0.tgz",
@@ -13341,19 +13346,27 @@
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
     },
+    "open": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.0.2.tgz",
+      "integrity": "sha512-70E/pFTPr7nZ9nLDPNTcj3IVqnNvKuP4VsBmoKV9YGTnChe0mlS3C4qM7qKarhZ8rGaHKLfo+vBTHXDp6ZSyLQ==",
+      "requires": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "dependencies": {
+        "is-wsl": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.1.1.tgz",
+          "integrity": "sha512-umZHcSrwlDHo2TGMXv0DZ8dIUGunZ2Iv68YZnrmCiBPkZ4aaOhtv7pXJKeki9k3qJ3RJr0cDyitcl5wEH3AYog=="
+        }
+      }
+    },
     "opencollective-postinstall": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz",
       "integrity": "sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw==",
       "dev": true
-    },
-    "opn": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/opn/-/opn-5.5.0.tgz",
-      "integrity": "sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==",
-      "requires": {
-        "is-wsl": "^1.1.0"
-      }
     },
     "opn-cli": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -211,7 +211,7 @@
     "node-cleanup": "^2.1.2",
     "node-unzip-2": "^0.2.8",
     "oclif": "^1.15.2",
-    "opn": "^5.5.0",
+    "open": "^7.0.2",
     "patch-package": "^6.2.0",
     "prettyjson": "^1.1.3",
     "progress-stream": "^2.0.0",


### PR DESCRIPTION
Info: https://github.com/sindresorhus/open/blob/v7.0.2/readme.md
>Note: The original open package was previously deprecated in favor of this package, and we got the name, so this package is now named open instead of opn

Changes: https://github.com/sindresorhus/open/releases
Notable stuff looks to be a bunch of windows fixes, WSL2 support, and typescript typings