### PR TITLE
Add explicit dependency on balena-settings-storage

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2214,6 +2214,25 @@
         "balena-settings-storage": "^5.0.0",
         "bluebird": "^3.7.2",
         "jwt-decode": "^2.2.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "8.10.61",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.61.tgz",
+          "integrity": "sha512-l+zSbvT8TPRaCxL1l9cwHCb0tSqGAGcjPJFItGGYat5oCTiq1uQQKYg5m7AF1mgnEBzFXGLJ2LRmNjtreRX76Q=="
+        },
+        "balena-settings-storage": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/balena-settings-storage/-/balena-settings-storage-5.0.2.tgz",
+          "integrity": "sha512-379S8kNo1NYZvTE5+iRHQ0Q4+uSXIqsE+83gxF+onBjX6ecyF7b7Z+ZVvRbmIeo5rn6xGO2P5iW72ehL5tXgaw==",
+          "requires": {
+            "@resin.io/types-node-localstorage": "^1.3.0",
+            "@types/bluebird": "^3.5.8",
+            "@types/node": "^8.0.19",
+            "bluebird": "^3.3.4",
+            "node-localstorage": "^1.3.0"
+          }
+        }
       }
     },
     "balena-config-json": {
@@ -2654,21 +2673,17 @@
       }
     },
     "balena-settings-storage": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/balena-settings-storage/-/balena-settings-storage-5.0.2.tgz",
-      "integrity": "sha512-379S8kNo1NYZvTE5+iRHQ0Q4+uSXIqsE+83gxF+onBjX6ecyF7b7Z+ZVvRbmIeo5rn6xGO2P5iW72ehL5tXgaw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/balena-settings-storage/-/balena-settings-storage-6.0.0.tgz",
+      "integrity": "sha512-8FqYzKtKz7CqaKpwlak6p25qMwx2Lo5+1v1pl+xuAv6kxJrKBX+HDHElciIRJtfYI//PmtwjuMTSoTeHU0crnA==",
       "requires": {
-        "@resin.io/types-node-localstorage": "^1.3.0",
-        "@types/bluebird": "^3.5.8",
-        "@types/node": "^8.0.19",
-        "bluebird": "^3.3.4",
-        "node-localstorage": "^1.3.0"
+        "@types/node": "^10.17.26"
       },
       "dependencies": {
         "@types/node": {
-          "version": "8.10.61",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.61.tgz",
-          "integrity": "sha512-l+zSbvT8TPRaCxL1l9cwHCb0tSqGAGcjPJFItGGYat5oCTiq1uQQKYg5m7AF1mgnEBzFXGLJ2LRmNjtreRX76Q=="
+          "version": "10.17.26",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.26.tgz",
+          "integrity": "sha512-myMwkO2Cr82kirHY8uknNRHEVtn0wV3DTQfkrjx17jmkstDRZ24gNUdl8AHXVyVclTYI/bNjgTPTAWvWLqXqkw=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -193,6 +193,7 @@
     "balena-sdk": "^13.6.0",
     "balena-semver": "^2.2.0",
     "balena-settings-client": "^4.0.5",
+    "balena-settings-storage": "^6.0.0",
     "balena-sync": "^11.0.0",
     "bluebird": "^3.7.2",
     "body-parser": "^1.19.0",


### PR DESCRIPTION
This also removes the last bluebird usage from `balena help` saving ~50ms for that specific command, a lot of other commands will still import bluebird but they can be handled on a command by command basis now that the main path is clean :)