### PR TITLE
`app create`: "You already have an application with that name!"

### DIFF
--- a/doc/cli.markdown
+++ b/doc/cli.markdown
@@ -307,6 +307,10 @@ Examples:
 
 ### Options
 
+#### -v, --verbose
+
+add extra columns in the tabular output (SLUG)
+
 ## app &#60;name&#62;
 
 Display detailed information about a single balena application.

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -132,6 +132,7 @@ const messages: {
 };
 
 const EXPECTED_ERROR_REGEXES = [
+	/^BalenaAmbiguousApplication:/, // balena-sdk
 	/^BalenaApplicationNotFound:/, // balena-sdk
 	/^BalenaDeviceNotFound:/, // balena-sdk
 	/^Missing \w+$/, // Capitano, oclif parser: RequiredArgsError, RequiredFlagError


### PR DESCRIPTION
Resolves: #1824
Change-type: minor

The PR also adds a `--verbose` option to `balena apps`, to include the application slug in the output (app's "full name").
