### PR TITLE
Node 13 compatibility: update ext2fs module

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -13682,9 +13682,9 @@
       }
     },
     "patch-package": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-6.2.0.tgz",
-      "integrity": "sha512-HWlQflaBBMjLBfOWomfolF8aqsFDeNbSNro1JDUgYqnVvPM5OILJ9DQdwIRiKmGaOsmHvhkl1FYkvv1I9r2ZJw==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-6.1.2.tgz",
+      "integrity": "sha512-5GnzR8lEyeleeariG+hGabUnD2b1yL7AIGFjlLo95zMGRWhZCel58IpeKD46wwPb7i+uNhUI8unV56ogk8Bgqg==",
       "requires": {
         "@yarnpkg/lockfile": "^1.1.0",
         "chalk": "^2.4.2",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5149,15 +5149,22 @@
       }
     },
     "ext2fs": {
-      "version": "1.0.29",
-      "resolved": "https://registry.npmjs.org/ext2fs/-/ext2fs-1.0.29.tgz",
-      "integrity": "sha512-AoHwqSNx8SLZizLCMs+etrvdethI+jzak5yVmHACV+G0ziiLd19E3OQpC+SMmGOL1V+uRz3om7VxT5itfThYfQ==",
+      "version": "1.0.31",
+      "resolved": "https://registry.npmjs.org/ext2fs/-/ext2fs-1.0.31.tgz",
+      "integrity": "sha512-bfaggH7juFJNxXoY2nPShr8CSFbijKRsPYOwmSSms88I5n1X7+qsVqnMLLiq6VMI9MxHIFvqGfB+cwum0U1uPQ==",
       "requires": {
         "async": "^2.6.1",
         "bindings": "^1.3.0",
         "bluebird": "^3.5.3",
-        "nan": "2.13.2",
+        "nan": "^2.14.0",
         "prebuild-install": "^5.2.1"
+      },
+      "dependencies": {
+        "nan": {
+          "version": "2.14.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+          "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+        }
       }
     },
     "extend": {

--- a/package.json
+++ b/package.json
@@ -213,7 +213,7 @@
     "node-unzip-2": "^0.2.8",
     "oclif": "^1.15.2",
     "open": "^7.0.2",
-    "patch-package": "^6.2.0",
+    "patch-package": "6.1.2",
     "prettyjson": "^1.1.3",
     "progress-stream": "^2.0.0",
     "raven": "^2.5.0",


### PR DESCRIPTION
Upgraded ext2fs version in `npm-shrinkwrap.json`

Resolves: # 1591, 
Change-type: patch
