### PR TITLE
Add support for global --debug flag

### DIFF
--- a/lib/preparser.ts
+++ b/lib/preparser.ts
@@ -52,6 +52,13 @@ export async function routeCliFramework(argv: string[], options: AppOptions) {
 			cmdSlice.shift();
 			cmdSlice.push('--help');
 		}
+
+		// support global --debug flag
+		const debugIndex = cmdSlice.indexOf('--debug');
+		if (debugIndex > -1) {
+			process.env.DEBUG = '1';
+			cmdSlice.splice(debugIndex, 1);
+		}
 	}
 
 	const [isOclif, isTopic] = isOclifCommand(cmdSlice);


### PR DESCRIPTION
Add support for global --debug flag.  Tested in oclif and capitano cases.

Change-type: patch
Resolves: #1777
Signed-off-by: Scott Lowe <scott@balena.io>