### PR TITLE
Fix 'balena login' web auth on Linux standalone zip install (xdg-open ENOENT)

### DIFF
--- a/automation/build-bin.ts
+++ b/automation/build-bin.ts
@@ -98,6 +98,7 @@ async function buildPkg() {
 	const paths: Array<[string, string[], string[]]> = [
 		// [platform, [source path], [destination path]]
 		['*', ['open', 'xdg-open'], ['xdg-open']],
+		['*', ['opn-cli', 'node_modules', 'opn', 'xdg-open'], ['xdg-open-402']],
 		['darwin', ['denymount', 'bin', 'denymount'], ['denymount']],
 	];
 	await Bluebird.map(paths, ([platform, source, dest]) => {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
       "build/auth/pages/*.ejs",
       "build/hooks",
       "node_modules/resin-discoverable-services/services/**/*",
+      "node_modules/opn-cli/node_modules/opn/xdg-open",
+      "node_modules/open/xdg-open",
       "node_modules/windosu/*.bat",
       "node_modules/windosu/*.cmd"
     ]

--- a/patches/open+7.0.2.patch
+++ b/patches/open+7.0.2.patch
@@ -1,0 +1,15 @@
+diff --git a/node_modules/open/index.js b/node_modules/open/index.js
+index 5fe49ad..c9194ba 100644
+--- a/node_modules/open/index.js
++++ b/node_modules/open/index.js
+@@ -10,7 +10,9 @@ const pAccess = promisify(fs.access);
+ const pExecFile = promisify(childProcess.execFile);
+ 
+ // Path to included `xdg-open`.
+-const localXdgOpenPath = path.join(__dirname, 'xdg-open');
++const localXdgOpenPath = process.pkg
++	? path.join(path.dirname(process.execPath), 'xdg-open')
++	: path.join(__dirname, 'xdg-open');
+ 
+ // Convert a path from WSL format to Windows format:
+ // `/mnt/c/Program Files/Example/MyApp.exe` → `C:\Program Files\Example\MyApp.exe`

--- a/patches/opn-cli++opn+4.0.2.patch
+++ b/patches/opn-cli++opn+4.0.2.patch
@@ -1,0 +1,14 @@
+diff --git a/node_modules/opn-cli/node_modules/opn/index.js b/node_modules/opn-cli/node_modules/opn/index.js
+index 13dcb66..16c5b2a 100644
+--- a/node_modules/opn-cli/node_modules/opn/index.js
++++ b/node_modules/opn-cli/node_modules/opn/index.js
+@@ -52,6 +52,9 @@ module.exports = function (target, opts) {
+ 			cmd = opts.app;
+ 		} else {
+ 			cmd = path.join(__dirname, 'xdg-open');
++			cmd = process.pkg
++				? path.join(path.dirname(process.execPath), 'xdg-open-402')
++				: path.join(__dirname, 'xdg-open');
+ 		}
+ 
+ 		if (appArgs.length > 0) {


### PR DESCRIPTION
Reported in #1657 and [flowdock](https://www.flowdock.com/app/rulemotion/public-s-community/threads/_4Mbt-BaW0WVsHYT_T140lMPKLe). Issue introduced by the `opn` → `open` upgrade in #1599, affecting CLI releases 11.25.6 to 11.28.14.

Resolves: #1657
Change-type: patch
