### PR TITLE
Make use of capitano's promise support to simplify the code

### DIFF
--- a/lib/actions/api-key.ts
+++ b/lib/actions/api-key.ts
@@ -18,8 +18,8 @@ export const generate: CommandDefinition<{
 
 			$ balena api-key generate "Jenkins Key"
 	`,
-	async action(params, _options, done) {
-		getBalenaSdk()
+	async action(params) {
+		await getBalenaSdk()
 			.models.apiKey.create(params.name)
 			.then(key => {
 				console.log(stripIndent`
@@ -29,7 +29,6 @@ export const generate: CommandDefinition<{
 
 					This key will not be shown again, so please save it now.
 				`);
-			})
-			.finally(done);
+			});
 	},
 };

--- a/lib/actions/app.ts
+++ b/lib/actions/app.ts
@@ -54,7 +54,7 @@ Examples:
 		},
 	],
 	permission: 'user',
-	async action(params, options, done) {
+	async action(params, options) {
 		const balena = getBalenaSdk();
 
 		const patterns = await import('../utils/patterns');
@@ -82,8 +82,7 @@ Examples:
 				console.info(
 					`Application created: ${application.app_name} (${application.device_type}, id ${application.id})`,
 				),
-			)
-			.nodeify(done);
+			);
 	},
 };
 
@@ -102,7 +101,7 @@ Examples:
 `,
 	permission: 'user',
 	primary: true,
-	async action(_params, _options, done) {
+	async action() {
 		const _ = await import('lodash');
 		const balena = getBalenaSdk();
 		const visuals = await import('resin-cli-visuals');
@@ -135,8 +134,7 @@ Examples:
 						]),
 					);
 				},
-			)
-			.nodeify(done);
+			);
 	},
 };
 
@@ -154,7 +152,7 @@ Examples:
 `,
 	permission: 'user',
 	primary: true,
-	async action(params, _options, done) {
+	async action(params) {
 		const visuals = await import('resin-cli-visuals');
 
 		return getBalenaSdk()
@@ -169,8 +167,7 @@ Examples:
 						'commit',
 					]),
 				);
-			})
-			.nodeify(done);
+			});
 	},
 };
 
@@ -187,10 +184,8 @@ Examples:
 	$ balena app restart MyApp\
 `,
 	permission: 'user',
-	async action(params, _options, done) {
-		return getBalenaSdk()
-			.models.application.restart(params.name)
-			.nodeify(done);
+	async action(params) {
+		return getBalenaSdk().models.application.restart(params.name);
 	},
 };
 
