### PR TITLE
Small improvements to `balena build`

### DIFF
--- a/doc/cli.markdown
+++ b/doc/cli.markdown
@@ -1888,11 +1888,11 @@ You must provide either an application or a device-type/architecture pair to use
 the balena Dockerfile pre-processor (e.g. Dockerfile.template -> Dockerfile).
 
 This command will look into the given source directory (or the current working
-directory if one isn't specified) for a docker-compose.yml file. If it is found,
-this command will build each service defined in the compose file. If a compose
-file isn't found, the command will look for a Dockerfile[.template] file (or
-alternative Dockerfile specified with the `-f` option), and if yet that isn't
-found, it will try to generate one.
+directory if one isn't specified) for a docker-compose.yml file, and if found,
+each service defined in the compose file will be built. If a compose file isn't
+found, it will look for a Dockerfile[.template] file (or alternative Dockerfile
+specified with the `--dockerfile` option), and if no dockerfile is found, it
+will try to generate one.
 
 The --registry-secrets option specifies a JSON or YAML file containing private
 Docker registry usernames and passwords to be used when pulling base images.

--- a/lib/actions/build.coffee
+++ b/lib/actions/build.coffee
@@ -77,11 +77,11 @@ module.exports =
 		the balena Dockerfile pre-processor (e.g. Dockerfile.template -> Dockerfile).
 
 		This command will look into the given source directory (or the current working
-		directory if one isn't specified) for a docker-compose.yml file. If it is found,
-		this command will build each service defined in the compose file. If a compose
-		file isn't found, the command will look for a Dockerfile[.template] file (or
-		alternative Dockerfile specified with the `-f` option), and if yet that isn't
-		found, it will try to generate one.
+		directory if one isn't specified) for a docker-compose.yml file, and if found,
+		each service defined in the compose file will be built. If a compose file isn't
+		found, it will look for a Dockerfile[.template] file (or alternative Dockerfile
+		specified with the `--dockerfile` option), and if no dockerfile is found, it
+		will try to generate one.
 
 		#{registrySecretsHelp}
 
@@ -121,6 +121,7 @@ module.exports =
 
 		sdk = getBalenaSdk()
 		{ ExpectedError } = require('../errors')
+		{ checkLoggedIn } = require('../utils/patterns')
 		{ validateProjectDirectory } = require('../utils/compose_ts')
 		helpers = require('../utils/helpers')
 		Logger = require('../utils/logger')
@@ -141,6 +142,8 @@ module.exports =
 		Promise.try ->
 			if (not (arch? and deviceType?) and not application?) or (application? and (arch? or deviceType?))
 				throw new ExpectedError('You must specify either an application or an arch/deviceType pair to build for')
+			if (application)
+				checkLoggedIn()
 		.then ->
 			validateProjectDirectory(sdk, {
 				dockerfilePath: options.dockerfile,


### PR DESCRIPTION
Check logged in for `balena build` if application specified
Correct eroneous `-f` flag in `balena build` help

Change-type: patch
Signed-off-by: Scott Lowe <scott@balena.io>

<!-- You can remove tags that do not apply. -->
Resolves: # <!-- Refer an issue of this repository that this PR fixes -->  
Change-type: major|minor|patch <!-- See https://semver.org/ -->  
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->  
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->  

---
Please check the CONTRIBUTING.md file for relevant information and some
guidance. Keep in mind that the CLI is a cross-platform application that runs
on Windows, macOS and Linux. Tests will be automatically run by balena CI on
all three operating systems, but this will only help if you have added test
code that exercises the modified or added feature code.

Note that each commit message (currently only the first line) will be
automatically copied to the CHANGELOG.md file, so try writing it in a way
that describes the feature or fix for CLI users.

If there isn't a linked issue or if the linked issue doesn't quite match the
PR, please add a PR description to explain its purpose or the features that it
implements. Adding PR comments to blocks of code that aren't self explanatory
usually helps with the review process.

If the PR introduces security considerations or affects the development, build
or release process, please be sure to highlight this in the PR description.
