### PR TITLE
Enable CLI upgrade of dev OS versions

### DIFF
--- a/lib/actions/keys.ts
+++ b/lib/actions/keys.ts
@@ -48,7 +48,7 @@ Examples:
 `,
 	permission: 'user',
 	async action(params) {
-		const key = await getBalenaSdk().models.key.get(params.id);
+		const key = await getBalenaSdk().models.key.get(parseInt(params.id, 10));
 
 		console.log(getVisuals().table.vertical(key, ['id', 'title']));
 
@@ -86,7 +86,7 @@ Examples:
 			'Are you sure you want to delete the key?',
 		);
 
-		await getBalenaSdk().models.key.remove(params.id);
+		await getBalenaSdk().models.key.remove(parseInt(params.id, 10));
 	},
 };
 

--- a/lib/utils/device/progress.ts
+++ b/lib/utils/device/progress.ts
@@ -18,7 +18,7 @@ import { Device } from 'balena-sdk';
 
 export const getDeviceOsProgress = (device: Device) => {
 	if (!device.is_online) {
-		return 0;
+		return null;
 	}
 
 	const status = BalenaDeviceStatus.getStatus(device).key;

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2089,9 +2089,9 @@
       }
     },
     "balena-hup-action-utils": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/balena-hup-action-utils/-/balena-hup-action-utils-3.0.2.tgz",
-      "integrity": "sha512-AwTAFQN4mtjsRLhkzspMKGBykWKvjVlZnzhAu6uyPBn8PGocyB3D30bR2jWgapd6uSdPJf38fcspRDbcpx3CHA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/balena-hup-action-utils/-/balena-hup-action-utils-4.0.0.tgz",
+      "integrity": "sha512-Qwk4h6QRqBiJNONRyoHPKtxgoRucdCK5VTG0A6LSCAo0qQrBRi4Alhdq76ksHQgZ2t/Gewfa7cuVAgiH78YMfw==",
       "requires": {
         "balena-semver": "^2.0.0",
         "lodash": "^4.17.11"
@@ -2124,9 +2124,9 @@
       }
     },
     "balena-pine": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/balena-pine/-/balena-pine-10.1.1.tgz",
-      "integrity": "sha512-Py0Id0w1QwwM20/gmZ4hRgTOf0sbCwmjGwkE0G/AO6fqnlFDe5ehaebzXk3AtWmW3K7WGDPUxcNAHohHG8aRJA==",
+      "version": "10.1.3",
+      "resolved": "https://registry.npmjs.org/balena-pine/-/balena-pine-10.1.3.tgz",
+      "integrity": "sha512-dOjftYx7vf9e3C9ENJyYyD8DNtQl6CxXuWgvNImfvK3Rw+zSRBPYfLw6S4MqbCWkcsQGjaS/zun/VJ9UNjJYhQ==",
       "requires": {
         "balena-errors": "^4.2.1",
         "bluebird": "^3.7.2",
@@ -2235,16 +2235,16 @@
       },
       "dependencies": {
         "qs": {
-          "version": "6.9.1",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.1.tgz",
-          "integrity": "sha512-Cxm7/SS/y/Z3MHWSxXb8lIFqgqBowP5JMlTUFyJN88y0SGQhVmZnqFK/PeuMX9LzUyWsqqhNxIyg0jlzq946yA=="
+          "version": "6.9.3",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.3.tgz",
+          "integrity": "sha512-EbZYNarm6138UKKq46tdx08Yo/q9ZhFoAXAI1meAFd2GtbRDhbZY2WQSICskT0c5q99aFzLG1D4nvTk9tqfXIw=="
         }
       }
     },
     "balena-sdk": {
-      "version": "12.29.1",
-      "resolved": "https://registry.npmjs.org/balena-sdk/-/balena-sdk-12.29.1.tgz",
-      "integrity": "sha512-e6nIuP16AaDpGQnOCDPR7kptCM7/iWHPp6bdmUeBsw9e5IX4zwI0FwFHi4L9EoRxByLKI5oRZYeYGeU++Sd1Nw==",
+      "version": "12.33.0",
+      "resolved": "https://registry.npmjs.org/balena-sdk/-/balena-sdk-12.33.0.tgz",
+      "integrity": "sha512-riqcJeA8SYMf20bgt1lhgw/eWiWXVwivGHgBer54/dxDIo48RIwys98LvkisIO2sTco1AmTL4Q0rePsMGjEYwQ==",
       "requires": {
         "@types/bluebird": "^3.5.30",
         "@types/lodash": "^4.14.149",
@@ -2253,8 +2253,8 @@
         "abortcontroller-polyfill": "^1.4.0",
         "balena-auth": "^3.0.1",
         "balena-device-status": "^3.2.1",
-        "balena-errors": "^4.2.1",
-        "balena-hup-action-utils": "~3.0.0",
+        "balena-errors": "^4.3.0",
+        "balena-hup-action-utils": "~4.0.0",
         "balena-pine": "^10.1.1",
         "balena-register-device": "^6.0.1",
         "balena-request": "^10.0.8",
@@ -2269,9 +2269,23 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "8.10.59",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.59.tgz",
-          "integrity": "sha512-8RkBivJrDCyPpBXhVZcjh7cQxVBSmRk9QM7hOketZzp6Tg79c0N8kkpAIito9bnJ3HCVCHVYz+KHTEbfQNfeVQ=="
+          "version": "8.10.60",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.60.tgz",
+          "integrity": "sha512-YjPbypHFuiOV0bTgeF07HpEEqhmHaZqYNSdCKeBJa+yFoQ/7BC+FpJcwmi34xUIIRVFktnUyP1dPU8U0612GOg=="
+        },
+        "balena-errors": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/balena-errors/-/balena-errors-4.3.2.tgz",
+          "integrity": "sha512-daa+3jHqvoha8zIIIX4jvxdus1LWhH+2Y5IJOzOuIzxmfLEq51EXeszMbcHrbSLlGlJpfaJDG7dfBmFXtabL6Q==",
+          "requires": {
+            "tslib": "^1.11.1",
+            "typed-error": "^3.0.0"
+          }
+        },
+        "tslib": {
+          "version": "1.11.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+          "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
         }
       }
     },
@@ -2314,9 +2328,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "8.10.59",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.59.tgz",
-          "integrity": "sha512-8RkBivJrDCyPpBXhVZcjh7cQxVBSmRk9QM7hOketZzp6Tg79c0N8kkpAIito9bnJ3HCVCHVYz+KHTEbfQNfeVQ=="
+          "version": "8.10.60",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.60.tgz",
+          "integrity": "sha512-YjPbypHFuiOV0bTgeF07HpEEqhmHaZqYNSdCKeBJa+yFoQ/7BC+FpJcwmi34xUIIRVFktnUyP1dPU8U0612GOg=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -173,7 +173,7 @@
     "balena-errors": "^4.2.1",
     "balena-image-manager": "^6.1.2",
     "balena-preload": "^8.4.0",
-    "balena-sdk": "^12.29.1",
+    "balena-sdk": "^12.33.0",
     "balena-semver": "^2.2.0",
     "balena-settings-client": "^4.0.4",
     "balena-sync": "^10.2.0",


### PR DESCRIPTION
Enable CLI upgrade of dev OS versions
Fix `device os-update` incorrectly showing 0% progress
Convert `device os-update` to use async/await

Change-type: minor
Resolves: #1725
Signed-off-by: Scott Lowe <scott@balena.io>