@@ -213,7 +208,7 @@ Examples:
 `,
 	options: [commandOptions.yes],
 	permission: 'user',
-	async action(params, options, done) {
+	async action(params, options) {
 		const patterns = await import('../utils/patterns');
 
 		return patterns
@@ -221,7 +216,6 @@ Examples:
 				options.yes ?? false,
 				'Are you sure you want to delete the application?',
 			)
-			.then(() => getBalenaSdk().models.application.remove(params.name))
-			.nodeify(done);
+			.then(() => getBalenaSdk().models.application.remove(params.name));
 	},
 };

--- a/lib/actions/build.coffee
+++ b/lib/actions/build.coffee
@@ -115,7 +115,7 @@ module.exports =
 			alias: 'a'
 		},
 	]
-	action: (params, options, done) ->
+	action: (params, options) ->
 		# compositions with many services trigger misleading warnings
 		require('events').defaultMaxListeners = 1000
 
@@ -181,4 +181,3 @@ module.exports =
 						convertEol: options.convertEol
 					})
 			)
-		.asCallback(done)

--- a/lib/actions/config.coffee
+++ b/lib/actions/config.coffee
@@ -46,7 +46,7 @@ exports.read =
 	]
 	permission: 'user'
 	root: true
-	action: (params, options, done) ->
+	action: (params, options) ->
 		Promise = require('bluebird')
 		config = require('balena-config-json')
 		visuals = require('resin-cli-visuals')
@@ -60,7 +60,6 @@ exports.read =
 			return config.read(drive, options.type)
 		.tap (configJSON) ->
 			console.info(prettyjson.render(configJSON))
-		.nodeify(done)
 
 exports.write =
 	signature: 'config write <key> <value>'
@@ -91,7 +90,7 @@ exports.write =
 	]
 	permission: 'user'
 	root: true
-	action: (params, options, done) ->
+	action: (params, options) ->
 		Promise = require('bluebird')
 		_ = require('lodash')
 		config = require('balena-config-json')
@@ -112,7 +111,6 @@ exports.write =
 				return config.write(drive, options.type, configJSON)
 		.tap ->
 			console.info('Done')
-		.nodeify(done)
 
 exports.inject =
 	signature: 'config inject <file>'
@@ -143,7 +141,7 @@ exports.inject =
 	]
 	permission: 'user'
 	root: true
-	action: (params, options, done) ->
+	action: (params, options) ->
 		Promise = require('bluebird')
 		config = require('balena-config-json')
 		visuals = require('resin-cli-visuals')
@@ -158,7 +156,6 @@ exports.inject =
 				return config.write(drive, options.type, configJSON)
 		.tap ->
 			console.info('Done')
-		.nodeify(done)
 
 exports.reconfigure =
 	signature: 'config reconfigure'
@@ -195,7 +192,7 @@ exports.reconfigure =
 	]
 	permission: 'user'
 	root: true
-	action: (params, options, done) ->
+	action: (params, options) ->
 		Promise = require('bluebird')
 		config = require('balena-config-json')
 		visuals = require('resin-cli-visuals')
@@ -216,7 +213,6 @@ exports.reconfigure =
 					return runCommand(configureCommand)
 		.then ->
 			console.info('Done')
-		.nodeify(done)
 
 exports.generate =
 	signature: 'config generate'
@@ -285,7 +281,7 @@ exports.generate =
 		}
 	]
 	permission: 'user'
-	action: (params, options, done) ->
+	action: (params, options) ->
 		normalizeUuidProp(options, 'device')
 		Promise = require('bluebird')
 		writeFileAsync = Promise.promisify(require('fs').writeFile)
@@ -355,4 +351,3 @@ exports.generate =
 				return writeFileAsync(options.output, JSON.stringify(config))
 
 			console.log(prettyjson.render(config))
-		.nodeify(done)

--- a/lib/actions/deploy.coffee
+++ b/lib/actions/deploy.coffee
@@ -194,7 +194,7 @@ module.exports =
 			boolean: true
 		},
 	]
-	action: (params, options, done) ->
+	action: (params, options) ->
 		# compositions with many services trigger misleading warnings
 		require('events').defaultMaxListeners = 1000
 		sdk = getBalenaSdk()
@@ -217,7 +217,7 @@ module.exports =
 		options.convertEol = options['convert-eol'] || false
 		delete options['convert-eol']
 		if options.convertEol and not options.build
-			return done(new ExpectedError('The --eol-conversion flag is only valid with --build.'))
+			return Promise.reject(new ExpectedError('The --eol-conversion flag is only valid with --build.'))
 
 		Promise.try ->
 			if not appName?
@@ -264,4 +264,3 @@ module.exports =
 						convertEol: options.convertEol
 					})
 			)
-		.asCallback(done)

--- a/lib/actions/device.coffee
+++ b/lib/actions/device.coffee
@@ -41,7 +41,7 @@ exports.list =
 	options: [ commandOptions.optionalApplication ]
 	permission: 'user'
 	primary: true
-	action: (params, options, done) ->
+	action: (params, options) ->
 		Promise = require('bluebird')
 		balena = getBalenaSdk()
 		visuals = require('resin-cli-visuals')
@@ -71,7 +71,6 @@ exports.list =
 				'os_version'
 				'dashboard_url'
 			]
-		.nodeify(done)
 
 exports.info =
 	signature: 'device <uuid>'
@@ -85,7 +84,7 @@ exports.info =
 	'''
 	permission: 'user'
 	primary: true
-	action: (params, options, done) ->
+	action: (params, options) ->
 		normalizeUuidProp(params)
 		balena = getBalenaSdk()
 		visuals = require('resin-cli-visuals')
@@ -116,7 +115,6 @@ exports.info =
 					'os_version'
 					'dashboard_url'
 				]
-		.nodeify(done)
 
 exports.register =
 	signature: 'device register <application>'
@@ -138,7 +136,7 @@ exports.register =
 			alias: 'u'
 		}
 	]
-	action: (params, options, done) ->
+	action: (params, options) ->
 		Promise = require('bluebird')
 		balena = getBalenaSdk()
 
@@ -150,7 +148,6 @@ exports.register =
 				return balena.models.device.register(application.id, uuid)
 		)
 		.get('uuid')
-		.nodeify(done)
 
 exports.remove =
 	signature: 'device rm <uuid>'
@@ -168,14 +165,13 @@ exports.remove =
 	'''
 	options: [ commandOptions.yes ]
 	permission: 'user'
-	action: (params, options, done) ->
+	action: (params, options) ->
 		normalizeUuidProp(params)
 		balena = getBalenaSdk()
 		patterns = require('../utils/patterns')
 
 		patterns.confirm(options.yes, 'Are you sure you want to delete the device?').then ->
 			balena.models.device.remove(params.uuid)
-		.nodeify(done)
 
 exports.identify =
 	signature: 'device identify <uuid>'
@@ -190,10 +186,10 @@ exports.identify =
 			$ balena device identify 23c73a1
 	'''
 	permission: 'user'
-	action: (params, options, done) ->
+	action: (params, options) ->
 		normalizeUuidProp(params)
 		balena = getBalenaSdk()
-		balena.models.device.identify(params.uuid).nodeify(done)
+		balena.models.device.identify(params.uuid)
 
 exports.reboot =
 	signature: 'device reboot <uuid>'
@@ -207,10 +203,10 @@ exports.reboot =
 	'''
 	options: [ commandOptions.forceUpdateLock ]
 	permission: 'user'
-	action: (params, options, done) ->
+	action: (params, options) ->
 		normalizeUuidProp(params)
 		balena = getBalenaSdk()
-		balena.models.device.reboot(params.uuid, options).nodeify(done)
+		balena.models.device.reboot(params.uuid, options)
 
 exports.shutdown =
 	signature: 'device shutdown <uuid>'
@@ -224,10 +220,10 @@ exports.shutdown =
 	'''
 	options: [ commandOptions.forceUpdateLock ]
 	permission: 'user'
-	action: (params, options, done) ->
+	action: (params, options) ->
 		normalizeUuidProp(params)
 		balena = getBalenaSdk()
-		balena.models.device.shutdown(params.uuid, options).nodeify(done)
+		balena.models.device.shutdown(params.uuid, options)
 
 exports.enableDeviceUrl =
 	signature: 'device public-url enable <uuid>'
@@ -240,10 +236,10 @@ exports.enableDeviceUrl =
 			$ balena device public-url enable 23c73a1
 	'''
 	permission: 'user'
-	action: (params, options, done) ->
+	action: (params, options) ->
 		normalizeUuidProp(params)
 		balena = getBalenaSdk()
-		balena.models.device.enableDeviceUrl(params.uuid).nodeify(done)
+		balena.models.device.enableDeviceUrl(params.uuid)
 
 exports.disableDeviceUrl =
 	signature: 'device public-url disable <uuid>'
@@ -256,10 +252,10 @@ exports.disableDeviceUrl =
 			$ balena device public-url disable 23c73a1
 	'''
 	permission: 'user'
-	action: (params, options, done) ->
+	action: (params, options) ->
 		normalizeUuidProp(params)
 		balena = getBalenaSdk()
-		balena.models.device.disableDeviceUrl(params.uuid).nodeify(done)
+		balena.models.device.disableDeviceUrl(params.uuid)
 
 exports.getDeviceUrl =
 	signature: 'device public-url <uuid>'
@@ -272,12 +268,11 @@ exports.getDeviceUrl =
 			$ balena device public-url 23c73a1
 	'''
 	permission: 'user'
-	action: (params, options, done) ->
+	action: (params, options) ->
 		normalizeUuidProp(params)
 		balena = getBalenaSdk()
 		balena.models.device.getDeviceUrl(params.uuid).then (url) ->
 			console.log(url)
-		.nodeify(done)
 
 exports.hasDeviceUrl =
 	signature: 'device public-url status <uuid>'
@@ -290,12 +285,11 @@ exports.hasDeviceUrl =
 			$ balena device public-url status 23c73a1
 	'''
 	permission: 'user'
-	action: (params, options, done) ->
+	action: (params, options) ->
 		normalizeUuidProp(params)
 		balena = getBalenaSdk()
 		balena.models.device.hasDeviceUrl(params.uuid).then (hasDeviceUrl) ->
 			console.log(hasDeviceUrl)
-		.nodeify(done)
 
 exports.rename =
 	signature: 'device rename <uuid> [newName]'
@@ -311,7 +305,7 @@ exports.rename =
 			$ balena device rename 7cf02a6 MyPi
 	'''
 	permission: 'user'
-	action: (params, options, done) ->
+	action: (params, options) ->
 		normalizeUuidProp(params)
 		Promise = require('bluebird')
 		balena = getBalenaSdk()
@@ -325,7 +319,6 @@ exports.rename =
 				type: 'input'
 
 		.then(_.partial(balena.models.device.rename, params.uuid))
-		.nodeify(done)
 
 exports.move =
 	signature: 'device move <uuid>'
@@ -342,7 +335,7 @@ exports.move =
 	'''
 	permission: 'user'
 	options: [ commandOptions.optionalApplication ]
-	action: (params, options, done) ->
+	action: (params, options) ->
 		normalizeUuidProp(params)
 		balena = getBalenaSdk()
 		patterns = require('../utils/patterns')
@@ -370,7 +363,6 @@ exports.move =
 			return balena.models.device.move(params.uuid, application)
 		.then (application) ->
 			console.info("#{params.uuid} was moved to #{application}")
-		.nodeify(done)
 
 exports.init =
 	signature: 'device init'
@@ -399,7 +391,7 @@ exports.init =
 		}
 	]
 	permission: 'user'
-	action: (params, options, done) ->
+	action: (params, options) ->
 		Promise = require('bluebird')
 		rimraf = Promise.promisify(require('rimraf'))
 		tmp = require('tmp')
@@ -448,8 +440,6 @@ exports.init =
 			.then (device) ->
 				console.log('Done')
 				return device.uuid
-
-		.nodeify(done)
 
 tsActions = require('./device_ts')
 exports.osUpdate = tsActions.osUpdate

--- a/lib/actions/device_ts.ts
+++ b/lib/actions/device_ts.ts
@@ -46,7 +46,7 @@ export const osUpdate: CommandDefinition<OsUpdate.Args, OsUpdate.Options> = {
 	`,
 	options: [commandOptions.optionalOsVersion, commandOptions.yes],
 	permission: 'user',
