### PR TITLE
Improve presentation of errors, help

### DIFF
--- a/lib/actions/help.js
+++ b/lib/actions/help.js
@@ -73,8 +73,8 @@ const manuallySortedPrimaryCommands = [
 
 const general = function(_params, options, done) {
 	console.log('Usage: balena [COMMAND] [OPTIONS]\n');
-	console.log(messages.reachingOut);
-	console.log('\nPrimary commands:\n');
+
+	console.log('Primary commands:\n');
 
 	// We do not want the wildcard command
 	// to be printed in the help screen.
@@ -123,6 +123,9 @@ const general = function(_params, options, done) {
 				console.log('\nGlobal Options:\n');
 				print(parse(capitano.state.globalOptions).sort());
 			}
+			console.log(indent('--debug\n'));
+
+			console.log(messages.help);
 
 			return done();
 		})
@@ -151,6 +154,8 @@ const commandHelp = (params, _options, done) =>
 			console.log('\nOptions:\n');
 			print(parse(command.options).sort());
 		}
+
+		console.log();
 
 		return done();
 	});

--- a/lib/utils/messages.ts
+++ b/lib/utils/messages.ts
@@ -9,18 +9,15 @@ create a new one at: https://github.com/balena-io/balena-cli/issues/\
 `;
 
 const debugHint = `\
-Additional information may be available by setting a DEBUG=1 environment
-variable: "set DEBUG=1" on a Windows command prompt, "$env:DEBUG = 1" on
-powershell, or "export DEBUG=1" on Linux or macOS.\n
+Additional information may be available with the \`--debug\` flag.
 `;
 
-export const getHelp = `${DEBUG_MODE ? '' : debugHint}\
-If you need help, don't hesitate in contacting our support forums at
-https://forums.balena.io
-
-For CLI bug reports or feature requests, have a look at the GitHub issues or
-create a new one at: https://github.com/balena-io/balena-cli/issues/\
+export const help = `\
+For help, visit our support forums: https://forums.balena.io
+For bug reports or feature requests, see: https://github.com/balena-io/balena-cli/issues/
 `;
+
+export const getHelp = (DEBUG_MODE ? '' : debugHint) + help;
 
 export const balenaAsciiArt = `\
  _            _

--- a/tests/commands/help.spec.ts
+++ b/tests/commands/help.spec.ts
@@ -4,12 +4,6 @@ import { cleanOutput, runCommand } from '../helpers';
 const SIMPLE_HELP = `
 Usage: balena [COMMAND] [OPTIONS]
 
-If you need help, or just want to say hi, don't hesitate in reaching out
-through our discussion and support forums at https://forums.balena.io
-
-For bug reports or feature requests, have a look at the GitHub issues or
-create a new one at: https://github.com/balena-io/balena-cli/issues/
-
 Primary commands:
 
     help [command...]                       show help
@@ -84,33 +78,33 @@ Additional commands:
 
 `;
 
+const LIST_ADDITIONAL = `
+Run \`balena help --verbose\` to list additional commands
+`;
+
 const GLOBAL_OPTIONS = `
 	Global Options:
 
 		--help, -h
 		--version, -v
+		--debug
+`;
+
+const ONLINE_RESOURCES = `
+      For help, visit our support forums: https://forums.balena.io
+      For bug reports or feature requests, see: https://github.com/balena-io/balena-cli/issues/
 `;
 
 describe('balena help', function() {
 	it('should list primary command summaries', async () => {
 		const { out, err } = await runCommand('help');
 
-		console.log('ONE');
-		console.log(cleanOutput(out));
-		console.log(
-			cleanOutput([
-				SIMPLE_HELP,
-				'Run `balena help --verbose` to list additional commands',
-				GLOBAL_OPTIONS,
-			]),
-		);
-		console.log();
-
 		expect(cleanOutput(out)).to.deep.equal(
 			cleanOutput([
 				SIMPLE_HELP,
-				'Run `balena help --verbose` to list additional commands',
+				LIST_ADDITIONAL,
 				GLOBAL_OPTIONS,
+				ONLINE_RESOURCES,
 			]),
 		);
 
@@ -121,7 +115,12 @@ describe('balena help', function() {
 		const { out, err } = await runCommand('help -v');
 
 		expect(cleanOutput(out)).to.deep.equal(
-			cleanOutput([SIMPLE_HELP, ADDITIONAL_HELP, GLOBAL_OPTIONS]),
+			cleanOutput([
+				SIMPLE_HELP,
+				ADDITIONAL_HELP,
+				GLOBAL_OPTIONS,
+				ONLINE_RESOURCES,
+			]),
 		);
 
 		expect(err.join('')).to.equal('');
@@ -135,8 +134,9 @@ describe('balena help', function() {
 		expect(cleanOutput(out)).to.deep.equal(
 			cleanOutput([
 				SIMPLE_HELP,
-				'Run `balena help --verbose` to list additional commands',
+				LIST_ADDITIONAL,
 				GLOBAL_OPTIONS,
+				ONLINE_RESOURCES,
 			]),
 		);
 


### PR DESCRIPTION
Improve presentation of errors, help, in line with recent discussions.

- Removed boilerplate from expected errors
- Removed color from expected errors
- Edited boilerplate to be more concise.
- Now only first lines of unexpected errors are red.
- Errors now print first line of stacktrace (if available) even when not in debug mode.
- Added extra expected errors pattern match for oclif parser errors.
- Added extra line after capitano command help to make it clearer, and match oclif.
- Added --debug to the list of global flags in help

Change-type: patch
Resolves: #1779 #1757
Signed-off-by: Scott Lowe <scott@balena.io>