### PR TITLE
balena deploy: Allow image layer caching when pushing to the registry

### DIFF
--- a/lib/utils/compose-types.d.ts
+++ b/lib/utils/compose-types.d.ts
@@ -36,6 +36,13 @@ export interface BuiltImage {
 	serviceName: string;
 }
 
+// TODO: avoid duplication with 'docker-toolbelt/lib/docker-toolbelt.d.ts'
+export interface ImageNameParts {
+	registry: string;
+	imageName: string;
+	tagName: string;
+}
+
 export interface TaggedImage {
 	localImage: import('dockerode').Image;
 	serviceImage: import('balena-release/build/models').ImageModel;

--- a/lib/utils/compose.js
+++ b/lib/utils/compose.js
@@ -583,7 +583,7 @@ export const tagServiceImages = (docker, images, serviceImages) =>
  * @param {import('docker-toolbelt')} docker
  * @param {import('./logger')} logger
  * @param {number} appID
- * @returns {Promise<string[]>}
+ * @returns {Promise<Array<import('./compose-types').ImageNameParts>>}
  */
 export const getPreviousRepos = (sdk, docker, logger, appID) =>
 	sdk.pine
@@ -614,7 +614,7 @@ export const getPreviousRepos = (sdk, docker, logger, appID) =>
 						logger.logDebug(
 							`Requesting access to previously pushed image repo (${registry.imageName})`,
 						);
-						return registry.imageName;
+						return registry;
 					});
 				});
 			} else {
@@ -627,11 +627,13 @@ export const getPreviousRepos = (sdk, docker, logger, appID) =>
 		});
 
 /**
+ * Note: this function is closely related to the balenaCloud builder's
+ * `getRegistryToken()` in `balena-builder/src/utils.coffee`.
  * @param {*} sdk
  * @param {string} tokenAuthEndpoint
  * @param {string} registry
  * @param {string[]} images
- * @param {string[]} previousRepos
+ * @param {string[]} previousRepos e.g. ["v2/ec1326492f27113d07a5b71b925bec72"]
  * @returns {Promise<string>}
  */
 export const authorizePush = function(

--- a/tests/commands/deploy.spec.ts
+++ b/tests/commands/deploy.spec.ts
@@ -40,8 +40,9 @@ const commonResponseLines = {
 		'[Info] without balena-cli intervention and regardless of the --emulated option.',
 		'[Build] main Image size: 1.14 MB',
 		'[Info] Creating release...',
+		'[Info] Pulling previous release images to enable layer caching...',
 		'[Info] Pushing images to registry...',
-		'[Info] Saving release...',
+		'[Info] Saving release... [status=success]',
 		'[Success] Deploy succeeded!',
 		'[Success] Release: 09f7c3e1fdec609be818002299edfc2a',
 	],
@@ -90,6 +91,7 @@ describe('balena deploy', function() {
 		docker.expectGetPing();
 		docker.expectGetInfo({});
 		docker.expectGetVersion({ persist: true });
+		docker.expectPostImagesCreate();
 		docker.expectPostImagesTag();
 		docker.expectPostImagesPush();
 		docker.expectDeleteImages();

--- a/tests/docker-mock.ts
+++ b/tests/docker-mock.ts
@@ -119,6 +119,10 @@ export class DockerMock extends NockMock {
 		]);
 	}
 
+	public expectPostImagesCreate(opts: ScopeOpts = {}) {
+		this.optPost(/^\/images\/create/, opts).reply(200);
+	}
+
 	public expectPostImagesTag(opts: ScopeOpts = {}) {
 		this.optPost(/^\/images\/.+?\/tag\?/, opts).reply(201);
 	}


### PR DESCRIPTION
Internal discussions:
* https://www.flowdock.com/app/rulemotion/i-cli/threads/kaEbyLk3TMTv-6DpxFINFEvJzf7
* https://www.flowdock.com/app/rulemotion/r-beginners/threads/S49_Ba5FTrllSDaDr8BL0P7CyMu

Connects-to: #1045
Change-type: minor