-	async action(params, options, done) {
+	async action(params, options) {
 		normalizeUuidProp(params);
 		const _ = await import('lodash');
 		const sdk = getBalenaSdk();
@@ -109,7 +109,6 @@ export const osUpdate: CommandDefinition<OsUpdate.Args, OsUpdate.Options> = {
 							.then(() => sdk.models.device.startOsUpdate(uuid, version))
 							.then(() => patterns.awaitDeviceOsUpdate(uuid, version)),
 					);
-			})
-			.nodeify(done);
+			});
 	},
 };

--- a/lib/actions/internal.coffee
+++ b/lib/actions/internal.coffee
@@ -25,7 +25,7 @@ exports.osInit =
 	'''
 	hidden: true
 	root: true
-	action: (params, options, done) ->
+	action: (params) ->
 		Promise = require('bluebird')
 		init = require('balena-device-init')
 		helpers = require('../utils/helpers')
@@ -35,7 +35,6 @@ exports.osInit =
 		Promise.join configPromise, manifestPromise, (config, manifest) ->
 			init.initialize(params.image, manifest, config)
 		.then(helpers.osProgressHandler)
-		.nodeify(done)
 
 exports.scanDevices =
 	signature: 'internal scandevices'
@@ -45,7 +44,7 @@ exports.scanDevices =
 	'''
 	hidden: true
 	root: true
