### PR TITLE
Add support for primary/secondary oclif commands

### DIFF
--- a/lib/actions-oclif/devices/supported.ts
+++ b/lib/actions-oclif/devices/supported.ts
@@ -14,10 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Command, flags } from '@oclif/command';
+import { flags } from '@oclif/command';
 import * as SDK from 'balena-sdk';
 import { stripIndent } from 'common-tags';
 import * as _ from 'lodash';
+import Command from '../../command';
 
 import * as cf from '../../utils/common-flags';
 import { getBalenaSdk, getVisuals } from '../../utils/lazy';

--- a/lib/actions-oclif/env/add.ts
+++ b/lib/actions-oclif/env/add.ts
@@ -15,10 +15,11 @@
  * limitations under the License.
  */
 
-import { Command, flags } from '@oclif/command';
+import { flags } from '@oclif/command';
 import * as BalenaSdk from 'balena-sdk';
 import { stripIndent } from 'common-tags';
 import * as _ from 'lodash';
+import Command from '../../command';
 
 import { ExpectedError } from '../../errors';
 import * as cf from '../../utils/common-flags';

--- a/lib/actions-oclif/env/rename.ts
+++ b/lib/actions-oclif/env/rename.ts
@@ -14,8 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Command, flags } from '@oclif/command';
+import { flags } from '@oclif/command';
 import { stripIndent } from 'common-tags';
+import Command from '../../command';
 
 import * as cf from '../../utils/common-flags';
 import * as ec from '../../utils/env-common';

--- a/lib/actions-oclif/env/rm.ts
+++ b/lib/actions-oclif/env/rm.ts
@@ -15,8 +15,9 @@
  * limitations under the License.
  */
 
-import { Command, flags } from '@oclif/command';
+import { flags } from '@oclif/command';
 import { stripIndent } from 'common-tags';
+import Command from '../../command';
 
 import * as ec from '../../utils/env-common';
 import { getBalenaSdk } from '../../utils/lazy';

--- a/lib/actions-oclif/envs.ts
+++ b/lib/actions-oclif/envs.ts
@@ -14,10 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Command, flags } from '@oclif/command';
+import { flags } from '@oclif/command';
 import * as SDK from 'balena-sdk';
 import { stripIndent } from 'common-tags';
 import * as _ from 'lodash';
+import Command from '../command';
 
 import { ExpectedError } from '../errors';
 import * as cf from '../utils/common-flags';

--- a/lib/actions-oclif/os/configure.ts
+++ b/lib/actions-oclif/os/configure.ts
@@ -15,12 +15,13 @@
  * limitations under the License.
  */
 
-import { Command, flags } from '@oclif/command';
+import { flags } from '@oclif/command';
 import BalenaSdk = require('balena-sdk');
 import Bluebird = require('bluebird');
 import { stripIndent } from 'common-tags';
 import * as _ from 'lodash';
 import * as path from 'path';
+import Command from '../../command';
 
 import { ExpectedError } from '../../errors';
 import * as cf from '../../utils/common-flags';

--- a/lib/actions-oclif/version.ts
+++ b/lib/actions-oclif/version.ts
@@ -15,8 +15,9 @@
  * limitations under the License.
  */
 
-import { Command, flags } from '@oclif/command';
+import { flags } from '@oclif/command';
 import { stripIndent } from 'common-tags';
+import Command from '../command';
 
 interface FlagsDef {
 	all?: boolean;

--- a/lib/command.ts
+++ b/lib/command.ts
@@ -1,0 +1,26 @@
+/**
+ * @license
+ * Copyright 2020 Balena Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Command from '@oclif/command';
+
+export default abstract class extends Command {
+	/**
+	 * When set to true, command will be listed in `help`,
+	 * otherwise listed in `help --verbose` with secondary commands.
+	 */
+	public static primary = false;
+}


### PR DESCRIPTION
To date all capitano->oclif conversions have been for 'secondary' commands (ie. those that are not listed in help without the --verbose flag).  Recently a primary command was converted, which highlighted the fact that we have no support for this concept in oclif.  

This PR adds a custom base class for the oclif commands, allowing us to add the `primary` boolean property to oclif commands (and potentially reduce duplication in future PRs).  It also updates the help command to support this.

Change-type: minor
Signed-off-by: Scott Lowe <scott@balena.io>