### PR TITLE
Stub the errors module without needing two export methods

### DIFF
--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -22,9 +22,6 @@ import { TypedError } from 'typed-error';
 import { getChalk } from './utils/lazy';
 import { getHelp } from './utils/messages';
 
-// Support stubbing of module functions.
-let ErrorsModule: any;
-
 export class ExpectedError extends TypedError {}
 
 export class NotLoggedInError extends ExpectedError {}
@@ -146,9 +143,9 @@ const EXPECTED_ERROR_REGEXES = [
 ];
 
 // Support unit testing of handleError
-async function getSentry() {
+export const getSentry = async function () {
 	return await import('@sentry/node');
-}
+};
 
 export async function handleError(error: Error) {
 	// Set appropriate exitCode
@@ -172,12 +169,12 @@ export async function handleError(error: Error) {
 
 	// Output/report error
 	if (isExpectedError) {
-		ErrorsModule.printExpectedErrorMessage(message.join('\n'));
+		printExpectedErrorMessage(message.join('\n'));
 	} else {
-		ErrorsModule.printErrorMessage(message.join('\n'));
+		printErrorMessage(message.join('\n'));
 
 		// Report "unexpected" errors via Sentry.io
-		const Sentry = await ErrorsModule.getSentry();
+		const Sentry = await getSentry();
 		Sentry.captureException(error);
 		try {
 			await Sentry.close(1000);
@@ -192,7 +189,7 @@ export async function handleError(error: Error) {
 	}
 }
 
-export function printErrorMessage(message: string) {
+export const printErrorMessage = function (message: string) {
 	const chalk = getChalk();
 
 	// Only first line should be red
@@ -204,11 +201,11 @@ export function printErrorMessage(message: string) {
 	});
 
 	console.error(`\n${getHelp}\n`);
-}
+};
 
-export function printExpectedErrorMessage(message: string) {
+export const printExpectedErrorMessage = function (message: string) {
 	console.error(`${message}\n`);
-}
+};
 
 /**
  * Print a friendly error message and exit the CLI with an error code, BYPASSING
@@ -229,14 +226,3 @@ export function exitWithExpectedError(message: string | Error): never {
 	printErrorMessage(message);
 	process.exit(1);
 }
-
-// Support stubbing of module functions.
-export default ErrorsModule = {
-	ExpectedError,
-	NotLoggedInError,
-	getSentry,
-	handleError,
-	printErrorMessage,
-	printExpectedErrorMessage,
-	exitWithExpectedError,
-};

--- a/tests/errors.spec.ts
+++ b/tests/errors.spec.ts
@@ -23,7 +23,7 @@ import {
 } from 'balena-errors';
 import { expect } from 'chai';
 import * as sinon from 'sinon';
-import ErrorsModule from '../build/errors';
+import * as ErrorsModule from '../build/errors';
 import { getHelp } from '../build/utils/messages';
 
 function red(s: string) {


### PR DESCRIPTION
Change-type: patch

<!-- You can remove tags that do not apply. -->
Resolves: # <!-- Refer an issue of this repository that this PR fixes -->  
Change-type: major|minor|patch <!-- See https://semver.org/ -->  
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->  
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->  

---
Please check the CONTRIBUTING.md file for relevant information and some
guidance. Keep in mind that the CLI is a cross-platform application that runs
on Windows, macOS and Linux. Tests will be automatically run by balena CI on
all three operating systems, but this will only help if you have added test
code that exercises the modified or added feature code.

Note that each commit message (currently only the first line) will be
automatically copied to the CHANGELOG.md file, so try writing it in a way
that describes the feature or fix for CLI users.

If there isn't a linked issue or if the linked issue doesn't quite match the
PR, please add a PR description to explain its purpose or the features that it
implements. Adding PR comments to blocks of code that aren't self explanatory
usually helps with the review process.

If the PR introduces security considerations or affects the development, build
or release process, please be sure to highlight this in the PR description.

Thank you very much for your contribution!
