### PR TITLE
Fix caching by preserving all file stats when pushing to device or cloud

### DIFF
--- a/lib/utils/compose.js
+++ b/lib/utils/compose.js
@@ -228,7 +228,12 @@ function originalTarDirectory(dir, param) {
 				readFile(file),
 				(filename, stats, data) =>
 					pack.entry(
-						{ name: toPosixPath(filename), size: stats.size, mode: stats.mode },
+						{
+							name: toPosixPath(filename),
+							mtime: stats.mtime,
+							size: stats.size,
+							mode: stats.mode,
+						},
 						data,
 					),
 			);

--- a/lib/utils/compose_ts.ts
+++ b/lib/utils/compose_ts.ts
@@ -189,8 +189,9 @@ export async function tarDirectory(
 		pack.entry(
 			{
 				name: toPosixPath(fileStats.relPath),
-				size: fileStats.stats.size,
+				mtime: fileStats.stats.mtime,
 				mode: fileStats.stats.mode,
+				size: fileStats.stats.size,
 			},
 			await readFile(fileStats.filePath),
 		);


### PR DESCRIPTION
This is likely one of the most frustrating bugs for our users, when sometimes cache is invalidated for apparently no reason. To fix this, save all stats from the host, not just size and permissions.

Change-type: patch
Signed-off-by: Cameron Diver <cameron@balena.io>

---
Please check the CONTRIBUTING.md file for relevant information and some
guidance. Keep in mind that the CLI is a cross-platform application that runs
on Windows, macOS and Linux. Tests will be automatically run by balena CI on
all three operating systems, but this will only help if you have added test
code that exercises the modified or added feature code.

Note that each commit message (currently only the first line) will be
automatically copied to the CHANGELOG.md file, so try writing it in a way
that describes the feature or fix for CLI users.

If there isn't a linked issue or if the linked issue doesn't quite match the
PR, please add a PR description to explain its purpose or the features that it
implements. Adding PR comments to blocks of code that aren't self explanatory
usually helps with the review process.

If the PR introduces security considerations or affects the development, build
or release process, please be sure to highlight this in the PR description.

Thank you very much for your contribution!
