### PR TITLE
Import just strip-tags from common-tags to reduce startup time

### DIFF
--- a/automation/build-bin.ts
+++ b/automation/build-bin.ts
@@ -21,7 +21,6 @@ import { run as oclifRun } from '@oclif/dev-cli';
 import * as archiver from 'archiver';
 import * as Bluebird from 'bluebird';
 import { execFile } from 'child_process';
-import { stripIndent } from 'common-tags';
 import * as filehound from 'filehound';
 import * as fs from 'fs-extra';
 import * as _ from 'lodash';
@@ -31,6 +30,7 @@ import * as rimraf from 'rimraf';
 import * as semver from 'semver';
 import * as util from 'util';
 
+import { stripIndent } from '../lib/utils/lazy';
 import {
 	getSubprocessStdout,
 	loadPackageJson,

--- a/automation/check-doc.js
+++ b/automation/check-doc.js
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-const { stripIndent } = require('common-tags');
+const stripIndent = require('common-tags/lib/stripIndent');
 const _ = require('lodash');
 const { promises: fs } = require('fs');
 const path = require('path');

--- a/lib/actions-oclif/api-key/generate.ts
+++ b/lib/actions-oclif/api-key/generate.ts
@@ -16,11 +16,10 @@
  */
 
 import { flags } from '@oclif/command';
-import { stripIndent } from 'common-tags';
 import Command from '../../command';
 import { ExpectedError } from '../../errors';
 import * as cf from '../../utils/common-flags';
-import { getBalenaSdk } from '../../utils/lazy';
+import { getBalenaSdk, stripIndent } from '../../utils/lazy';
 
 interface FlagsDef {
 	help: void;

--- a/lib/actions-oclif/app/create.ts
+++ b/lib/actions-oclif/app/create.ts
@@ -16,11 +16,10 @@
  */
 
 import { flags } from '@oclif/command';
-import { stripIndent } from 'common-tags';
 import Command from '../../command';
 import { ExpectedError } from '../../errors';
 import * as cf from '../../utils/common-flags';
-import { getBalenaSdk } from '../../utils/lazy';
+import { getBalenaSdk, stripIndent } from '../../utils/lazy';
 
 interface FlagsDef {
 	type?: string; // application device type

--- a/lib/actions-oclif/app/index.ts
+++ b/lib/actions-oclif/app/index.ts
@@ -16,10 +16,9 @@
  */
 
 import { flags } from '@oclif/command';
-import { stripIndent } from 'common-tags';
 import Command from '../../command';
 import * as cf from '../../utils/common-flags';
-import { getBalenaSdk, getVisuals } from '../../utils/lazy';
+import { getBalenaSdk, getVisuals, stripIndent } from '../../utils/lazy';
 import { tryAsInteger } from '../../utils/validation';
 
 interface FlagsDef {

--- a/lib/actions-oclif/app/restart.ts
+++ b/lib/actions-oclif/app/restart.ts
@@ -16,10 +16,9 @@
  */
 
 import { flags } from '@oclif/command';
-import { stripIndent } from 'common-tags';
 import Command from '../../command';
 import * as cf from '../../utils/common-flags';
-import { getBalenaSdk } from '../../utils/lazy';
+import { getBalenaSdk, stripIndent } from '../../utils/lazy';
 import { tryAsInteger } from '../../utils/validation';
 
 interface FlagsDef {

--- a/lib/actions-oclif/app/rm.ts
+++ b/lib/actions-oclif/app/rm.ts
@@ -16,10 +16,9 @@
  */
 
 import { flags } from '@oclif/command';
-import { stripIndent } from 'common-tags';
 import Command from '../../command';
 import * as cf from '../../utils/common-flags';
-import { getBalenaSdk } from '../../utils/lazy';
+import { getBalenaSdk, stripIndent } from '../../utils/lazy';
 import { tryAsInteger } from '../../utils/validation';
 
 interface FlagsDef {

--- a/lib/actions-oclif/apps.ts
+++ b/lib/actions-oclif/apps.ts
@@ -17,10 +17,9 @@
 
 import { flags } from '@oclif/command';
 import type { Application } from 'balena-sdk';
-import { stripIndent } from 'common-tags';
 import Command from '../command';
 import * as cf from '../utils/common-flags';
-import { getBalenaSdk, getVisuals } from '../utils/lazy';
+import { getBalenaSdk, getVisuals, stripIndent } from '../utils/lazy';
 import { isV12 } from '../utils/version';
 
 interface ExtendedApplication extends Application {

--- a/lib/actions-oclif/device/identify.ts
+++ b/lib/actions-oclif/device/identify.ts
@@ -17,10 +17,9 @@
 
 import { flags } from '@oclif/command';
 import type { IArg } from '@oclif/parser/lib/args';
-import { stripIndent } from 'common-tags';
 import Command from '../../command';
 import * as cf from '../../utils/common-flags';
-import { getBalenaSdk } from '../../utils/lazy';
+import { getBalenaSdk, stripIndent } from '../../utils/lazy';
 import { tryAsInteger } from '../../utils/validation';
 import { ExpectedError } from '../../errors';
 

--- a/lib/actions-oclif/device/index.ts
+++ b/lib/actions-oclif/device/index.ts
@@ -17,11 +17,10 @@
 
 import { flags } from '@oclif/command';
 import { IArg } from '@oclif/parser/lib/args';
-import { stripIndent } from 'common-tags';
 import Command from '../../command';
 import * as cf from '../../utils/common-flags';
 import { expandForAppName } from '../../utils/helpers';
-import { getBalenaSdk, getVisuals } from '../../utils/lazy';
+import { getBalenaSdk, getVisuals, stripIndent } from '../../utils/lazy';
 import { tryAsInteger } from '../../utils/validation';
 import type { Application, Device } from 'balena-sdk';
 

--- a/lib/actions-oclif/device/move.ts
+++ b/lib/actions-oclif/device/move.ts
@@ -18,12 +18,11 @@
 import { flags } from '@oclif/command';
 import type { IArg } from '@oclif/parser/lib/args';
 import type { Application, Device } from 'balena-sdk';
-import { stripIndent } from 'common-tags';
 import * as _ from 'lodash';
 import Command from '../../command';
 import * as cf from '../../utils/common-flags';
 import { expandForAppName } from '../../utils/helpers';
-import { getBalenaSdk } from '../../utils/lazy';
+import { getBalenaSdk, stripIndent } from '../../utils/lazy';
 import { tryAsInteger } from '../../utils/validation';
 
 interface ExtendedDevice extends Device {

--- a/lib/actions-oclif/device/os-update.ts
+++ b/lib/actions-oclif/device/os-update.ts
@@ -17,10 +17,9 @@
 
 import { flags } from '@oclif/command';
 import type { IArg } from '@oclif/parser/lib/args';
-import { stripIndent } from 'common-tags';
 import Command from '../../command';
 import * as cf from '../../utils/common-flags';
-import { getBalenaSdk } from '../../utils/lazy';
+import { getBalenaSdk, stripIndent } from '../../utils/lazy';
 import { tryAsInteger } from '../../utils/validation';
 import type { Device } from 'balena-sdk';
 import { ExpectedError } from '../../errors';

--- a/lib/actions-oclif/device/public-url.ts
+++ b/lib/actions-oclif/device/public-url.ts
@@ -17,11 +17,10 @@
 
 import { flags } from '@oclif/command';
 import type { IArg } from '@oclif/parser/lib/args';
-import { stripIndent } from 'common-tags';
 import Command from '../../command';
 import { ExpectedError } from '../../errors';
 import * as cf from '../../utils/common-flags';
-import { getBalenaSdk } from '../../utils/lazy';
+import { getBalenaSdk, stripIndent } from '../../utils/lazy';
 import { tryAsInteger } from '../../utils/validation';
 
 interface FlagsDef {

--- a/lib/actions-oclif/device/reboot.ts
+++ b/lib/actions-oclif/device/reboot.ts
@@ -17,10 +17,9 @@
 
 import { flags } from '@oclif/command';
 import type { IArg } from '@oclif/parser/lib/args';
-import { stripIndent } from 'common-tags';
 import Command from '../../command';
 import * as cf from '../../utils/common-flags';
-import { getBalenaSdk } from '../../utils/lazy';
+import { getBalenaSdk, stripIndent } from '../../utils/lazy';
 import { tryAsInteger } from '../../utils/validation';
 
 interface FlagsDef {

--- a/lib/actions-oclif/device/register.ts
+++ b/lib/actions-oclif/device/register.ts
@@ -17,10 +17,9 @@
 
 import { flags } from '@oclif/command';
 import type { IArg } from '@oclif/parser/lib/args';
-import { stripIndent } from 'common-tags';
 import Command from '../../command';
 import * as cf from '../../utils/common-flags';
-import { getBalenaSdk } from '../../utils/lazy';
+import { getBalenaSdk, stripIndent } from '../../utils/lazy';
 import { tryAsInteger } from '../../utils/validation';
 
 interface FlagsDef {

--- a/lib/actions-oclif/device/rename.ts
+++ b/lib/actions-oclif/device/rename.ts
@@ -17,10 +17,9 @@
 
 import { flags } from '@oclif/command';
 import type { IArg } from '@oclif/parser/lib/args';
-import { stripIndent } from 'common-tags';
 import Command from '../../command';
 import * as cf from '../../utils/common-flags';
-import { getBalenaSdk } from '../../utils/lazy';
+import { getBalenaSdk, stripIndent } from '../../utils/lazy';
 import { tryAsInteger } from '../../utils/validation';
 
 interface FlagsDef {

--- a/lib/actions-oclif/device/rm.ts
+++ b/lib/actions-oclif/device/rm.ts
@@ -17,10 +17,9 @@
 
 import { flags } from '@oclif/command';
 import type { IArg } from '@oclif/parser/lib/args';
-import { stripIndent } from 'common-tags';
 import Command from '../../command';
 import * as cf from '../../utils/common-flags';
-import { getBalenaSdk } from '../../utils/lazy';
+import { getBalenaSdk, stripIndent } from '../../utils/lazy';
 import { tryAsInteger } from '../../utils/validation';
 
 interface FlagsDef {

--- a/lib/actions-oclif/device/shutdown.ts
+++ b/lib/actions-oclif/device/shutdown.ts
@@ -17,10 +17,9 @@
 
 import { flags } from '@oclif/command';
 import type { IArg } from '@oclif/parser/lib/args';
-import { stripIndent } from 'common-tags';
 import Command from '../../command';
 import * as cf from '../../utils/common-flags';
-import { getBalenaSdk } from '../../utils/lazy';
+import { getBalenaSdk, stripIndent } from '../../utils/lazy';
 import { tryAsInteger } from '../../utils/validation';
 import { ExpectedError } from '../../errors';
 

--- a/lib/actions-oclif/devices/index.ts
+++ b/lib/actions-oclif/devices/index.ts
@@ -16,12 +16,11 @@
  */
 
 import { flags } from '@oclif/command';
-import { stripIndent } from 'common-tags';
 import * as _ from 'lodash';
 import Command from '../../command';
 import * as cf from '../../utils/common-flags';
 import { expandForAppName } from '../../utils/helpers';
-import { getBalenaSdk, getVisuals } from '../../utils/lazy';
+import { getBalenaSdk, getVisuals, stripIndent } from '../../utils/lazy';
 import { tryAsInteger } from '../../utils/validation';
 import type { Device, Application } from 'balena-sdk';
 

--- a/lib/actions-oclif/devices/supported.ts
+++ b/lib/actions-oclif/devices/supported.ts
@@ -16,12 +16,11 @@
  */
 import { flags } from '@oclif/command';
 import type * as SDK from 'balena-sdk';
-import { stripIndent } from 'common-tags';
 import * as _ from 'lodash';
 import Command from '../../command';
 
 import * as cf from '../../utils/common-flags';
-import { getBalenaSdk, getVisuals } from '../../utils/lazy';
+import { getBalenaSdk, getVisuals, stripIndent } from '../../utils/lazy';
 import { CommandHelp } from '../../utils/oclif-utils';
 import { isV12 } from '../../utils/version';
 

--- a/lib/actions-oclif/env/add.ts
+++ b/lib/actions-oclif/env/add.ts
@@ -17,13 +17,12 @@
 
 import { flags } from '@oclif/command';
 import type * as BalenaSdk from 'balena-sdk';
-import { stripIndent } from 'common-tags';
 import * as _ from 'lodash';
 import Command from '../../command';
 
 import { ExpectedError } from '../../errors';
 import * as cf from '../../utils/common-flags';
-import { getBalenaSdk } from '../../utils/lazy';
+import { getBalenaSdk, stripIndent } from '../../utils/lazy';
 import { CommandHelp } from '../../utils/oclif-utils';
 
 interface FlagsDef {

--- a/lib/actions-oclif/env/rename.ts
+++ b/lib/actions-oclif/env/rename.ts
@@ -15,12 +15,11 @@
  * limitations under the License.
  */
 import { flags } from '@oclif/command';
-import { stripIndent } from 'common-tags';
 import Command from '../../command';
 
 import * as cf from '../../utils/common-flags';
 import * as ec from '../../utils/env-common';
-import { getBalenaSdk } from '../../utils/lazy';
+import { getBalenaSdk, stripIndent } from '../../utils/lazy';
 import { CommandHelp } from '../../utils/oclif-utils';
 import { parseAsInteger } from '../../utils/validation';
 

--- a/lib/actions-oclif/env/rm.ts
+++ b/lib/actions-oclif/env/rm.ts
@@ -16,11 +16,10 @@
  */
 
 import { flags } from '@oclif/command';
-import { stripIndent } from 'common-tags';
 import Command from '../../command';
 
 import * as ec from '../../utils/env-common';
-import { getBalenaSdk } from '../../utils/lazy';
+import { getBalenaSdk, stripIndent } from '../../utils/lazy';
 import { CommandHelp } from '../../utils/oclif-utils';
 import { parseAsInteger } from '../../utils/validation';
 

--- a/lib/actions-oclif/envs.ts
+++ b/lib/actions-oclif/envs.ts
@@ -16,13 +16,12 @@
  */
 import { flags } from '@oclif/command';
 import type * as SDK from 'balena-sdk';
-import { stripIndent } from 'common-tags';
 import * as _ from 'lodash';
 import Command from '../command';
 
 import { ExpectedError } from '../errors';
 import * as cf from '../utils/common-flags';
-import { getBalenaSdk, getVisuals } from '../utils/lazy';
+import { getBalenaSdk, getVisuals, stripIndent } from '../utils/lazy';
 import { CommandHelp } from '../utils/oclif-utils';
 import { isV12 } from '../utils/version';
 

--- a/lib/actions-oclif/internal/osinit.ts
+++ b/lib/actions-oclif/internal/osinit.ts
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-import { stripIndent } from 'common-tags';
 import Command from '../../command';
+import { stripIndent } from '../../utils/lazy';
 import { CommandHelp } from '../../utils/oclif-utils';
 
 // 'Internal' commands are called during the execution of other commands.

--- a/lib/actions-oclif/internal/scandevices.ts
+++ b/lib/actions-oclif/internal/scandevices.ts
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-import { stripIndent } from 'common-tags';
 import Command from '../../command';
+import { stripIndent } from '../../utils/lazy';
 
 // 'Internal' commands are called during the execution of other commands.
 // `scandevices` is called during by `join`,`leave'.

--- a/lib/actions-oclif/join.ts
+++ b/lib/actions-oclif/join.ts
@@ -16,10 +16,9 @@
  */
 
 import { flags } from '@oclif/command';
-import { stripIndent } from 'common-tags';
 import Command from '../command';
 import * as cf from '../utils/common-flags';
-import { getBalenaSdk } from '../utils/lazy';
+import { getBalenaSdk, stripIndent } from '../utils/lazy';
 
 interface FlagsDef {
 	application?: string;

--- a/lib/actions-oclif/key/add.ts
+++ b/lib/actions-oclif/key/add.ts
@@ -16,11 +16,10 @@
  */
 
 import { flags } from '@oclif/command';
-import { stripIndent } from 'common-tags';
 import Command from '../../command';
 import { ExpectedError } from '../../errors';
 import * as cf from '../../utils/common-flags';
-import { getBalenaSdk } from '../../utils/lazy';
+import { getBalenaSdk, stripIndent } from '../../utils/lazy';
 
 interface FlagsDef {
 	help: void;

--- a/lib/actions-oclif/key/index.ts
+++ b/lib/actions-oclif/key/index.ts
@@ -16,10 +16,9 @@
  */
 
 import { flags } from '@oclif/command';
-import { stripIndent } from 'common-tags';
 import Command from '../../command';
 import * as cf from '../../utils/common-flags';
-import { getBalenaSdk, getVisuals } from '../../utils/lazy';
+import { getBalenaSdk, getVisuals, stripIndent } from '../../utils/lazy';
 import { parseAsInteger } from '../../utils/validation';
 
 type IArg<T> = import('@oclif/parser').args.IArg<T>;

--- a/lib/actions-oclif/key/rm.ts
+++ b/lib/actions-oclif/key/rm.ts
@@ -16,10 +16,9 @@
  */
 
 import { flags } from '@oclif/command';
-import { stripIndent } from 'common-tags';
 import Command from '../../command';
 import * as cf from '../../utils/common-flags';
-import { getBalenaSdk } from '../../utils/lazy';
+import { getBalenaSdk, stripIndent } from '../../utils/lazy';
 import { parseAsInteger } from '../../utils/validation';
 
 type IArg<T> = import('@oclif/parser').args.IArg<T>;

--- a/lib/actions-oclif/keys.ts
+++ b/lib/actions-oclif/keys.ts
@@ -16,10 +16,9 @@
  */
 
 import { flags } from '@oclif/command';
-import { stripIndent } from 'common-tags';
 import Command from '../command';
 import * as cf from '../utils/common-flags';
-import { getBalenaSdk, getVisuals } from '../utils/lazy';
+import { getBalenaSdk, getVisuals, stripIndent } from '../utils/lazy';
 
 interface FlagsDef {
 	help: void;

--- a/lib/actions-oclif/leave.ts
+++ b/lib/actions-oclif/leave.ts
@@ -16,10 +16,9 @@
  */
 
 import { flags } from '@oclif/command';
-import { stripIndent } from 'common-tags';
 import Command from '../command';
 import * as cf from '../utils/common-flags';
-import { getBalenaSdk } from '../utils/lazy';
+import { getBalenaSdk, stripIndent } from '../utils/lazy';
 
 interface FlagsDef {
 	help?: void;

--- a/lib/actions-oclif/login.ts
+++ b/lib/actions-oclif/login.ts
@@ -16,10 +16,9 @@
  */
 
 import { flags } from '@oclif/command';
-import { stripIndent } from 'common-tags';
 import Command from '../command';
 import * as cf from '../utils/common-flags';
-import { getBalenaSdk } from '../utils/lazy';
+import { getBalenaSdk, stripIndent } from '../utils/lazy';
 import { ExpectedError } from '../errors';
 
 interface FlagsDef {

--- a/lib/actions-oclif/logout.ts
+++ b/lib/actions-oclif/logout.ts
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-import { stripIndent } from 'common-tags';
 import Command from '../command';
-import { getBalenaSdk } from '../utils/lazy';
+import { getBalenaSdk, stripIndent } from '../utils/lazy';
 
 export default class LogoutCmd extends Command {
 	public static description = stripIndent`

--- a/lib/actions-oclif/note.ts
+++ b/lib/actions-oclif/note.ts
@@ -16,12 +16,11 @@
  */
 
 import { flags } from '@oclif/command';
-import { stripIndent } from 'common-tags';
 import * as _ from 'lodash';
 import Command from '../command';
 import { ExpectedError } from '../errors';
 import * as cf from '../utils/common-flags';
-import { getBalenaSdk } from '../utils/lazy';
+import { getBalenaSdk, stripIndent } from '../utils/lazy';
 
 interface FlagsDef {
 	device?: string; // device UUID

--- a/lib/actions-oclif/os/configure.ts
+++ b/lib/actions-oclif/os/configure.ts
@@ -18,14 +18,13 @@
 import { flags } from '@oclif/command';
 import type * as BalenaSdk from 'balena-sdk';
 import Bluebird = require('bluebird');
-import { stripIndent } from 'common-tags';
 import * as _ from 'lodash';
 import * as path from 'path';
 import Command from '../../command';
 
 import { ExpectedError } from '../../errors';
 import * as cf from '../../utils/common-flags';
-import { getBalenaSdk } from '../../utils/lazy';
+import { getBalenaSdk, stripIndent } from '../../utils/lazy';
 import { CommandHelp } from '../../utils/oclif-utils';
 
 const BOOT_PARTITION = 1;

--- a/lib/actions-oclif/scan.ts
+++ b/lib/actions-oclif/scan.ts
@@ -17,10 +17,9 @@
 
 import { flags } from '@oclif/command';
 import type { LocalBalenaOsDevice } from 'balena-sync';
-import { stripIndent } from 'common-tags';
 import Command from '../command';
 import * as cf from '../utils/common-flags';
-import { getVisuals } from '../utils/lazy';
+import { getVisuals, stripIndent } from '../utils/lazy';
 
 interface FlagsDef {
 	verbose: boolean;

--- a/lib/actions-oclif/settings.ts
+++ b/lib/actions-oclif/settings.ts
@@ -16,10 +16,9 @@
  */
 
 import { flags } from '@oclif/command';
-import { stripIndent } from 'common-tags';
 import Command from '../command';
 import * as cf from '../utils/common-flags';
-import { getBalenaSdk } from '../utils/lazy';
+import { getBalenaSdk, stripIndent } from '../utils/lazy';
 
 interface FlagsDef {
 	help: void;

--- a/lib/actions-oclif/tag/rm.ts
+++ b/lib/actions-oclif/tag/rm.ts
@@ -16,11 +16,10 @@
  */
 
 import { flags } from '@oclif/command';
-import { stripIndent } from 'common-tags';
 import Command from '../../command';
 import { ExpectedError } from '../../errors';
 import * as cf from '../../utils/common-flags';
-import { getBalenaSdk } from '../../utils/lazy';
+import { getBalenaSdk, stripIndent } from '../../utils/lazy';
 import { disambiguateReleaseParam } from '../../utils/normalization';
 import { tryAsInteger } from '../../utils/validation';
 

--- a/lib/actions-oclif/tag/set.ts
+++ b/lib/actions-oclif/tag/set.ts
@@ -16,11 +16,10 @@
  */
 
 import { flags } from '@oclif/command';
-import { stripIndent } from 'common-tags';
 import Command from '../../command';
 import { ExpectedError } from '../../errors';
 import * as cf from '../../utils/common-flags';
-import { getBalenaSdk } from '../../utils/lazy';
+import { getBalenaSdk, stripIndent } from '../../utils/lazy';
 import { disambiguateReleaseParam } from '../../utils/normalization';
 import { tryAsInteger } from '../../utils/validation';
 

--- a/lib/actions-oclif/tags.ts
+++ b/lib/actions-oclif/tags.ts
@@ -16,11 +16,10 @@
  */
 
 import { flags } from '@oclif/command';
-import { stripIndent } from 'common-tags';
 import Command from '../command';
 import { ExpectedError } from '../errors';
 import * as cf from '../utils/common-flags';
-import { getBalenaSdk, getVisuals } from '../utils/lazy';
+import { getBalenaSdk, getVisuals, stripIndent } from '../utils/lazy';
 import { disambiguateReleaseParam } from '../utils/normalization';
 import { tryAsInteger } from '../utils/validation';
 import { isV12 } from '../utils/version';

--- a/lib/actions-oclif/version.ts
+++ b/lib/actions-oclif/version.ts
@@ -16,8 +16,8 @@
  */
 
 import { flags } from '@oclif/command';
-import { stripIndent } from 'common-tags';
 import Command from '../command';
+import { stripIndent } from '../utils/lazy';
 
 interface FlagsDef {
 	all?: boolean;

--- a/lib/actions-oclif/whoami.ts
+++ b/lib/actions-oclif/whoami.ts
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-import { stripIndent } from 'common-tags';
 import Command from '../command';
-import { getBalenaSdk, getVisuals } from '../utils/lazy';
+import { getBalenaSdk, getVisuals, stripIndent } from '../utils/lazy';
 
 export default class WhoamiCmd extends Command {
 	public static description = stripIndent`

--- a/lib/actions/local/flash.ts
+++ b/lib/actions/local/flash.ts
@@ -15,9 +15,8 @@ limitations under the License.
 */
 
 import type { CommandDefinition } from 'capitano';
-import { stripIndent } from 'common-tags';
 import type * as SDK from 'etcher-sdk';
-import { getChalk, getVisuals } from '../../utils/lazy';
+import { getChalk, getVisuals, stripIndent } from '../../utils/lazy';
 
 async function getDrive(options: {
 	drive?: string;

--- a/lib/actions/logs.ts
+++ b/lib/actions/logs.ts
@@ -16,9 +16,8 @@ limitations under the License.
 
 import type { LogMessage } from 'balena-sdk';
 import type { CommandDefinition } from 'capitano';
-import { stripIndent } from 'common-tags';
 
-import { getBalenaSdk } from '../utils/lazy';
+import { getBalenaSdk, stripIndent } from '../utils/lazy';
 import { normalizeUuidProp } from '../utils/normalization';
 import { validateDotLocalUrl } from '../utils/validation';
 

--- a/lib/actions/push.ts
+++ b/lib/actions/push.ts
@@ -16,10 +16,9 @@ limitations under the License.
 
 import type { BalenaSDK } from 'balena-sdk';
 import type { CommandDefinition } from 'capitano';
-import { stripIndent } from 'common-tags';
 
 import { ExpectedError } from '../errors';
-import { getBalenaSdk } from '../utils/lazy';
+import { getBalenaSdk, stripIndent } from '../utils/lazy';
 import { dockerignoreHelp, registrySecretsHelp } from '../utils/messages';
 import {
 	validateApplicationName,

--- a/lib/actions/ssh.ts
+++ b/lib/actions/ssh.ts
@@ -15,9 +15,8 @@ limitations under the License.
 */
 import type * as BalenaSdk from 'balena-sdk';
 import type { CommandDefinition } from 'capitano';
-import { stripIndent } from 'common-tags';
 
-import { getBalenaSdk } from '../utils/lazy';
+import { getBalenaSdk, stripIndent } from '../utils/lazy';
 import { validateDotLocalUrl, validateIPAddress } from '../utils/validation';
 
 async function getContainerId(

--- a/lib/actions/tunnel.ts
+++ b/lib/actions/tunnel.ts
@@ -15,11 +15,10 @@ limitations under the License.
 */
 import * as Bluebird from 'bluebird';
 import type { CommandDefinition } from 'capitano';
-import { stripIndent } from 'common-tags';
 import * as _ from 'lodash';
 import { createServer, Server, Socket } from 'net';
 
-import { getBalenaSdk } from '../utils/lazy';
+import { getBalenaSdk, stripIndent } from '../utils/lazy';
 import { getOnlineTargetUuid } from '../utils/patterns';
 import { tunnelConnectionToDevice } from '../utils/tunnel';
 

--- a/lib/actions/util.ts
+++ b/lib/actions/util.ts
@@ -20,8 +20,7 @@ limitations under the License.
 */
 
 import type { CommandDefinition } from 'capitano';
-import { stripIndent } from 'common-tags';
-import { getChalk, getVisuals } from '../utils/lazy';
+import { getChalk, getVisuals, stripIndent } from '../utils/lazy';
 
 export const availableDrives: CommandDefinition<{}, {}> = {
 	signature: 'util available-drives',

--- a/lib/app-common.ts
+++ b/lib/app-common.ts
@@ -16,7 +16,7 @@
  */
 
 import * as packageJSON from '../package.json';
-import { onceAsync } from './utils/lazy';
+import { onceAsync, stripIndent } from './utils/lazy';
 
 class CliSettings {
 	public readonly settings: any;
@@ -64,10 +64,9 @@ export const setupSentry = onceAsync(async () => {
 	return Sentry.getCurrentHub();
 });
 
-function checkNodeVersion() {
+async function checkNodeVersion() {
 	const validNodeVersions = packageJSON.engines.node;
-	if (!require('semver').satisfies(process.version, validNodeVersions)) {
-		const { stripIndent } = require('common-tags');
+	if (!(await import('semver')).satisfies(process.version, validNodeVersions)) {
 		console.warn(stripIndent`
 			------------------------------------------------------------------------------
 			Warning: Node version "${process.version}" does not match required versions "${validNodeVersions}".

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -14,12 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { BalenaError } from 'balena-errors';
-import { stripIndent } from 'common-tags';
+import type { BalenaError } from 'balena-errors';
 import * as _ from 'lodash';
 import * as os from 'os';
 import { TypedError } from 'typed-error';
-import { getChalk } from './utils/lazy';
+import { getChalk, stripIndent } from './utils/lazy';
 import { getHelp } from './utils/messages';
 
 export class ExpectedError extends TypedError {}

--- a/lib/preparser.ts
+++ b/lib/preparser.ts
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { stripIndent } from 'common-tags';
+import { stripIndent } from './utils/lazy';
 
 import { exitWithExpectedError } from './errors';
 

--- a/lib/utils/cloud.ts
+++ b/lib/utils/cloud.ts
@@ -16,8 +16,8 @@
  */
 
 import type * as SDK from 'balena-sdk';
-import { stripIndent } from 'common-tags';
 import * as _ from 'lodash';
+import { stripIndent } from './lazy';
 
 import { ExpectedError } from '../errors';
 

--- a/lib/utils/compose.js
+++ b/lib/utils/compose.js
@@ -16,10 +16,9 @@
  */
 
 import * as Bluebird from 'bluebird';
-import { stripIndent } from 'common-tags';
 import * as path from 'path';
 
-import { getChalk } from './lazy';
+import { getChalk, stripIndent } from './lazy';
 
 export const appendProjectOptions = (opts) =>
 	opts.concat([

--- a/lib/utils/compose_ts.ts
+++ b/lib/utils/compose_ts.ts
@@ -16,7 +16,6 @@
  */
 import { BalenaSDK } from 'balena-sdk';
 import * as Bluebird from 'bluebird';
-import { stripIndent } from 'common-tags';
 import type * as Dockerode from 'dockerode';
 import * as _ from 'lodash';
 import { promises as fs } from 'fs';
@@ -25,6 +24,7 @@ import { Composition } from 'resin-compose-parse';
 import * as MultiBuild from 'resin-multibuild';
 import { Readable } from 'stream';
 import * as tar from 'tar-stream';
+import { stripIndent } from './lazy';
 
 import { ExpectedError } from '../errors';
 import { getBalenaSdk, getChalk } from '../utils/lazy';

--- a/lib/utils/device/ssh.ts
+++ b/lib/utils/device/ssh.ts
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 import type { ContainerInfo } from 'dockerode';
+import { stripIndent } from '../lazy';
 
 export interface DeviceSSHOpts {
 	address: string;
@@ -31,7 +32,6 @@ export async function performLocalDeviceSSH(
 	const reduce = await import('lodash/reduce');
 	const { spawnSshAndExitOnError } = await import('../ssh');
 	const { ExpectedError } = await import('../../errors');
-	const { stripIndent } = await import('common-tags');
 
 	let command = '';
 

--- a/lib/utils/env-common.ts
+++ b/lib/utils/env-common.ts
@@ -16,7 +16,7 @@
  */
 
 import { flags } from '@oclif/command';
-import { stripIndent } from 'common-tags';
+import { stripIndent } from './lazy';
 
 import { ExpectedError } from '../errors';
 

--- a/lib/utils/lazy.ts
+++ b/lib/utils/lazy.ts
@@ -19,6 +19,7 @@ limitations under the License.
 import type * as BalenaSdk from 'balena-sdk';
 import type { Chalk } from 'chalk';
 import type * as visuals from 'resin-cli-visuals';
+import type { stripIndent as StripIndent } from 'common-tags';
 
 // Equivalent of _.once but avoiding the need to import lodash for lazy deps
 const once = <T>(fn: () => T) => {
@@ -50,3 +51,7 @@ export const getVisuals = once(
 );
 
 export const getChalk = once(() => require('chalk') as Chalk);
+
+// Directly export stripIndent as we always use it immediately, but importing just `stripIndent` reduces startup time
+// tslint:disable-next-line:no-var-requires
+export const stripIndent = require('common-tags/lib/stripIndent') as typeof StripIndent;

--- a/lib/utils/patterns.ts
+++ b/lib/utils/patterns.ts
@@ -16,12 +16,11 @@ limitations under the License.
 import { BalenaApplicationNotFound } from 'balena-errors';
 import type * as BalenaSdk from 'balena-sdk';
 import Bluebird = require('bluebird');
-import { stripIndent } from 'common-tags';
 import _ = require('lodash');
 import _form = require('resin-cli-form');
 
 import { exitWithExpectedError, instanceOf, NotLoggedInError } from '../errors';
-import { getBalenaSdk, getVisuals } from './lazy';
+import { getBalenaSdk, getVisuals, stripIndent } from './lazy';
 import validation = require('./validation');
 import { isV12 } from './version';
 

--- a/lib/utils/promote.ts
+++ b/lib/utils/promote.ts
@@ -15,10 +15,9 @@
  * limitations under the License.
  */
 import type * as BalenaSdk from 'balena-sdk';
-import { stripIndent } from 'common-tags';
 
 import { ExpectedError, printErrorMessage } from '../errors';
-import { getVisuals } from './lazy';
+import { getVisuals, stripIndent } from './lazy';
 import Logger = require('./logger');
 import { exec, execBuffered, getDeviceOsRelease } from './ssh';
 

--- a/lib/utils/qemu.ts
+++ b/lib/utils/qemu.ts
@@ -16,9 +16,8 @@
  */
 
 import * as Bluebird from 'bluebird';
-import { stripIndent } from 'common-tags';
 import type * as Dockerode from 'dockerode';
-import { getBalenaSdk } from './lazy';
+import { getBalenaSdk, stripIndent } from './lazy';
 import Logger = require('./logger');
 
 export const QEMU_VERSION = 'v4.0.0+balena2';

--- a/lib/utils/remote-build.ts
+++ b/lib/utils/remote-build.ts
@@ -26,7 +26,7 @@ import type { Pack } from 'tar-stream';
 import { ExpectedError } from '../errors';
 import { exitWithExpectedError } from '../errors';
 import { tarDirectory } from './compose';
-import { getVisuals } from './lazy';
+import { getVisuals, stripIndent } from './lazy';
 import Logger = require('./logger');
 
 const globalLogger = Logger.getLogger();
@@ -183,8 +183,6 @@ function handleHeadlessBuildMessage(message: HeadlessBuilderMessage) {
 }
 
 function handleBuilderMetadata(obj: BuilderMessage, build: RemoteBuild) {
-	const { stripIndent } = require('common-tags');
-
 	switch (obj.resource) {
 		case 'cursor':
 			if (obj.value == null) {

--- a/lib/utils/sudo.ts
+++ b/lib/utils/sudo.ts
@@ -16,7 +16,7 @@
  */
 
 import { ChildProcess, spawn, SpawnOptions } from 'child_process';
-import { stripIndent } from 'common-tags';
+import { stripIndent } from './lazy';
 
 /**
  * Execute a child process with admin / superuser privileges, prompting the user for

--- a/tests/commands/build.spec.ts
+++ b/tests/commands/build.spec.ts
@@ -19,11 +19,11 @@
 require('../config-tests'); // required for side effects
 
 import { expect } from 'chai';
-import { stripIndent } from 'common-tags';
 import mock = require('mock-require');
 import { promises as fs } from 'fs';
 import * as path from 'path';
 
+import { stripIndent } from '../../lib/utils/lazy';
 import { BalenaAPIMock } from '../balena-api-mock';
 import { expectStreamNoCRLF, testDockerBuildStream } from '../docker-build';
 import { DockerMock, dockerResponsePath } from '../docker-mock';

--- a/tests/commands/env/envs.spec.ts
+++ b/tests/commands/env/envs.spec.ts
@@ -16,7 +16,7 @@
  */
 
 import { expect } from 'chai';
-import { stripIndent } from 'common-tags';
+import { stripIndent } from '../../../lib/utils/lazy';
 
 import { isV12 } from '../../../lib/utils/version';
 import { BalenaAPIMock } from '../../balena-api-mock';

--- a/tests/docker-build.ts
+++ b/tests/docker-build.ts
@@ -16,7 +16,6 @@
  */
 
 import { expect } from 'chai';
-import { stripIndent } from 'common-tags';
 import * as _ from 'lodash';
 import { promises as fs } from 'fs';
 import * as path from 'path';
@@ -27,6 +26,7 @@ import * as tar from 'tar-stream';
 import { streamToBuffer } from 'tar-utils';
 import { URL } from 'url';
 
+import { stripIndent } from '../lib/utils/lazy';
 import { BuilderMock } from './builder-mock';
 import { DockerMock } from './docker-mock';
 import { cleanOutput, fillTemplateArray, runCommand } from './helpers';

--- a/tslint.json
+++ b/tslint.json
@@ -2,6 +2,6 @@
     "extends": "./node_modules/@balena/lint/config/tslint-prettier.json",
     "rules": {
         "ignoreDefinitionFiles": false,
-        "import-blacklist": [true, "resin-cli-visuals", "chalk"]
+        "import-blacklist": [true, "resin-cli-visuals", "chalk", "common-tags"]
     }
 }


### PR DESCRIPTION
This saves ~100ms for me on startup with no fast-boot cache and ~50ms
with a fast-boot cache

Change-type: patch

<!-- You can remove tags that do not apply. -->
Resolves: # <!-- Refer an issue of this repository that this PR fixes -->  
Change-type: major|minor|patch <!-- See https://semver.org/ -->  
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->  
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->  

---
Please check the CONTRIBUTING.md file for relevant information and some
guidance. Keep in mind that the CLI is a cross-platform application that runs
on Windows, macOS and Linux. Tests will be automatically run by balena CI on
all three operating systems, but this will only help if you have added test
code that exercises the modified or added feature code.

Note that each commit message (currently only the first line) will be
automatically copied to the CHANGELOG.md file, so try writing it in a way
that describes the feature or fix for CLI users.

If there isn't a linked issue or if the linked issue doesn't quite match the
PR, please add a PR description to explain its purpose or the features that it
implements. Adding PR comments to blocks of code that aren't self explanatory
usually helps with the review process.

If the PR introduces security considerations or affects the development, build
or release process, please be sure to highlight this in the PR description.

Thank you very much for your contribution!
