### PR TITLE
balena deploy: Fix "access denied" pushing images to registry

### DIFF
--- a/lib/utils/compose_ts.ts
+++ b/lib/utils/compose_ts.ts
@@ -588,9 +588,7 @@ async function getTokenForPreviousRepos(
 	const { authorizePush, getPreviousRepos } = await import('./compose');
 	const sdk = getBalenaSdk();
 	const previousRepos = await getPreviousRepos(sdk, docker, logger, appId);
-	if (!previousRepos || previousRepos.length === 0) {
-		return '';
-	}
+
 	const token = await authorizePush(
 		sdk,
 		apiEndpoint,


### PR DESCRIPTION
This bug was introduced in the Typescript conversion in #1837 (my bad...)
Kindly reported by @xginn8 in https://www.flowdock.com/app/rulemotion/i-cli/threads/yDJIhV8zk_Iu65rLKVpPJ-cG2V5

Change-type: patch
