### PR TITLE
Enforce lazy loading via tslint import-blacklist

### DIFF
--- a/lib/utils/lazy.ts
+++ b/lib/utils/lazy.ts
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// tslint:disable:import-blacklist - the import blacklist is to enforce lazy loading so exempt this file
+
 import * as BalenaSdk from 'balena-sdk';
 import { Chalk } from 'chalk';
 import * as visuals from 'resin-cli-visuals';

--- a/tslint.json
+++ b/tslint.json
@@ -1,6 +1,7 @@
 {
     "extends": "./node_modules/@balena/lint/config/tslint-prettier.json",
     "rules": {
-        "ignoreDefinitionFiles": false
+        "ignoreDefinitionFiles": false,
+        "import-blacklist": [true, "resin-cli-visuals", "chalk"]
     }
 }


### PR DESCRIPTION
The import blacklist should include balena-sdk but we need to import it for types so it's trickier