### PR TITLE
Use cacheScope for fast-boot2 to allow caching when globally installed

### DIFF
--- a/bin/balena
+++ b/bin/balena
@@ -9,6 +9,7 @@ process.env.OCLIF_TS_NODE = 0;
 
 // Use fast-boot to cache require lookups, speeding up startup
 require('fast-boot2').start({
+	cacheScope: __dirname + '/..',
 	cacheFile: __dirname + '/.fast-boot.json'
 })
 // Run the CLI

--- a/bin/balena-dev
+++ b/bin/balena-dev
@@ -11,6 +11,7 @@ process.env.UV_THREADPOOL_SIZE = '64';
 
 // Use fast-boot to cache require lookups, speeding up startup
 require('fast-boot2').start({
+	cacheScope: __dirname + '/..',
 	cacheFile: '.fast-boot.json',
 });
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -6305,9 +6305,9 @@
       }
     },
     "fast-boot2": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/fast-boot2/-/fast-boot2-1.0.9.tgz",
-      "integrity": "sha512-yE94XdtU0xlM0M8+0tZfdps6U40UVCKB1Ioi1dq3Yf+0zAyzHQ9gYm73eKeRfTRz/Al+T39G8ZQk81v9kt+E4g=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-boot2/-/fast-boot2-1.1.0.tgz",
+      "integrity": "sha512-gSQx19TsNlsqlNHXI2mkjw/sf1ZRMHfpORIXvgMkQpTT41JuKaNwe9elEuOuv+ZUU3b1xf4uSAN3LTGbW4CQew=="
     },
     "fast-deep-equal": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -214,7 +214,7 @@
     "etcher-sdk": "^2.0.20",
     "event-stream": "3.3.4",
     "express": "^4.13.3",
-    "fast-boot2": "^1.0.9",
+    "fast-boot2": "^1.1.0",
     "get-stdin": "^7.0.0",
     "global-agent": "^2.1.12",
     "global-tunnel-ng": "^2.1.1",


### PR DESCRIPTION
Saves ~250ms on subsequent calls to `balena help` when using the global npm install version, not sure about savings for other packaging methods