### PR TITLE
Add runtime warning for unused .dockerignore files

### DIFF
--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -140,7 +140,7 @@ const EXPECTED_ERROR_REGEXES = [
 	/^BalenaDeviceNotFound/, // balena-sdk
 	/^BalenaExpiredToken/, // balena-sdk
 	/^Missing \w+$/, // Capitano,
-	/^Missing \d required argument/, // oclif parser: RequiredArgsError, RequiredFlagError
+	/^Missing \d+ required arg/, // oclif parser: RequiredArgsError, RequiredFlagError
 	/^Unexpected argument/, // oclif parser: UnexpectedArgsError
 	/to be one of/, // oclif parser: FlagInvalidOptionError, ArgInvalidOptionError
 ];

--- a/lib/utils/ignore.ts
+++ b/lib/utils/ignore.ts
@@ -190,7 +190,7 @@ export class FileIgnorer {
 	}
 }
 
-interface FileStats {
+export interface FileStats {
 	filePath: string;
 	relPath: string;
 	stats: fs.Stats;
@@ -256,7 +256,7 @@ async function readDockerIgnoreFile(projectDir: string): Promise<string> {
  */
 export async function filterFilesWithDockerignore(
 	projectDir: string,
-): Promise<FileStats[]> {
+): Promise<{ filteredFileList: FileStats[]; dockerignoreFiles: FileStats[] }> {
 	// path.resolve() also converts forward slashes to backslashes on Windows
 	projectDir = path.resolve(projectDir);
 	const dockerIgnoreStr = await readDockerIgnoreFile(projectDir);
@@ -276,5 +276,12 @@ export async function filterFilesWithDockerignore(
 	]);
 
 	const files = await listFiles(projectDir);
-	return files.filter((file: FileStats) => !ig.ignores(file.relPath));
+	const dockerignoreFiles: FileStats[] = [];
+	const filteredFileList = files.filter((file: FileStats) => {
+		if (path.basename(file.relPath) === '.dockerignore') {
+			dockerignoreFiles.push(file);
+		}
+		return !ig.ignores(file.relPath);
+	});
+	return { filteredFileList, dockerignoreFiles };
 }

--- a/tests/test-data/projects/docker-compose/basic/service2/.dockerignore
+++ b/tests/test-data/projects/docker-compose/basic/service2/.dockerignore
@@ -1,0 +1,1 @@
+file2-crlf.sh

--- a/tests/test-data/projects/no-docker-compose/basic/src/.dockerignore
+++ b/tests/test-data/projects/no-docker-compose/basic/src/.dockerignore
@@ -1,0 +1,1 @@
+windows-crlf.sh


### PR DESCRIPTION
Print a warning message at runtime if `.dockerignore` files are found in project subdirectories, as these files will not be used. Motivated by forum thread: [Builds failing overnight w/ cli v12.1.1](https://forums.balena.io/t/builds-failing-overnight-w-cli-v12-1-1/137120/).

Connects-to: #1870 
Connects-to: balena-io/balena-on-balena/issues/200
Change-type: patch
