### PR TITLE
Make windows installer remove old files before installation.

### DIFF
--- a/patches/@oclif+dev-cli+1.22.0.patch
+++ b/patches/@oclif+dev-cli+1.22.0.patch
@@ -11,7 +11,7 @@ index cd771cd..4a66939 100644
      }
  }
 diff --git a/node_modules/@oclif/dev-cli/lib/commands/pack/win.js b/node_modules/@oclif/dev-cli/lib/commands/pack/win.js
-index a9d4276..75c2f8b 100644
+index a9d4276..4ac508f 100644
 --- a/node_modules/@oclif/dev-cli/lib/commands/pack/win.js
 +++ b/node_modules/@oclif/dev-cli/lib/commands/pack/win.js
 @@ -3,11 +3,14 @@ Object.defineProperty(exports, "__esModule", { value: true });
@@ -47,6 +47,20 @@ index a9d4276..75c2f8b 100644
  };
  exports.default = PackWin;
  const scripts = {
+@@ -89,6 +93,13 @@ VIAddVersionKey /LANG=\${LANG_ENGLISH} "ProductVersion" "\${VERSION}.0"
+ InstallDir "\$PROGRAMFILES${arch === 'x64' ? '64' : ''}\\${config.dirname}"
+ 
+ Section "${config.name} CLI \${VERSION}"
++  ; First remove any old client files.
++	; (Remnants of old versions were causing CLI errors)
++	; Initially tried running the Uninstall.exe, but was
++	; unable to make script wait for completion (despite using _?)
++	DetailPrint "Removing files from previous version."
++	RMDir /r "$INSTDIR\\client"
++  
+   SetOutPath $INSTDIR
+   File /r bin
+   File /r client
 diff --git a/node_modules/@oclif/dev-cli/lib/tarballs/build.js b/node_modules/@oclif/dev-cli/lib/tarballs/build.js
 index 3e613e0..dd23903 100644
 --- a/node_modules/@oclif/dev-cli/lib/tarballs/build.js


### PR DESCRIPTION
This is an npx patch to the [oclif/dev-cli build script](https://github.com/oclif/dev-cli/blob/master/src/commands/pack/win.ts) that creates the windows standalone installer.

This modifies the `nsis` installer script so that the installation section first deletes the `./client` folder, if it exists from a previous installation.

This has been tested extensively, including:
 - As a new install (to verify that a missing `./client` folder does not cause problems)
 - Installed over the top of v11.28.0 (which previously causes errors when doing `balena apps`)

(Background) Initially the idea was to run the uninstaller (if installed) as the first step of installation.  However I wasn't able to resolve one issue: the installer would not wait for the uninstaller to finish before continuing, which lead to the uninstaller and installer running in parallel.  This is caused by the uninstaller copying itself outside of the app directory, and then spawning a new process (so it can delete itself).   This should be suppressible according to the docs, but after multiple attempts with various changes, I could not get this to work (very slow testing/iteration cycle too).

Change-type: patch
Resolves: #1658

