### PR TITLE
Enable long stack traces for `--debug` as well as `DEBUG=1`

### DIFF
--- a/lib/app-common.ts
+++ b/lib/app-common.ts
@@ -218,28 +218,6 @@ function setupBalenaSdkSharedOptions(settings: CliSettings) {
 	});
 }
 
-let BluebirdConfigured = false;
-
-/**
- * Configure Bluebird and assign it as the global promise library.
- * Modules like `stream-to-promise` will otherwise produce native promises,
- * which leads to errors as much of the CLI JavaScript code expects Bluebird
- * promises.
- */
-export function configureBluebird() {
-	if (BluebirdConfigured) {
-		return;
-	}
-	BluebirdConfigured = true;
-	const Bluebird = require('bluebird') as typeof import('bluebird');
-	Bluebird.config({
-		longStackTraces: process.env.DEBUG ? true : false,
-	});
-	if (!(global as any)['@@any-promise/REGISTRATION']) {
-		require('any-promise/register/bluebird');
-	}
-}
-
 /**
  * Addresses the console warning:
  * (node:49500) MaxListenersExceededWarning: Possible EventEmitter memory
@@ -253,7 +231,6 @@ export function setMaxListeners(maxListeners: number) {
 export async function globalInit() {
 	await setupSentry();
 	checkNodeVersion();
-	configureBluebird();
 
 	const settings = new CliSettings();
 

--- a/lib/preparser.ts
+++ b/lib/preparser.ts
@@ -61,6 +61,13 @@ export async function routeCliFramework(argv: string[], options: AppOptions) {
 		}
 	}
 
+	// Enable bluebird long stack traces when in debug mode, must be set
+	// before the first bluebird require - done here so that it will also
+	// be enabled when using the `--debug` flag to enable debug mode
+	if (process.env.DEBUG) {
+		process.env.BLUEBIRD_LONG_STACK_TRACES = '1';
+	}
+
 	const Logger = await import('./utils/logger');
 	Logger.command = cmdSlice[0];
 

--- a/package.json
+++ b/package.json
@@ -185,7 +185,6 @@
     "@types/update-notifier": "^4.1.0",
     "@zeit/dockerignore": "0.0.3",
     "JSONStream": "^1.0.3",
-    "any-promise": "^1.3.0",
     "archiver": "^3.1.1",
     "balena-config-json": "^4.0.0",
     "balena-device-init": "^5.0.2",

--- a/tests/config-tests.ts
+++ b/tests/config-tests.ts
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-import { configureBluebird, setMaxListeners } from '../build/app-common';
+import { setMaxListeners } from '../build/app-common';
 
-configureBluebird();
 setMaxListeners(35); // it appears that 'nock' adds a bunch of listeners - bug?
 // SL: Looks like it's not nock causing this, as have seen the problem triggered from help.spec,
 //     which is not using nock.  Perhaps mocha/chai? (unlikely), or something in the CLI?

--- a/tests/nock-mock.ts
+++ b/tests/nock-mock.ts
@@ -15,10 +15,6 @@
  * limitations under the License.
  */
 
-import { configureBluebird } from '../build/app-common';
-
-configureBluebird();
-
 import * as nock from 'nock';
 
 export interface ScopeOpts {


### PR DESCRIPTION
Change-type: patch

<!-- You can remove tags that do not apply. -->
Resolves: # <!-- Refer an issue of this repository that this PR fixes -->  
Change-type: major|minor|patch <!-- See https://semver.org/ -->  
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->  
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->  

---
Please check the CONTRIBUTING.md file for relevant information and some
guidance. Keep in mind that the CLI is a cross-platform application that runs
on Windows, macOS and Linux. Tests will be automatically run by balena CI on
all three operating systems, but this will only help if you have added test
code that exercises the modified or added feature code.

Note that each commit message (currently only the first line) will be
automatically copied to the CHANGELOG.md file, so try writing it in a way
that describes the feature or fix for CLI users.

If there isn't a linked issue or if the linked issue doesn't quite match the
PR, please add a PR description to explain its purpose or the features that it
implements. Adding PR comments to blocks of code that aren't self explanatory
usually helps with the review process.

If the PR introduces security considerations or affects the development, build
or release process, please be sure to highlight this in the PR description.

Thank you very much for your contribution!
