### PR TITLE
Disable oclif's ts-node registering when running against built code

### DIFF
--- a/bin/balena
+++ b/bin/balena
@@ -4,6 +4,9 @@
 // operations otherwise, if the pool runs out.
 process.env.UV_THREADPOOL_SIZE = '64';
 
+// Disable oclif registering ts-node
+process.env.OCLIF_TS_NODE = 0;
+
 // Use fast-boot to cache require lookups, speeding up startup
 require('fast-boot2').start({
 	cacheFile: __dirname + '/.fast-boot.json'


### PR DESCRIPTION
This shaves ~360ms off of commands that would trigger that - at the very least `balena apps` does trigger it