### PR TITLE
Clarify -c flag in balena push

### DIFF
--- a/doc/cli.markdown
+++ b/doc/cli.markdown
@@ -2074,7 +2074,11 @@ Alternative Dockerfile name/path, relative to the source folder
 
 #### --nocache, -c
 
-Don't use cache when building this project
+Don't use cached layers of previously built images for this project. This ensures
+that the latest base image and packages are pulled. Note that build logs may still
+display the message _"Pulling previous images for caching purposes" (as the cloud
+builder needs previous images to compute delta updates), but the logs will not
+display the "Using cache" lines for each build step of a Dockerfile.
 
 #### --noparent-check
 

--- a/lib/actions/push.ts
+++ b/lib/actions/push.ts
@@ -192,7 +192,12 @@ export const push: CommandDefinition<
 		{
 			signature: 'nocache',
 			alias: 'c',
-			description: "Don't use cache when building this project",
+			description: stripIndent`
+                Don't use cached layers of previously built images for this project. This ensures
+                that the latest base image and packages are pulled. Note that build logs may still
+                display the message _"Pulling previous images for caching purposes" (as the cloud
+                builder needs previous images to compute delta updates), but the logs will not
+                display the "Using cache" lines for each build step of a Dockerfile.`,
 			boolean: true,
 		},
 		{


### PR DESCRIPTION
Add more information to the --no-cache or -c option for balena push CLI command. 

Change-type: patch

See: [Flowdock](https://www.flowdock.com/app/rulemotion/i-cli/threads/XrTz7wOdxS74q8G_iKU8m16Xgzp)
@pdcastro :eyes: 