### PR TITLE
Modify oclif help to match balena conventions

### DIFF
--- a/patches/@oclif+plugin-help+2.2.0.patch
+++ b/patches/@oclif+plugin-help+2.2.0.patch
@@ -1,0 +1,37 @@
+diff --git a/node_modules/@oclif/plugin-help/lib/command.js b/node_modules/@oclif/plugin-help/lib/command.js
+index ab72c1b..75078d5 100644
+--- a/node_modules/@oclif/plugin-help/lib/command.js
++++ b/node_modules/@oclif/plugin-help/lib/command.js
+@@ -86,7 +86,7 @@ class CommandHelp {
+         if (!args.filter(a => a.description).length)
+             return;
+         let body = list_1.renderList(args.map(a => {
+-            const name = a.name.toUpperCase();
++            const name = a.required ? `<${a.name}>` : `[${a.name}]`;
+             let description = a.description || '';
+             if (a.default)
+                 description = `[default: ${a.default}] ${description}`;
+@@ -130,8 +130,7 @@ class CommandHelp {
+                     value = flag.options.join('|');
+                 }
+                 if (!value.includes('|'))
+-                    value = underline(value);
+-                left += `=${value}`;
++                left += ` <${value}>`;
+             }
+             let right = flag.description || '';
+             if (flag.type === 'option' && flag.default) {
+diff --git a/node_modules/@oclif/plugin-help/lib/index.js b/node_modules/@oclif/plugin-help/lib/index.js
+index 43acf30..bebefa6 100644
+--- a/node_modules/@oclif/plugin-help/lib/index.js
++++ b/node_modules/@oclif/plugin-help/lib/index.js
+@@ -74,7 +74,8 @@ class Help {
+             console.log(title + '\n');
+         console.log(this.command(command));
+         console.log();
+-        if (topics.length) {
++        const SUPPRESS_SUBTOPICS = true;
++        if (topics.length && !SUPPRESS_SUBTOPICS) {
+             console.log(this.topics(topics));
+             console.log();
+         }


### PR DESCRIPTION
This patch applies a few modifications to the standard oclif help:
 - Remove `COMMANDS` section which is was displayed for the root command of 'topic' style commands (e.g. `balena app`).
 - When displaying options, use a space rather than `=` between option flag and option value
 - Remove underline from option values
 - Enclose argument names in `<>` (for required args), or `[]` for optional args.
 - Remove toUpper for argument names.

Before:

```
USAGE
  $ balena example <requiredArgument> [optionalArgument]

ARGUMENTS
  REQUIREDARGUMENT  some required argument
  OPTIONALARGUMENT  some optional argument

OPTIONS
  -a, --application=application  application name    // <-- Note application would be underlined here
  -h, --help                       show CLI help

DESCRIPTION
  Some example description.

EXAMPLES
  $ balena example
  $ balena example 123

COMMANDS
  EXAMPLE:SUBEXAMPLE
  EXAMPLE:SUBEXAMPLE2
```

After: 

```
USAGE
  $ balena example <requiredArgument> [optionalArgument]

ARGUMENTS
  <requiredArgument>  some required argument
  [optionalArgument]  some optional argument

OPTIONS
  -a, --application <application>  application name
  -h, --help                       show CLI help

DESCRIPTION
  Some example description.

EXAMPLES
  $ balena example
  $ balena example 123
```




Change-type: patch
Signed-off-by: Scott Lowe <scott@balena.io>

Resolves: #1782 
