### PR TITLE
Replace windows dns workaround with single lookup

### DIFF
--- a/lib/utils/helpers.ts
+++ b/lib/utils/helpers.ts
@@ -327,24 +327,6 @@ function windowsCmdExeEscapeArg(arg: string): string {
 }
 
 /**
- * Workaround a window system bug which causes multiple rapid DNS lookups
- * to fail for mDNS.
- *
- * It introduces a simple pause, and should be used between operations that
- * trigger mDNS resolutions.
- *
- * Windows bug: https://support.microsoft.com/en-gb/help/4057932/getaddrinfo-failed-with-wsahost-not-found-11001-error
- */
-export async function workaroundWindowsDnsIssue(ipOrHostname: string) {
-	// 300ms seemed to be the smallest delay that worked reliably but may
-	// vary between systems.
-	const delay = 500;
-	if (process.platform === 'win32' && ipOrHostname.includes('.local')) {
-		await new Promise(r => setTimeout(r, delay));
-	}
-}
-
-/**
  * Error handling wrapper around the npm `which` package:
  * "Like the unix which utility. Finds the first instance of a specified
  * executable in the PATH environment variable. Does not cache the results,


### PR DESCRIPTION
This replaces a workaround for a windows dns issue affecting livepush (see https://github.com/balena-io/balena-cli/issues/1528 , https://github.com/balena-io/balena-cli/issues/1518), with an alternative approach that initially does a single dns lookup, and then uses the IP address for subsequent operations.  (Requested by @CameronDiver )

Change-type: patch
Connects-to: #1518
Resolves: #1727
Signed-off-by: Scott Lowe <scott@balena.io>