### PR TITLE
preload: Expand dockerd stderr logs in case of errors

### DIFF
--- a/patches/balena-preload+9.0.0.patch
+++ b/patches/balena-preload+9.0.0.patch
@@ -1,0 +1,20 @@
+diff --git a/node_modules/balena-preload/src/preload.py b/node_modules/balena-preload/src/preload.py
+index 887eaf3..0c5cc7f 100755
+--- a/node_modules/balena-preload/src/preload.py
++++ b/node_modules/balena-preload/src/preload.py
+@@ -489,8 +489,13 @@ def start_docker_daemon(storage_driver, docker_dir):
+         if running_dockerd.process.exit_code is not None:
+             # There is no reason for dockerd to exit with a 0 status now.
+             assert running_dockerd.process.exit_code != 0
+-            # This will raise an sh.ErrorReturnCode_X exception.
+-            running_dockerd.wait()
++            try:
++                # This will raise an sh.ErrorReturnCode_X exception.
++                running_dockerd.wait()
++            except:
++                print("An error has occurred executing 'dockerd':\n{}".format(
++                    running_dockerd.stderr.decode("utf8")), file=sys.stderr, flush=True)
++                raise
+         # Check that we can connect to dockerd.
+         output = docker("version", _ok_code=[0, 1])
+         ok = output.exit_code == 0


### PR DESCRIPTION
Connects-to: https://github.com/balena-io/balena-cli/issues/1922
Connects-to: https://github.com/balena-io-modules/balena-preload/pull/220/
Connects-to: https://github.com/balena-io-modules/balena-preload/issues/221
Change-type: patch

See also: 
* https://jel.ly.fish/ce5dab94-a799-4087-b29f-b9cd3171cbae
* https://www.flowdock.com/app/rulemotion/resin-frontend/threads/LR3semNNWM40cDocYriEExLTbXW
* https://www.flowdock.com/app/rulemotion/i-cli/threads/CxBdnZ9X2VeMOJDupNJqUnNyqeX
