### PR TITLE
Avoid patch-package warning with 'npm install -g --production'

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build/",
     "doc/",
     "lib/",
+    "patches0/",
     "patches/",
     "*.md",
     "npm-shrinkwrap.json"


### PR DESCRIPTION
Fix the following warnings (result of PR #1739):
```
$ npm install -g --production balena-cli
...
Applying patches...
No patch files found
patch-package 6.2.2
Applying patches...
@oclif/dev-cli@1.22.0 ✔
open@7.0.2 ✔
opn@4.0.2 ✔

Warning: patch-package detected a patch file version mismatch

  Don't worry! This is probably fine. The patch was still applied
  successfully. Here's the deets:

  Patch file created for

    pkg@4.4.2.dev

  applied to

    pkg@4.4.2

  At path

    node_modules/pkg

  This warning is just to give you a heads-up. There is a small chance of
  breakage even though the patch was applied successfully. Make sure the package
  still behaves like you expect (you wrote tests, right?) and then run

    patch-package pkg

  to update the version in the patch file name and make this warning go away.

qqjs/execa@0.10.0 ✔

Warning: patch-package detected a patch file version mismatch

  Don't worry! This is probably fine. The patch was still applied
  successfully. Here's the deets:

  Patch file created for

    qqjs@0.3.10.dev

  applied to

    qqjs@0.3.10

  At path

    node_modules/qqjs

  This warning is just to give you a heads-up. There is a small chance of
  breakage even though the patch was applied successfully. Make sure the package
  still behaves like you expect (you wrote tests, right?) and then run

    patch-package qqjs

  to update the version in the patch file name and make this warning go away.

windosu@0.3.0 ✔
```

Change-type: patch