-	action: (params, options, done) ->
+	action: ->
 		Promise = require('bluebird')
 		{ forms } = require('balena-sync')
 
@@ -53,4 +52,3 @@ exports.scanDevices =
 			forms.selectLocalBalenaOsDevice()
 			.then (hostnameOrIp) ->
 				console.error("==> Selected device: #{hostnameOrIp}")
-		.nodeify(done)

--- a/lib/actions/join.ts
+++ b/lib/actions/join.ts
@@ -13,7 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import * as Bluebird from 'bluebird';
 import { CommandDefinition } from 'capitano';
 import { stripIndent } from 'common-tags';
 import { getBalenaSdk } from '../utils/lazy';
@@ -64,13 +63,11 @@ export const join: CommandDefinition<Args, Options> = {
 	permission: 'user',
 	primary: true,
 
-	async action(params, options, done) {
+	async action(params, options) {
 		const Logger = await import('../utils/logger');
 		const promote = await import('../utils/promote');
 		const sdk = getBalenaSdk();
 		const logger = Logger.getLogger();
-		return Bluebird.try(() => {
-			return promote.join(logger, sdk, params.deviceIp, options.application);
-		}).nodeify(done);
+		return promote.join(logger, sdk, params.deviceIp, options.application);
 	},
 };

--- a/lib/actions/leave.ts
+++ b/lib/actions/leave.ts
@@ -13,7 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import * as Bluebird from 'bluebird';
 import { CommandDefinition } from 'capitano';
 import { stripIndent } from 'common-tags';
 import { getBalenaSdk } from '../utils/lazy';
@@ -47,13 +46,11 @@ export const leave: CommandDefinition<Args, {}> = {
 	permission: 'user',
 	primary: true,
 
-	async action(params, _options, done) {
+	async action(params) {
 		const Logger = await import('../utils/logger');
 		const promote = await import('../utils/promote');
 		const sdk = getBalenaSdk();
 		const logger = Logger.getLogger();
-		return Bluebird.try(() => {
-			return promote.leave(logger, sdk, params.deviceIp);
-		}).nodeify(done);
+		return promote.leave(logger, sdk, params.deviceIp);
 	},
 };

--- a/lib/actions/local/configure.coffee
+++ b/lib/actions/local/configure.coffee
@@ -203,7 +203,7 @@ module.exports =
 			$ balena local configure path/to/image.img
 	'''
 	root: true
-	action: (params, options, done) ->
+	action: (params, options) ->
 		Promise = require('bluebird')
 		path = require('path')
 		umount = require('umount')
@@ -234,4 +234,3 @@ module.exports =
 			denymount params.target, dmHandler, dmOpts
 		.then ->
 			console.log('Done!')
-		.asCallback(done)

--- a/lib/actions/local/ssh.coffee
+++ b/lib/actions/local/ssh.coffee
@@ -62,7 +62,7 @@ module.exports =
 			alias: 'p'
 	]
 	root: true
-	action: (params, options, done) ->
+	action: (params, options) ->
 		child_process = require('child_process')
 		Promise = require 'bluebird'
 		_ = require('lodash')
@@ -111,4 +111,3 @@ module.exports =
 			subShellCommand = getSubShellCommand(command)
 			child_process.spawn subShellCommand.program, subShellCommand.args,
 				stdio: 'inherit'
-		.nodeify(done)

--- a/lib/actions/local/stop.coffee
+++ b/lib/actions/local/stop.coffee
@@ -44,7 +44,7 @@ module.exports =
 			alias: 'a'
 	]
 	root: true
-	action: (params, options, done) ->
+	action: (params, options) ->
 		Promise = require('bluebird')
 		chalk = require('chalk')
 		{ forms, config, BalenaLocalDockerUtils } = require('balena-sync')

--- a/lib/actions/os.coffee
+++ b/lib/actions/os.coffee
@@ -56,7 +56,7 @@ exports.versions =
 
 			$ balena os versions raspberrypi3
 	'''
-	action: (params, options, done) ->
+	action: (params, options) ->
 		balena = getBalenaSdk()
 
 		balena.models.os.getSupportedVersions(params.type)
@@ -98,7 +98,7 @@ exports.download =
 		}
 		commandOptions.osVersionOrSemver
 	]
