### PR TITLE
Use `import type` where possible to explicitly import only type info

### DIFF
--- a/automation/build-bin.ts
+++ b/automation/build-bin.ts
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import type { JsonVersions } from '../lib/actions-oclif/version';
+
 import { run as oclifRun } from '@oclif/dev-cli';
 import * as archiver from 'archiver';
 import * as Bluebird from 'bluebird';
@@ -135,7 +137,6 @@ async function buildPkg() {
  * existing mocha/chai CLI command testing.
  */
 async function testPkg() {
-	type JsonVersions = import('../lib/actions-oclif/version').JsonVersions;
 	const pkgBalenaPath = path.join(
 		ROOT,
 		'build-bin',

--- a/automation/capitanodoc/utils.ts
+++ b/automation/capitanodoc/utils.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { OptionDefinition } from 'capitano';
+import type { OptionDefinition } from 'capitano';
 import * as ent from 'ent';
 import * as fs from 'fs';
 import * as readline from 'readline';

--- a/lib/actions-oclif/apps.ts
+++ b/lib/actions-oclif/apps.ts
@@ -16,7 +16,7 @@
  */
 
 import { flags } from '@oclif/command';
-import { Application } from 'balena-sdk';
+import type { Application } from 'balena-sdk';
 import { stripIndent } from 'common-tags';
 import Command from '../command';
 import * as cf from '../utils/common-flags';

--- a/lib/actions-oclif/device/identify.ts
+++ b/lib/actions-oclif/device/identify.ts
@@ -16,7 +16,7 @@
  */
 
 import { flags } from '@oclif/command';
-import { IArg } from '@oclif/parser/lib/args';
+import type { IArg } from '@oclif/parser/lib/args';
 import { stripIndent } from 'common-tags';
 import Command from '../../command';
 import * as cf from '../../utils/common-flags';

--- a/lib/actions-oclif/device/index.ts
+++ b/lib/actions-oclif/device/index.ts
@@ -23,7 +23,7 @@ import * as cf from '../../utils/common-flags';
 import { expandForAppName } from '../../utils/helpers';
 import { getBalenaSdk, getVisuals } from '../../utils/lazy';
 import { tryAsInteger } from '../../utils/validation';
-import { Application, Device } from 'balena-sdk';
+import type { Application, Device } from 'balena-sdk';
 
 interface ExtendedDevice extends Device {
 	dashboard_url?: string;

--- a/lib/actions-oclif/device/move.ts
+++ b/lib/actions-oclif/device/move.ts
@@ -16,8 +16,8 @@
  */
 
 import { flags } from '@oclif/command';
-import { IArg } from '@oclif/parser/lib/args';
-import { Application, Device } from 'balena-sdk';
+import type { IArg } from '@oclif/parser/lib/args';
+import type { Application, Device } from 'balena-sdk';
 import { stripIndent } from 'common-tags';
 import * as _ from 'lodash';
 import Command from '../../command';

--- a/lib/actions-oclif/device/os-update.ts
+++ b/lib/actions-oclif/device/os-update.ts
@@ -16,13 +16,13 @@
  */
 
 import { flags } from '@oclif/command';
-import { IArg } from '@oclif/parser/lib/args';
+import type { IArg } from '@oclif/parser/lib/args';
 import { stripIndent } from 'common-tags';
 import Command from '../../command';
 import * as cf from '../../utils/common-flags';
 import { getBalenaSdk } from '../../utils/lazy';
 import { tryAsInteger } from '../../utils/validation';
-import { Device } from 'balena-sdk';
+import type { Device } from 'balena-sdk';
 import { ExpectedError } from '../../errors';
 
 interface FlagsDef {

--- a/lib/actions-oclif/device/public-url.ts
+++ b/lib/actions-oclif/device/public-url.ts
@@ -16,7 +16,7 @@
  */
 
 import { flags } from '@oclif/command';
-import { IArg } from '@oclif/parser/lib/args';
+import type { IArg } from '@oclif/parser/lib/args';
 import { stripIndent } from 'common-tags';
 import Command from '../../command';
 import { ExpectedError } from '../../errors';

--- a/lib/actions-oclif/device/reboot.ts
+++ b/lib/actions-oclif/device/reboot.ts
@@ -16,7 +16,7 @@
  */
 
 import { flags } from '@oclif/command';
-import { IArg } from '@oclif/parser/lib/args';
+import type { IArg } from '@oclif/parser/lib/args';
 import { stripIndent } from 'common-tags';
 import Command from '../../command';
 import * as cf from '../../utils/common-flags';

--- a/lib/actions-oclif/device/register.ts
+++ b/lib/actions-oclif/device/register.ts
@@ -16,7 +16,7 @@
  */
 
 import { flags } from '@oclif/command';
-import { IArg } from '@oclif/parser/lib/args';
+import type { IArg } from '@oclif/parser/lib/args';
 import { stripIndent } from 'common-tags';
 import Command from '../../command';
 import * as cf from '../../utils/common-flags';

--- a/lib/actions-oclif/device/rename.ts
+++ b/lib/actions-oclif/device/rename.ts
@@ -16,7 +16,7 @@
  */
 
 import { flags } from '@oclif/command';
-import { IArg } from '@oclif/parser/lib/args';
+import type { IArg } from '@oclif/parser/lib/args';
 import { stripIndent } from 'common-tags';
 import Command from '../../command';
 import * as cf from '../../utils/common-flags';

--- a/lib/actions-oclif/device/rm.ts
+++ b/lib/actions-oclif/device/rm.ts
@@ -16,7 +16,7 @@
  */
 
 import { flags } from '@oclif/command';
-import { IArg } from '@oclif/parser/lib/args';
+import type { IArg } from '@oclif/parser/lib/args';
 import { stripIndent } from 'common-tags';
 import Command from '../../command';
 import * as cf from '../../utils/common-flags';

--- a/lib/actions-oclif/device/shutdown.ts
+++ b/lib/actions-oclif/device/shutdown.ts
@@ -16,7 +16,7 @@
  */
 
 import { flags } from '@oclif/command';
-import { IArg } from '@oclif/parser/lib/args';
+import type { IArg } from '@oclif/parser/lib/args';
 import { stripIndent } from 'common-tags';
 import Command from '../../command';
 import * as cf from '../../utils/common-flags';

--- a/lib/actions-oclif/devices/index.ts
+++ b/lib/actions-oclif/devices/index.ts
@@ -23,7 +23,7 @@ import * as cf from '../../utils/common-flags';
 import { expandForAppName } from '../../utils/helpers';
 import { getBalenaSdk, getVisuals } from '../../utils/lazy';
 import { tryAsInteger } from '../../utils/validation';
-import { Device, Application } from 'balena-sdk';
+import type { Device, Application } from 'balena-sdk';
 
 interface ExtendedDevice extends Device {
 	dashboard_url?: string;

--- a/lib/actions-oclif/devices/supported.ts
+++ b/lib/actions-oclif/devices/supported.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 import { flags } from '@oclif/command';
-import * as SDK from 'balena-sdk';
+import type * as SDK from 'balena-sdk';
 import { stripIndent } from 'common-tags';
 import * as _ from 'lodash';
 import Command from '../../command';

--- a/lib/actions-oclif/env/add.ts
+++ b/lib/actions-oclif/env/add.ts
@@ -16,7 +16,7 @@
  */
 
 import { flags } from '@oclif/command';
-import * as BalenaSdk from 'balena-sdk';
+import type * as BalenaSdk from 'balena-sdk';
 import { stripIndent } from 'common-tags';
 import * as _ from 'lodash';
 import Command from '../../command';

--- a/lib/actions-oclif/envs.ts
+++ b/lib/actions-oclif/envs.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 import { flags } from '@oclif/command';
-import * as SDK from 'balena-sdk';
+import type * as SDK from 'balena-sdk';
 import { stripIndent } from 'common-tags';
 import * as _ from 'lodash';
 import Command from '../command';

--- a/lib/actions-oclif/os/configure.ts
+++ b/lib/actions-oclif/os/configure.ts
@@ -16,7 +16,7 @@
  */
 
 import { flags } from '@oclif/command';
-import BalenaSdk = require('balena-sdk');
+import type * as BalenaSdk from 'balena-sdk';
 import Bluebird = require('bluebird');
 import { stripIndent } from 'common-tags';
 import * as _ from 'lodash';

--- a/lib/actions-oclif/scan.ts
+++ b/lib/actions-oclif/scan.ts
@@ -16,7 +16,7 @@
  */
 
 import { flags } from '@oclif/command';
-import { LocalBalenaOsDevice } from 'balena-sync';
+import type { LocalBalenaOsDevice } from 'balena-sync';
 import { stripIndent } from 'common-tags';
 import Command from '../command';
 import * as cf from '../utils/common-flags';

--- a/lib/actions/local/flash.ts
+++ b/lib/actions/local/flash.ts
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { CommandDefinition } from 'capitano';
+import type { CommandDefinition } from 'capitano';
 import { stripIndent } from 'common-tags';
-import * as SDK from 'etcher-sdk';
+import type * as SDK from 'etcher-sdk';
 import { getChalk, getVisuals } from '../../utils/lazy';
 
 async function getDrive(options: {

--- a/lib/actions/logs.ts
+++ b/lib/actions/logs.ts
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { LogMessage } from 'balena-sdk';
-import { CommandDefinition } from 'capitano';
+import type { LogMessage } from 'balena-sdk';
+import type { CommandDefinition } from 'capitano';
 import { stripIndent } from 'common-tags';
 
 import { getBalenaSdk } from '../utils/lazy';

--- a/lib/actions/push.ts
+++ b/lib/actions/push.ts
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { BalenaSDK } from 'balena-sdk';
-import { CommandDefinition } from 'capitano';
+import type { BalenaSDK } from 'balena-sdk';
+import type { CommandDefinition } from 'capitano';
 import { stripIndent } from 'common-tags';
 
 import { ExpectedError } from '../errors';

--- a/lib/actions/ssh.ts
+++ b/lib/actions/ssh.ts
@@ -13,8 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import * as BalenaSdk from 'balena-sdk';
-import { CommandDefinition } from 'capitano';
+import type * as BalenaSdk from 'balena-sdk';
+import type { CommandDefinition } from 'capitano';
 import { stripIndent } from 'common-tags';
 
 import { getBalenaSdk } from '../utils/lazy';

--- a/lib/actions/tunnel.ts
+++ b/lib/actions/tunnel.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 import * as Bluebird from 'bluebird';
-import { CommandDefinition } from 'capitano';
+import type { CommandDefinition } from 'capitano';
 import { stripIndent } from 'common-tags';
 import * as _ from 'lodash';
 import { createServer, Server, Socket } from 'net';

--- a/lib/actions/util.ts
+++ b/lib/actions/util.ts
@@ -19,7 +19,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { CommandDefinition } from 'capitano';
+import type { CommandDefinition } from 'capitano';
 import { stripIndent } from 'common-tags';
 import { getChalk, getVisuals } from '../utils/lazy';
 

--- a/lib/app-common.ts
+++ b/lib/app-common.ts
@@ -78,7 +78,8 @@ function checkNodeVersion() {
 	}
 }
 
-export type GlobalTunnelNgConfig = import('global-tunnel-ng').Options;
+import type { Options as GlobalTunnelNgConfig } from 'global-tunnel-ng';
+export type { GlobalTunnelNgConfig };
 
 type ProxyConfig = string | GlobalTunnelNgConfig;
 

--- a/lib/app-oclif.ts
+++ b/lib/app-oclif.ts
@@ -30,7 +30,7 @@ class CustomMain extends Main {
 	}
 }
 
-type AppOptions = import('./preparser').AppOptions;
+import type { AppOptions } from './preparser';
 
 /**
  * oclif CLI entrypoint

--- a/lib/auth/server.ts
+++ b/lib/auth/server.ts
@@ -17,7 +17,7 @@ limitations under the License.
 import * as Bluebird from 'bluebird';
 import * as bodyParser from 'body-parser';
 import * as express from 'express';
-import { Socket } from 'net';
+import type { Socket } from 'net';
 import * as path from 'path';
 
 import * as utils from './utils';

--- a/lib/hooks/prerun/track.ts
+++ b/lib/hooks/prerun/track.ts
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Hook } from '@oclif/config';
+import type { Hook } from '@oclif/config';
 
 let trackResolve: (result: Promise<any>) => void;
 

--- a/lib/utils/cloud.ts
+++ b/lib/utils/cloud.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import * as SDK from 'balena-sdk';
+import type * as SDK from 'balena-sdk';
 import { stripIndent } from 'common-tags';
 import * as _ from 'lodash';
 

--- a/lib/utils/common-flags.ts
+++ b/lib/utils/common-flags.ts
@@ -17,7 +17,7 @@
 
 import { flags } from '@oclif/command';
 
-type IBooleanFlag<T> = import('@oclif/parser/lib/flags').IBooleanFlag<T>;
+import type { IBooleanFlag } from '@oclif/parser/lib/flags';
 
 export const application = flags.string({
 	char: 'a',

--- a/lib/utils/compose-types.d.ts
+++ b/lib/utils/compose-types.d.ts
@@ -15,10 +15,8 @@
  * limitations under the License.
  */
 
-import { Composition, ImageDescriptor } from 'resin-compose-parse';
-import { Pack } from 'tar-stream';
-
-import Logger = require('./logger');
+import type { Composition, ImageDescriptor } from 'resin-compose-parse';
+import type { Pack } from 'tar-stream';
 
 interface Image {
 	context: string;

--- a/lib/utils/compose_ts.ts
+++ b/lib/utils/compose_ts.ts
@@ -17,7 +17,7 @@
 import { BalenaSDK } from 'balena-sdk';
 import * as Bluebird from 'bluebird';
 import { stripIndent } from 'common-tags';
-import Dockerode = require('dockerode');
+import type * as Dockerode from 'dockerode';
 import * as _ from 'lodash';
 import { fs } from 'mz';
 import * as path from 'path';

--- a/lib/utils/config.ts
+++ b/lib/utils/config.ts
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import BalenaSdk = require('balena-sdk');
+import type * as BalenaSdk from 'balena-sdk';
 import * as semver from 'balena-semver';
 import Bluebird = require('bluebird');
 import { getBalenaSdk } from './lazy';

--- a/lib/utils/device/api.ts
+++ b/lib/utils/device/api.ts
@@ -16,10 +16,10 @@
  */
 import * as Bluebird from 'bluebird';
 import * as _ from 'lodash';
-import { NodeJSSocketWithFileDescriptor } from 'net-keepalive';
+import type { NodeJSSocketWithFileDescriptor } from 'net-keepalive';
 import * as os from 'os';
 import * as request from 'request';
-import * as Stream from 'stream';
+import type * as Stream from 'stream';
 
 import Logger = require('../logger');
 import * as ApiErrors from './errors';

--- a/lib/utils/device/deploy.ts
+++ b/lib/utils/device/deploy.ts
@@ -26,7 +26,7 @@ import {
 	LocalImage,
 	RegistrySecrets,
 } from 'resin-multibuild';
-import { Readable } from 'stream';
+import type { Readable } from 'stream';
 
 import { BALENA_ENGINE_TMP_PATH } from '../../config';
 import {

--- a/lib/utils/device/live.ts
+++ b/lib/utils/device/live.ts
@@ -1,17 +1,18 @@
 import * as Bluebird from 'bluebird';
 import * as chokidar from 'chokidar';
-import * as Dockerode from 'dockerode';
+import type * as Dockerode from 'dockerode';
 import Livepush, { ContainerNotRunningError } from 'livepush';
 import * as _ from 'lodash';
 import * as path from 'path';
-import { Composition } from 'resin-compose-parse';
-import { BuildTask } from 'resin-multibuild';
+import type { Composition } from 'resin-compose-parse';
+import type { BuildTask } from 'resin-multibuild';
 
 import { instanceOf } from '../../errors';
 import Logger = require('../logger');
 
 import { Dockerfile } from 'livepush';
-import DeviceAPI, { DeviceInfo, Status } from './api';
+import type DeviceAPI from './api';
+import type { DeviceInfo, Status } from './api';
 import {
 	DeviceDeployOptions,
 	generateTargetState,

--- a/lib/utils/device/logs.ts
+++ b/lib/utils/device/logs.ts
@@ -1,7 +1,7 @@
 import * as Bluebird from 'bluebird';
 import ColorHash = require('color-hash');
 import * as _ from 'lodash';
-import { Readable } from 'stream';
+import type { Readable } from 'stream';
 
 import { getChalk } from '../lazy';
 import Logger = require('../logger');

--- a/lib/utils/device/ssh.ts
+++ b/lib/utils/device/ssh.ts
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import { ContainerInfo } from 'dockerode';
+import type { ContainerInfo } from 'dockerode';
 
 export interface DeviceSSHOpts {
 	address: string;

--- a/lib/utils/docker.ts
+++ b/lib/utils/docker.ts
@@ -15,8 +15,7 @@
  * limitations under the License.
  */
 
-import Dockerode = require('dockerode');
-import * as dockerode from 'dockerode';
+import type * as dockerode from 'dockerode';
 
 export * from './docker-js';
 
@@ -24,7 +23,7 @@ interface BalenaEngineVersion extends dockerode.DockerVersion {
 	Engine?: string;
 }
 
-export async function isBalenaEngine(docker: Dockerode): Promise<boolean> {
+export async function isBalenaEngine(docker: dockerode): Promise<boolean> {
 	// dockerVersion.Engine should equal 'balena-engine' for the current/latest
 	// version of balenaEngine, but it was at one point (mis)spelt 'balaena':
 	// https://github.com/balena-os/balena-engine/pull/32/files

--- a/lib/utils/env-common.ts
+++ b/lib/utils/env-common.ts
@@ -20,7 +20,7 @@ import { stripIndent } from 'common-tags';
 
 import { ExpectedError } from '../errors';
 
-type IBooleanFlag<T> = import('@oclif/parser/lib/flags').IBooleanFlag<T>;
+import type { IBooleanFlag } from '@oclif/parser/lib/flags';
 
 export const booleanConfig: IBooleanFlag<boolean> = flags.boolean({
 	char: 'c',

--- a/lib/utils/helpers.ts
+++ b/lib/utils/helpers.ts
@@ -14,15 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { InitializeEmitter, OperationState } from 'balena-device-init';
-import * as BalenaSdk from 'balena-sdk';
+import type { InitializeEmitter, OperationState } from 'balena-device-init';
+import type * as BalenaSdk from 'balena-sdk';
 import * as Bluebird from 'bluebird';
 import { spawn, SpawnOptions } from 'child_process';
 import * as _ from 'lodash';
 import * as os from 'os';
 import * as ShellEscape from 'shell-escape';
 
-import { Device, PineOptionsFor } from 'balena-sdk';
+import type { Device, PineOptionsFor } from 'balena-sdk';
 import { ExpectedError } from '../errors';
 import { getBalenaSdk, getChalk, getVisuals } from './lazy';
 

--- a/lib/utils/lazy.ts
+++ b/lib/utils/lazy.ts
@@ -16,9 +16,9 @@ limitations under the License.
 
 // tslint:disable:import-blacklist - the import blacklist is to enforce lazy loading so exempt this file
 
-import * as BalenaSdk from 'balena-sdk';
-import { Chalk } from 'chalk';
-import * as visuals from 'resin-cli-visuals';
+import type * as BalenaSdk from 'balena-sdk';
+import type { Chalk } from 'chalk';
+import type * as visuals from 'resin-cli-visuals';
 
 // Equivalent of _.once but avoiding the need to import lodash for lazy deps
 const once = <T>(fn: () => T) => {

--- a/lib/utils/normalization.ts
+++ b/lib/utils/normalization.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { BalenaSDK } from 'balena-sdk';
+import type { BalenaSDK } from 'balena-sdk';
 import _ = require('lodash');
 import { ExpectedError } from '../errors';
 

--- a/lib/utils/oclif-utils.ts
+++ b/lib/utils/oclif-utils.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import * as Config from '@oclif/config';
+import type * as Config from '@oclif/config';
 
 /**
  * This class is a partial copy-and-paste of

--- a/lib/utils/patterns.ts
+++ b/lib/utils/patterns.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 import { BalenaApplicationNotFound } from 'balena-errors';
-import * as BalenaSdk from 'balena-sdk';
+import type * as BalenaSdk from 'balena-sdk';
 import Bluebird = require('bluebird');
 import { stripIndent } from 'common-tags';
 import _ = require('lodash');

--- a/lib/utils/promote.ts
+++ b/lib/utils/promote.ts
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as BalenaSdk from 'balena-sdk';
+import type * as BalenaSdk from 'balena-sdk';
 import { stripIndent } from 'common-tags';
 
 import { ExpectedError, printErrorMessage } from '../errors';

--- a/lib/utils/qemu.ts
+++ b/lib/utils/qemu.ts
@@ -17,7 +17,7 @@
 
 import * as Bluebird from 'bluebird';
 import { stripIndent } from 'common-tags';
-import Dockerode = require('dockerode');
+import type * as Dockerode from 'dockerode';
 import { getBalenaSdk } from './lazy';
 import Logger = require('./logger');
 

--- a/lib/utils/remote-build.ts
+++ b/lib/utils/remote-build.ts
@@ -13,15 +13,15 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import { BalenaSDK } from 'balena-sdk';
+import type { BalenaSDK } from 'balena-sdk';
 import * as Bluebird from 'bluebird';
 import * as JSONStream from 'JSONStream';
 import * as readline from 'readline';
 import * as request from 'request';
 import { RegistrySecrets } from 'resin-multibuild';
-import * as Stream from 'stream';
+import type * as Stream from 'stream';
 import streamToPromise = require('stream-to-promise');
-import { Pack } from 'tar-stream';
+import type { Pack } from 'tar-stream';
 
 import { ExpectedError } from '../errors';
 import { exitWithExpectedError } from '../errors';

--- a/lib/utils/tunnel.ts
+++ b/lib/utils/tunnel.ts
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import { BalenaSDK } from 'balena-sdk';
+import type { BalenaSDK } from 'balena-sdk';
 import * as Bluebird from 'bluebird';
 import { Socket } from 'net';
 import { TypedError } from 'typed-error';


### PR DESCRIPTION
Depends on https://github.com/prettier/prettier/issues/7263 for the linting to work