### PR TITLE
Remove all module level bluebird usage from eagerly loaded modules

### DIFF
--- a/lib/actions/build.js
+++ b/lib/actions/build.js
@@ -15,10 +15,6 @@
  * limitations under the License.
  */
 
-// Imported here because it's needed for the setup
-// of this action
-import * as Bluebird from 'bluebird';
-
 import * as dockerUtils from '../utils/docker';
 import * as compose from '../utils/compose';
 import { dockerignoreHelp, registrySecretsHelp } from '../utils/messages';
@@ -39,7 +35,7 @@ import { getBalenaSdk } from '../utils/lazy';
  */
 const buildProject = function (docker, logger, composeOpts, opts) {
 	const { loadProject } = require('../utils/compose_ts');
-	return Bluebird.resolve(loadProject(logger, composeOpts))
+	return loadProject(logger, composeOpts)
 		.then(function (project) {
 			const appType = opts.app?.application_type?.[0];
 			if (
@@ -74,8 +70,9 @@ const buildProject = function (docker, logger, composeOpts, opts) {
 			logger.outputDeferredMessages();
 			logger.logSuccess('Build succeeded!');
 		})
-		.tapCatch(() => {
+		.catch((err) => {
 			logger.logError('Build failed');
+			throw err;
 		});
 };
 
@@ -135,7 +132,7 @@ Examples:
 			},
 		]),
 	),
