### PR TITLE
Use @balena/es-version to set the desired es version for modules

### DIFF
--- a/bin/balena
+++ b/bin/balena
@@ -11,6 +11,10 @@ process.env.OCLIF_TS_NODE = 0;
 require('fast-boot2').start({
 	cacheScope: __dirname + '/..',
 	cacheFile: __dirname + '/.fast-boot.json'
-})
+});
+
+// Set the desired es version for downstream modules that support it
+require('@balena/es-version').set('es2018');
+
 // Run the CLI
 require('../build/app').run();

--- a/bin/balena-dev
+++ b/bin/balena-dev
@@ -15,6 +15,9 @@ require('fast-boot2').start({
 	cacheFile: '.fast-boot.json',
 });
 
+// Set the desired es version for downstream modules that support it
+require('@balena/es-version').set('es2018');
+
 const path = require('path');
 const rootDir = path.join(__dirname, '..');
 // Note: before ts-node v6.0.0, 'transpile-only' (no type checking) was the

--- a/package.json
+++ b/package.json
@@ -175,6 +175,7 @@
   },
   "dependencies": {
     "@balena/dockerignore": "^1.0.2",
+    "@balena/es-version": "^1.0.0",
     "@oclif/command": "^1.5.19",
     "@resin.io/valid-email": "^0.1.0",
     "@sentry/node": "^5.13.2",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
 	"compilerOptions": {
 		"declaration": true,
 		"module": "commonjs",
-		"target": "es2017",
+		"target": "es2018",
 		"outDir": "build",
 		"strict": true,
 		"strictPropertyInitialization": false,


### PR DESCRIPTION
This allows us to use es2018 versions of downstream modules (or the closest version under) when they're available, which means we'll be using native object spread, native async/await, etc instead of transpiled versions