### PR TITLE
Fix seemingly random ENOENT error (update 'is-installed-globally' dependency)

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -8283,9 +8283,9 @@
       }
     },
     "is-installed-globally": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.3.1.tgz",
-      "integrity": "sha512-oiEcGoQbGc+3/iijAijrK2qFpkNoNjsHOm/5V5iaeydyrS/hnwaRCEgH5cpW0P3T1lSjV5piB7S5b5lEugNLhg==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.3.2.tgz",
+      "integrity": "sha512-wZ8x1js7Ia0kecP/CHM/3ABkAmujX7WPvQk6uu3Fly/Mk44pySulQpnHG46OMjHGXApINnV4QhY3SWnECO2z5g==",
       "requires": {
         "global-dirs": "^2.0.1",
         "is-path-inside": "^3.0.1"


### PR DESCRIPTION
`is-installed-globally` version 0.3.2 fixed the ENOENT issue:
* https://github.com/sindresorhus/is-installed-globally/issues/4
* https://github.com/sindresorhus/is-installed-globally/issues/6
* https://github.com/sindresorhus/is-installed-globally/pull/7

The CLI's `npm-shrinkwrap.json` file has two occurrences of affected `is-installed-globally` dependency:
```
    "is-installed-globally": {
      "version": "0.3.1",
...
        "is-installed-globally": {
          "version": "0.1.0",
```

This PR updates the first one, but leaves `is-installed-globally` v0.1.0 alone: there is a net of dependencies that I couldn't untangle. Even so, strictly this PR resolves issue #1723 because that issue qualified the problem as "when running cli commands", and the v0.1.0 dependency only applies when running `patch-package` in the `postinstall` npm script. `patch-package` v6.2.1 resolves the problem by removing the dependency altogether, but we cannot upgrade from `patch-package` 6.1 to 6.2 because of issue ds300/patch-package/issues/201. I created PR ds300/patch-package/pull/224 in their repo, which hopefully would allow us to upgrade `patch-package`. Meanwhile, this PR should alleviate the problem.

Change-type: patch
Resolves: #1723 