-	action: (params, options, done) ->
+	action: (params, options) ->
 		Promise = require('bluebird')
 		unzip = require('node-unzip-2')
 		fs = require('fs')
@@ -145,7 +145,6 @@ exports.download =
 			return rindle.wait(stream.pipe(output)).return(options.output)
 		.tap (output) ->
 			console.info('The image was downloaded successfully')
-		.nodeify(done)
 
 buildConfigForDeviceType = (deviceType, advanced = false) ->
 	form = require('resin-cli-form')
@@ -192,7 +191,7 @@ exports.buildConfig =
 			parameter: 'output'
 		}
 	]
-	action: (params, options, done) ->
+	action: (params, options) ->
 		fs = require('fs')
 		Promise = require('bluebird')
 		writeFileAsync = Promise.promisify(fs.writeFile)
@@ -200,7 +199,6 @@ exports.buildConfig =
 		buildConfig(params.image, params['device-type'], options.advanced)
 		.then (answers) ->
 			writeFileAsync(options.output, JSON.stringify(answers, null, 4))
-		.nodeify(done)
 
 INIT_WARNING_MESSAGE = '''
 	Note: Initializing the device may ask for administrative permissions
@@ -231,7 +229,7 @@ exports.initialize =
 		}
 		commandOptions.drive
 	]
-	action: (params, options, done) ->
+	action: (params, options) ->
 		Promise = require('bluebird')
 		umountAsync = Promise.promisify(require('umount').umount)
 		form = require('resin-cli-form')
@@ -288,4 +286,3 @@ exports.initialize =
 
 				umountAsync(answers.drive).tap ->
 					console.info("You can safely remove #{answers.drive} now")
-		.nodeify(done)

--- a/lib/actions/scan.coffee
+++ b/lib/actions/scan.coffee
@@ -70,7 +70,7 @@ module.exports =
 	]
 	primary: true
 	root: true
-	action: (params, options, done) ->
+	action: (params, options) ->
 		Promise = require('bluebird')
 		_ = require('lodash')
 		prettyjson = require('prettyjson')
@@ -111,4 +111,3 @@ module.exports =
 				return { host, address, dockerInfo, dockerVersion }
 		.then (devicesInfo) ->
 			console.log(prettyjson.render(devicesInfo, noColor: true))
-		.nodeify(done)

--- a/lib/actions/settings.ts
+++ b/lib/actions/settings.ts
@@ -27,13 +27,12 @@ Examples:
 
 	$ balena settings\
 `,
-	async action(_params, _options, done) {
+	async action() {
 		const prettyjson = await import('prettyjson');
 
 		return getBalenaSdk()
 			.settings.getAll()
 			.then(prettyjson.render)
-			.then(console.log)
-			.nodeify(done);
+			.then(console.log);
 	},
 };

--- a/lib/actions/tags.ts
+++ b/lib/actions/tags.ts
@@ -54,7 +54,7 @@ export const list: CommandDefinition<
 		commandOptions.optionalRelease,
 	],
 	permission: 'user',
-	async action(_params, options, done) {
+	async action(_params, options) {
 		normalizeUuidProp(options, 'device');
 		const Bluebird = await import('bluebird');
 		const _ = await import('lodash');
@@ -104,21 +104,19 @@ export const list: CommandDefinition<
 				// return never, so that TS typings are happy
 				return exitWithExpectedError(wrongParametersError);
 			},
-		)
-			.tap(function(environmentVariables) {
-				if (_.isEmpty(environmentVariables)) {
-					exitWithExpectedError('No tags found');
-				}
+		).tap(function(environmentVariables) {
+			if (_.isEmpty(environmentVariables)) {
+				exitWithExpectedError('No tags found');
+			}
 
-				console.log(
-					visuals.table.horizontal(environmentVariables, [
-						'id',
-						'tag_key',
-						'value',
-					]),
-				);
-			})
-			.nodeify(done);
+			console.log(
+				visuals.table.horizontal(environmentVariables, [
+					'id',
+					'tag_key',
+					'value',
+				]),
+			);
+		});
 	},
 };
 
@@ -159,24 +157,22 @@ export const set: CommandDefinition<
 		commandOptions.optionalRelease,
 	],
 	permission: 'user',
-	async action(params, options, done) {
+	async action(params, options) {
 		normalizeUuidProp(options, 'device');
-		const Bluebird = await import('bluebird');
 		const _ = await import('lodash');
 		const balena = getBalenaSdk();
 
 		const { exitWithExpectedError } = await import('../utils/patterns');
 
-		return Bluebird.try(async () => {
-			if (_.isEmpty(params.tagKey)) {
-				return exitWithExpectedError('No tag key was provided');
-			}
+		if (_.isEmpty(params.tagKey)) {
+			return exitWithExpectedError('No tag key was provided');
+		}
 
-			if (
-				_.filter([options.application, options.device, options.release])
-					.length !== 1
-			) {
-				return exitWithExpectedError(stripIndent`
+		if (
+			_.filter([options.application, options.device, options.release])
+				.length !== 1
+		) {
+			return exitWithExpectedError(stripIndent`
 					To set a resource tag, you must provide exactly one of:
 
 					* An application, with --application <appname>
@@ -187,40 +183,39 @@ export const set: CommandDefinition<
 
 					  $ balena help tag set
 				`);
-			}
+		}
 
-			if (params.value == null) {
-				params.value = '';
-			}
+		if (params.value == null) {
+			params.value = '';
+		}
 
-			if (options.application) {
-				return balena.models.application.tags.set(
-					options.application,
-					params.tagKey,
-					params.value,
-				);
-			}
-			if (options.device) {
-				return balena.models.device.tags.set(
-					options.device,
-					params.tagKey,
-					params.value,
-				);
-			}
-			if (options.release) {
-				const releaseParam = await disambiguateReleaseParam(
-					balena,
-					options.release,
-					options.release_raw,
-				);
+		if (options.application) {
+			return balena.models.application.tags.set(
+				options.application,
+				params.tagKey,
+				params.value,
+			);
+		}
+		if (options.device) {
+			return balena.models.device.tags.set(
+				options.device,
+				params.tagKey,
+				params.value,
+			);
+		}
+		if (options.release) {
+			const releaseParam = await disambiguateReleaseParam(
+				balena,
+				options.release,
+				options.release_raw,
+			);
 
-				return balena.models.release.tags.set(
-					releaseParam,
-					params.tagKey,
-					params.value,
-				);
-			}
-		}).nodeify(done);
+			return balena.models.release.tags.set(
+				releaseParam,
+				params.tagKey,
+				params.value,
+			);
+		}
 	},
 };
 
@@ -253,52 +248,49 @@ export const remove: CommandDefinition<
 		commandOptions.optionalRelease,
 	],
 	permission: 'user',
-	async action(params, options, done) {
-		const Bluebird = await import('bluebird');
+	async action(params, options) {
 		const _ = await import('lodash');
 		const balena = getBalenaSdk();
 		const { exitWithExpectedError } = await import('../utils/patterns');
 
-		return Bluebird.try(async () => {
-			if (_.isEmpty(params.tagKey)) {
-				return exitWithExpectedError('No tag key was provided');
-			}
+		if (_.isEmpty(params.tagKey)) {
+			return exitWithExpectedError('No tag key was provided');
+		}
 
-			if (
-				_.filter([options.application, options.device, options.release])
-					.length !== 1
-			) {
-				return exitWithExpectedError(stripIndent`
-					To remove a resource tag, you must provide exactly one of:
+		if (
+			_.filter([options.application, options.device, options.release])
+				.length !== 1
+		) {
+			return exitWithExpectedError(stripIndent`
+				To remove a resource tag, you must provide exactly one of:
 
-					* An application, with --application <appname>
-					* A device, with --device <uuid>
-					* A release, with --release <id or commit>
+				* An application, with --application <appname>
+				* A device, with --device <uuid>
+				* A release, with --release <id or commit>
 
-					See the help page for examples:
+				See the help page for examples:
 
-					  $ balena help tag rm
-				`);
-			}
+					$ balena help tag rm
+			`);
+		}
 
-			if (options.application) {
-				return balena.models.application.tags.remove(
-					options.application,
-					params.tagKey,
-				);
-			}
-			if (options.device) {
-				return balena.models.device.tags.remove(options.device, params.tagKey);
-			}
-			if (options.release) {
-				const releaseParam = await disambiguateReleaseParam(
-					balena,
-					options.release,
-					options.release_raw,
-				);
+		if (options.application) {
+			return balena.models.application.tags.remove(
+				options.application,
+				params.tagKey,
+			);
+		}
+		if (options.device) {
+			return balena.models.device.tags.remove(options.device, params.tagKey);
+		}
+		if (options.release) {
+			const releaseParam = await disambiguateReleaseParam(
+				balena,
+				options.release,
+				options.release_raw,
+			);
 
-				return balena.models.release.tags.remove(releaseParam, params.tagKey);
-			}
-		}).nodeify(done);
+			return balena.models.release.tags.remove(releaseParam, params.tagKey);
+		}
 	},
 };


### PR DESCRIPTION
There is still usage of the callback method for capitano in the codebase but only for code that actually uses a callback interface somewhere, anything purely promise based now relies on the promise handling (and as you can see I got to delete a load of code :D )