### PR TITLE
Improve oclif missing argument/flag errors

### DIFF
--- a/patches/@oclif+parser+3.8.4.patch
+++ b/patches/@oclif+parser+3.8.4.patch
@@ -1,0 +1,55 @@
+diff --git a/node_modules/@oclif/parser/lib/errors.js b/node_modules/@oclif/parser/lib/errors.js
+index 93912ca..c4cac1d 100644
+--- a/node_modules/@oclif/parser/lib/errors.js
++++ b/node_modules/@oclif/parser/lib/errors.js
+@@ -10,7 +10,8 @@ const m = deps_1.default()
+     .add('list', () => require('./list'));
+ class CLIParseError extends errors_1.CLIError {
+     constructor(options) {
+-        options.message += '\nSee more help with --help';
++        const help = options.command ? `\`${options.command} --help\`` : '--help';
++        options.message += `\nSee more help with ${help}`;
+         super(options.message);
+         this.parse = options.parse;
+     }
+@@ -31,22 +32,24 @@ class InvalidArgsSpecError extends CLIParseError {
+ exports.InvalidArgsSpecError = InvalidArgsSpecError;
+ class RequiredArgsError extends CLIParseError {
+     constructor({ args, parse }) {
+-        let message = `Missing ${args.length} required arg${args.length === 1 ? '' : 's'}`;
++        const command = 'balena ' + parse.input.context.id.replace(/:/g, ' ');
++        let message = `Missing ${args.length} required argument${args.length === 1 ? '' : 's'}`;
+         const namedArgs = args.filter(a => a.name);
+         if (namedArgs.length) {
+             const list = m.list.renderList(namedArgs.map(a => [a.name, a.description]));
+             message += `:\n${list}`;
+         }
+-        super({ parse, message });
++        super({ parse, message, command });
+         this.args = args;
+     }
+ }
+ exports.RequiredArgsError = RequiredArgsError;
+ class RequiredFlagError extends CLIParseError {
+     constructor({ flag, parse }) {
++        const command = 'balena ' + parse.input.context.id.replace(/:/g, ' ');
+         const usage = m.list.renderList(m.help.flagUsages([flag], { displayRequired: false }));
+         const message = `Missing required flag:\n${usage}`;
+-        super({ parse, message });
++        super({ parse, message, command });
+         this.flag = flag;
+     }
+ }
+diff --git a/node_modules/@oclif/parser/lib/list.js b/node_modules/@oclif/parser/lib/list.js
+index 3907cc0..b689ca1 100644
+--- a/node_modules/@oclif/parser/lib/list.js
++++ b/node_modules/@oclif/parser/lib/list.js
+@@ -21,7 +21,7 @@ function renderList(items) {
+         }
+         left = left.padEnd(maxLength);
+         right = linewrap(maxLength + 2, right);
+-        return `${left}  ${right}`;
++        return `${left} : ${right}`;
+     });
+     return lines.join('\n');
+ }


### PR DESCRIPTION
This patch modifies oclif's missing required argument and missing required flag error messages to meet the requirements recently discussed, as described in :  https://github.com/balena-io/balena-cli/issues/1776

Unfortunately it was not possible to add `< >` around parameter names, because of the fact that in oclif the rendering is shared between both missing argument and missing flag errors.  Otherwise meets requirements.

Output is now in the format:
```
Missing 1 required argument:
argumentName : argument description
See more help with `balena xxx --help`
```
```
Missing required flag:
--timeout : flag description
See more help with `balena xxx --help`
```

Change-type: patch
Resolves: #1776
Signed-off-by: Scott Lowe <scott@balena.io>
