### PR TITLE
Add back the device mac_address field

### DIFF
--- a/lib/actions-oclif/device/index.ts
+++ b/lib/actions-oclif/device/index.ts
@@ -94,6 +94,7 @@ export default class DeviceCmd extends Command {
 				'status',
 				'is_online',
 				'ip_address',
+				'mac_address',
 				'application_name',
 				'last_seen',
 				'uuid',


### PR DESCRIPTION
Looks like this was accidentally removed during the
oclif refactor of `balena device`

Change-type: patch
See: https://github.com/balena-io/balena-cli/pull/1871
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>


---
Please check the CONTRIBUTING.md file for relevant information and some
guidance. Keep in mind that the CLI is a cross-platform application that runs
on Windows, macOS and Linux. Tests will be automatically run by balena CI on
all three operating systems, but this will only help if you have added test
code that exercises the modified or added feature code.

Note that each commit message (currently only the first line) will be
automatically copied to the CHANGELOG.md file, so try writing it in a way
that describes the feature or fix for CLI users.

If there isn't a linked issue or if the linked issue doesn't quite match the
PR, please add a PR description to explain its purpose or the features that it
implements. Adding PR comments to blocks of code that aren't self explanatory
usually helps with the review process.

If the PR introduces security considerations or affects the development, build
or release process, please be sure to highlight this in the PR description.

Thank you very much for your contribution!