-	action(params, options) {
+	async action(params, options) {
 		// compositions with many services trigger misleading warnings
 		// @ts-ignore editing property that isn't typed but does exist
 		require('events').defaultMaxListeners = 1000;
@@ -159,27 +156,24 @@ Examples:
 
 		const { application, arch, deviceType } = options;
 
-		return Bluebird.try(function () {
-			if (
-				(application == null && (arch == null || deviceType == null)) ||
-				(application != null && (arch != null || deviceType != null))
-			) {
-				throw new ExpectedError(
-					'You must specify either an application or an arch/deviceType pair to build for',
-				);
-			}
-			if (application) {
-				return checkLoggedIn();
-			}
+		if (
+			(application == null && (arch == null || deviceType == null)) ||
+			(application != null && (arch != null || deviceType != null))
+		) {
+			throw new ExpectedError(
+				'You must specify either an application or an arch/deviceType pair to build for',
+			);
+		}
+		if (application) {
+			await checkLoggedIn();
+		}
+
+		return validateProjectDirectory(sdk, {
+			dockerfilePath: options.dockerfile,
+			noParentCheck: options['noparent-check'] || false,
+			projectPath: options.source || '.',
+			registrySecretsPath: options['registry-secrets'],
 		})
-			.then(() =>
-				validateProjectDirectory(sdk, {
-					dockerfilePath: options.dockerfile,
-					noParentCheck: options['noparent-check'] || false,
-					projectPath: options.source || '.',
-					registrySecretsPath: options['registry-secrets'],
-				}),
-			)
 			.then(function ({ dockerfilePath, registrySecrets }) {
 				options.dockerfile = dockerfilePath;
 				options['registry-secrets'] = registrySecrets;

--- a/lib/actions/deploy.js
+++ b/lib/actions/deploy.js
@@ -15,10 +15,6 @@
  * limitations under the License.
  */
 
-// Imported here because it's needed for the setup
-// of this action
-import * as Bluebird from 'bluebird';
-
 import * as dockerUtils from '../utils/docker';
 import * as compose from '../utils/compose';
 import { dockerignoreHelp, registrySecretsHelp } from '../utils/messages';
@@ -41,6 +37,7 @@ import { getBalenaSdk, getChalk } from '../utils/lazy';
  * @param {any} opts
  */
 const deployProject = function (docker, logger, composeOpts, opts) {
+	const Bluebird = require('bluebird');
 	const _ = require('lodash');
 	const doodles = require('resin-doodles');
 	const sdk = getBalenaSdk();
@@ -49,7 +46,7 @@ const deployProject = function (docker, logger, composeOpts, opts) {
 		loadProject,
 	} = require('../utils/compose_ts');
 
-	return Bluebird.resolve(loadProject(logger, composeOpts, opts.image))
+	return loadProject(logger, composeOpts, opts.image)
 		.then(function (project) {
 			if (
 				project.descriptors.length > 1 &&
@@ -178,8 +175,9 @@ const deployProject = function (docker, logger, composeOpts, opts) {
 			console.log(doodles.getDoodle()); // Show charlie
 			console.log();
 		})
-		.tapCatch(() => {
+		.catch((err) => {
 			logger.logError('Deploy failed');
+			throw err;
 		});
 };
 
@@ -245,7 +243,7 @@ Examples:
 			},
 		]),
 	),
-	action(params, options) {
+	async action(params, options) {
 		// compositions with many services trigger misleading warnings
 		// @ts-ignore editing property that isn't typed but does exist
 		require('events').defaultMaxListeners = 1000;
@@ -268,55 +266,53 @@ Examples:
 		appName = appName_raw || appName || options.application;
 		delete options.application;
 
-		return Bluebird.try(function () {
-			if (appName == null) {
-				throw new ExpectedError(
-					'Please specify the name of the application to deploy',
-				);
-			}
+		if (appName == null) {
+			throw new ExpectedError(
+				'Please specify the name of the application to deploy',
+			);
+		}
 
-			if (image != null && options.build) {
-				throw new ExpectedError(
-					'Build option is not applicable when specifying an image',
-				);
-			}
-		})
-			.then(function () {
-				if (image) {
-					return getRegistrySecrets(sdk, options['registry-secrets']).then(
-						(registrySecrets) => {
-							options['registry-secrets'] = registrySecrets;
-						},
-					);
-				} else {
-					return validateProjectDirectory(sdk, {
-						dockerfilePath: options.dockerfile,
-						noParentCheck: options['noparent-check'] || false,
-						projectPath: options.source || '.',
-						registrySecretsPath: options['registry-secrets'],
-					}).then(function ({ dockerfilePath, registrySecrets }) {
-						options.dockerfile = dockerfilePath;
-						options['registry-secrets'] = registrySecrets;
-					});
-				}
-			})
-			.then(() => helpers.getAppWithArch(appName))
-			.then(function (app) {
-				return Promise.all([
-					dockerUtils.getDocker(options),
-					dockerUtils.generateBuildOpts(options),
-					compose.generateOpts(options),
-				]).then(([docker, buildOpts, composeOpts]) =>
-					deployProject(docker, logger, composeOpts, {
-						app,
-						appName, // may be prefixed by 'owner/', unlike app.app_name
-						image,
-						shouldPerformBuild: !!options.build,
-						shouldUploadLogs: !options.nologupload,
-						buildEmulated: !!options.emulated,
-						buildOpts,
-					}),
-				);
+		if (image != null && options.build) {
+			throw new ExpectedError(
+				'Build option is not applicable when specifying an image',
+			);
+		}
+
+		if (image) {
+			const registrySecrets = await getRegistrySecrets(
+				sdk,
+				options['registry-secrets'],
+			);
+			options['registry-secrets'] = registrySecrets;
+		} else {
+			const {
+				dockerfilePath,
+				registrySecrets,
+			} = await validateProjectDirectory(sdk, {
+				dockerfilePath: options.dockerfile,
+				noParentCheck: options['noparent-check'] || false,
+				projectPath: options.source || '.',
+				registrySecretsPath: options['registry-secrets'],
 			});
+			options.dockerfile = dockerfilePath;
+			options['registry-secrets'] = registrySecrets;
+		}
+
+		const app = await helpers.getAppWithArch(appName);
+
+		const [docker, buildOpts, composeOpts] = await Promise.all([
+			dockerUtils.getDocker(options),
+			dockerUtils.generateBuildOpts(options),
+			compose.generateOpts(options),
+		]);
+		await deployProject(docker, logger, composeOpts, {
+			app,
+			appName, // may be prefixed by 'owner/', unlike app.app_name
+			image,
+			shouldPerformBuild: !!options.build,
+			shouldUploadLogs: !options.nologupload,
+			buildEmulated: !!options.emulated,
+			buildOpts,
+		});
 	},
 };

--- a/lib/actions/device.js
+++ b/lib/actions/device.js
@@ -81,7 +81,7 @@ Examples:
 				return Bluebird.using(download(), (tempPath) =>
 					runCommand(`device register ${application.app_name}`)
 						.then(balena.models.device.get)
-						.tap(function (device) {
+						.then(function (device) {
 							let configureCommand = `os configure '${tempPath}' --device ${device.uuid}`;
 							if (options.config) {
 								configureCommand += ` --config '${options.config}'`;
@@ -103,7 +103,8 @@ Examples:
 									balena.models.device.remove(device.uuid).finally(function () {
 										throw error;
 									}),
-								);
+								)
+								.then(() => device);
 						}),
 				).then(function (device) {
 					console.log('Done');

--- a/lib/actions/os.js
+++ b/lib/actions/os.js
@@ -312,8 +312,7 @@ ${INIT_WARNING_MESSAGE}\
 						`Going to erase ${answers.drive}.`,
 						true,
 					)
-					.return(answers.drive)
-					.then(umountAsync);
+					.then(() => umountAsync(answers.drive));
 			})
 			.tap((answers) =>
 				helpers.sudo([

--- a/lib/app-capitano.ts
+++ b/lib/app-capitano.ts
@@ -14,11 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import * as Bluebird from 'bluebird';
-
 import * as capitano from 'capitano';
 import * as actions from './actions';
 import * as events from './events';
+import { promisify } from 'util';
 
 capitano.permission('user', (done) =>
 	require('./utils/patterns').checkLoggedIn().then(done, done),
@@ -76,17 +75,17 @@ capitano.command(actions.local.flash);
 // ---------- Public utils ----------
 capitano.command(actions.util.availableDrives);
 
-//------------ Local build and deploy -------
+// ------------ Local build and deploy -------
 capitano.command(actions.build);
 capitano.command(actions.deploy);
 
-//------------ Push/remote builds -------
+// ------------ Push/remote builds -------
 capitano.command(actions.push.push);
 
-export function run(argv) {
+export function run(argv: string[]) {
 	const cli = capitano.parse(argv.slice(2));
 	const runCommand = function () {
-		const capitanoExecuteAsync = Bluebird.promisify(capitano.execute);
+		const capitanoExecuteAsync = promisify(capitano.execute);
 		if (cli.global?.help) {
 			return capitanoExecuteAsync({
 				command: `help ${cli.command ?? ''}`,
@@ -97,9 +96,7 @@ export function run(argv) {
 	};
 
 	const trackCommand = function () {
-		const getMatchCommandAsync = Bluebird.promisify(
-			capitano.state.getMatchCommand,
-		);
+		const getMatchCommandAsync = promisify(capitano.state.getMatchCommand);
 		return getMatchCommandAsync(cli.command).then(function (command) {
 			// cmdSignature is literally a string like, for example:
 			//     "push <applicationOrDevice>"
@@ -111,7 +108,7 @@ export function run(argv) {
 		});
 	};
 
-	return Bluebird.all([trackCommand(), runCommand()]).catch(
+	return Promise.all([trackCommand(), runCommand()]).catch(
 		require('./errors').handleError,
 	);
 }

--- a/lib/utils/compose.js
+++ b/lib/utils/compose.js
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-import * as Bluebird from 'bluebird';
 import * as path from 'path';
 
 import { ExpectedError } from '../errors';
@@ -196,12 +195,12 @@ export function createProject(composePath, composeStr, projectName = null) {
  * optionally converting text file line endings (CRLF to LF).
  * @param {string} dir Source directory
  * @param {import('./compose-types').TarDirectoryOptions} param
- * @returns {Bluebird<import('stream').Readable>}
+ * @returns {Promise<import('stream').Readable>}
  */
 export function tarDirectory(dir, param) {
 	let { nogitignore = false } = param;
 	if (nogitignore) {
-		return Bluebird.resolve(require('./compose_ts').tarDirectory(dir, param));
+		return require('./compose_ts').tarDirectory(dir, param);
 	} else {
 		return originalTarDirectory(dir, param);
 	}
@@ -213,7 +212,7 @@ export function tarDirectory(dir, param) {
  * deleted in CLI v13.
  * @param {string} dir Source directory
  * @param {import('./compose-types').TarDirectoryOptions} param
- * @returns {Bluebird<import('stream').Readable>}
+ * @returns {Promise<import('stream').Readable>}
  */
 function originalTarDirectory(dir, param) {
 	let {
@@ -225,6 +224,7 @@ function originalTarDirectory(dir, param) {
 		convertEol = false;
 	}
 
+	const Bluebird = require('bluebird');
 	const tar = require('tar-stream');
 	const klaw = require('klaw');
 	const { promises: fs } = require('fs');
@@ -323,6 +323,7 @@ export function buildProject(
 	nogitignore,
 	multiDockerignore,
 ) {
+	const Bluebird = require('bluebird');
 	const _ = require('lodash');
 	const humanize = require('humanize');
 	const compose = require('resin-compose-parse');
@@ -377,12 +378,14 @@ export function buildProject(
 		.then((
 			needsQemu, // Tar up the directory, ready for the build stream
 		) =>
-			tarDirectory(projectPath, {
-				composition,
-				convertEol,
-				multiDockerignore,
-				nogitignore,
-			})
+			Bluebird.resolve(
+				tarDirectory(projectPath, {
+					composition,
+					convertEol,
+					multiDockerignore,
+					nogitignore,
+				}),
+			)
 				.then((tarStream) =>
 					makeBuildTasks(
 						composition,
@@ -555,7 +558,7 @@ export function buildProject(
  * @param {number} userId
  * @param {number} appId
  * @param {import('resin-compose-parse').Composition} composition
- * @returns {Bluebird<import('./compose-types').Release>}
+ * @returns {Promise<import('./compose-types').Release>}
  */
 export const createRelease = function (
 	apiEndpoint,
@@ -638,7 +641,7 @@ export const tagServiceImages = (docker, images, serviceImages) =>
  * @param {import('docker-toolbelt')} docker
  * @param {import('./logger')} logger
  * @param {number} appID
- * @returns {Bluebird<string[]>}
+ * @returns {Promise<string[]>}
  */
 export const getPreviousRepos = (sdk, docker, logger, appID) =>
 	sdk.pine
@@ -691,7 +694,7 @@ export const getPreviousRepos = (sdk, docker, logger, appID) =>
  * @param {string} registry
  * @param {string[]} images
  * @param {string[]} previousRepos
- * @returns {Bluebird<string>}
+ * @returns {Promise<string>}
  */
 export const authorizePush = function (
 	sdk,
@@ -734,6 +737,7 @@ export const pushAndUpdateServiceImages = function (
 	const { DockerProgress } = require('docker-progress');
 	const { retry } = require('./helpers');
 	const tty = require('./tty')(process.stdout);
+	const Bluebird = require('bluebird');
 
 	const opts = { authconfig: { registrytoken: token } };
 

--- a/lib/utils/device/live.ts
+++ b/lib/utils/device/live.ts
@@ -1,4 +1,3 @@
-import * as Bluebird from 'bluebird';
 import * as chokidar from 'chokidar';
 import type * as Dockerode from 'dockerode';
 import Livepush, { ContainerNotRunningError } from 'livepush';
@@ -20,6 +19,7 @@ import {
 } from './deploy';
 import { BuildError } from './errors';
 import { getServiceColourFn } from './logs';
+import { delay } from '../helpers';
 
 // How often do we want to check the device state
 // engine has settled (delay in ms)
@@ -251,7 +251,7 @@ export class LivepushManager {
 		this.logger.logDebug(
 			`Device state not settled, retrying in ${DEVICE_STATUS_SETTLE_CHECK_INTERVAL}ms`,
 		);
-		await Bluebird.delay(DEVICE_STATUS_SETTLE_CHECK_INTERVAL);
+		await delay(DEVICE_STATUS_SETTLE_CHECK_INTERVAL);
 		await this.awaitDeviceStateSettle();
 	}
 
@@ -308,7 +308,7 @@ export class LivepushManager {
 			);
 			await this.cancelRebuild(serviceName);
 			while (this.rebuildsCancelled[serviceName]) {
-				await Bluebird.delay(1000);
+				await delay(1000);
 			}
 		}
 

--- a/lib/utils/docker-js.js
+++ b/lib/utils/docker-js.js
@@ -17,7 +17,6 @@
 
 // Functions to help actions which rely on using docker
 
-import * as Bluebird from 'bluebird';
 import * as _ from 'lodash';
 import { ExpectedError } from '../errors';
 
@@ -109,6 +108,7 @@ Implements the same feature as the "docker build --cache-from" option.`,
 
 const generateConnectOpts = function (opts) {
 	const { promises: fs } = require('fs');
+	const Bluebird = require('bluebird');
 
 	return Bluebird.try(function () {
 		const connectOpts = {};
@@ -213,7 +213,7 @@ export function generateBuildOpts(options) {
  * 	port?: number;
  * 	timeout?: number;
  * }} options
- * @returns {Bluebird<import('docker-toolbelt')>}
+ * @returns {Promise<import('docker-toolbelt')>}
  */
 export function getDocker(options) {
 	return generateConnectOpts(options)
@@ -223,6 +223,7 @@ export function getDocker(options) {
 
 const getDockerToolbelt = _.once(function () {
 	const Docker = require('docker-toolbelt');
+	const Bluebird = require('bluebird');
 	Bluebird.promisifyAll(Docker.prototype, {
 		filter(name) {
 			return name === 'run';

--- a/lib/utils/qemu.ts
+++ b/lib/utils/qemu.ts
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-import * as Bluebird from 'bluebird';
 import type * as Dockerode from 'dockerode';
 import { getBalenaSdk, stripIndent } from './lazy';
 import Logger = require('./logger');
@@ -37,9 +36,14 @@ export function copyQemu(context: string, arch: string) {
 	const binDir = path.join(context, '.balena');
 	const binPath = path.join(binDir, QEMU_BIN_NAME);
 
-	return Bluebird.resolve(fs.promises.mkdir(binDir))
-		.catch({ code: 'EEXIST' }, function () {
-			// noop
+	return fs.promises
+		.mkdir(binDir)
+		.catch(function (err) {
+			if (err.code === 'EEXIST') {
+				// ignore
+				return;
+			}
+			throw err;
 		})
 		.then(() => getQemuPath(arch))
 		.then(
@@ -65,9 +69,14 @@ export const getQemuPath = function (arch: string) {
 	const { promises: fs } = require('fs') as typeof import('fs');
 
 	return balena.settings.get('binDirectory').then((binDir) =>
-		Bluebird.resolve(fs.mkdir(binDir))
-			.catch({ code: 'EEXIST' }, function () {
-				// noop
+		fs
+			.mkdir(binDir)
+			.catch(function (err) {
+				if (err.code === 'EEXIST') {
+					// ignore
+					return;
+				}
+				throw err;
 			})
 			.then(() =>
 				path.join(binDir, `${QEMU_BIN_NAME}-${arch}-${QEMU_VERSION}`),

--- a/lib/utils/tunnel.ts
+++ b/lib/utils/tunnel.ts
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 import type { BalenaSDK } from 'balena-sdk';
-import * as Bluebird from 'bluebird';
 import { Socket } from 'net';
 import { TypedError } from 'typed-error';
 
@@ -42,11 +41,11 @@ export const tunnelConnectionToDevice = (
 	port: number,
 	sdk: BalenaSDK,
 ) => {
-	return Bluebird.props({
-		vpnUrl: sdk.settings.get('vpnUrl'),
-		whoami: sdk.auth.whoami(),
-		token: sdk.auth.getToken(),
-	}).then(({ vpnUrl, whoami, token }) => {
+	return Promise.all([
+		sdk.settings.get('vpnUrl'),
+		sdk.auth.whoami(),
+		sdk.auth.getToken(),
+	]).then(([vpnUrl, whoami, token]) => {
 		const auth = {
 			user: whoami || 'root',
 			password: token,

--- a/typings/capitano/index.d.ts
+++ b/typings/capitano/index.d.ts
@@ -81,9 +81,13 @@ declare module 'capitano' {
 		globalOptions: OptionDefinition[];
 	};
 
+	export function run(
+		command: string,
+		callback: (err: Error | null, result: any) => void,
+	): void;
 	export function execute(
 		args: any,
-		callback: (err?: any, result: any) => void,
+		callback: (err?: Error, result: any) => void,
 	): void;
 	export function globalOption(option: OptionDefinition): void;
 	export function permission(


### PR DESCRIPTION
When combined with https://github.com/balena-io-modules/balena-settings-storage/pull/27/files and #1905 this removes bluebird from the `balena help` path entirely and saves ~50ms, and also means any other actions which do not use bluebird will also get those benefits