### PR TITLE
Device: explicitly fetch only the presented fields

### DIFF
--- a/lib/actions-oclif/device/index.ts
+++ b/lib/actions-oclif/device/index.ts
@@ -69,19 +69,26 @@ export default class DeviceCmd extends Command {
 
 		const balena = getBalenaSdk();
 
-		const [device, overallStatus] = await Promise.all([
-			balena.models.device.get(params.uuid, expandForAppName) as Promise<
-				ExtendedDevice
-			>,
-			// TODO: drop this and add `overall_status` to a $select in the above
-			// pine query once the overall_status field is moved to open-balena-api.
-			// See: https://github.com/balena-io/open-balena-api/issues/338
-			balena.models.device
-				.get(params.uuid, { $select: 'overall_status' })
-				.then(({ overall_status }) => overall_status)
-				.catchReturn(''),
-		]);
-		device.status = overallStatus;
+		const device: ExtendedDevice = await balena.models.device.get(params.uuid, {
+			$select: [
+				'device_name',
+				'id',
+				'device_type',
+				'overall_status',
+				'is_online',
+				'ip_address',
+				'mac_address',
+				'last_connectivity_event',
+				'uuid',
+				'is_on__commit',
+				'supervisor_version',
+				'is_web_accessible',
+				'note',
+				'os_version',
+			],
+			...expandForAppName,
+		});
+		device.status = device.overall_status;
 
 		device.dashboard_url = balena.models.device.getDashboardUrl(device.uuid);
 

--- a/lib/actions-oclif/device/index.ts
+++ b/lib/actions-oclif/device/index.ts
@@ -28,6 +28,7 @@ interface ExtendedDevice extends Device {
 	dashboard_url?: string;
 	application_name?: string;
 	commit?: string;
+	last_seen?: string;
 }
 
 interface FlagsDef {
@@ -98,6 +99,7 @@ export default class DeviceCmd extends Command {
 			: 'N/a';
 
 		device.commit = device.is_on__commit;
+		device.last_seen = device.last_connectivity_event;
 
 		console.log(
 			getVisuals().table.vertical(device, [

--- a/tests/commands/device/device.spec.ts
+++ b/tests/commands/device/device.spec.ts
@@ -90,7 +90,7 @@ describe('balena device', function () {
 
 		const lines = cleanOutput(out);
 
-		expect(lines).to.have.lengthOf(13);
+		expect(lines).to.have.lengthOf(14);
 		expect(lines[0]).to.equal('== SPARKLING WOOD');
 		expect(lines[6].split(':')[1].trim()).to.equal('test app');
 
@@ -118,7 +118,7 @@ describe('balena device', function () {
 
 		const lines = cleanOutput(out);
 
-		expect(lines).to.have.lengthOf(13);
+		expect(lines).to.have.lengthOf(14);
 		expect(lines[0]).to.equal('== SPARKLING WOOD');
 		expect(lines[6].split(':')[1].trim()).to.equal('N/a');
 

--- a/tests/commands/device/device.spec.ts
+++ b/tests/commands/device/device.spec.ts
@@ -78,7 +78,6 @@ describe('balena device', function () {
 	it('should list device details for provided uuid', async () => {
 		api.expectGetWhoAmI({ optional: true, persist: true });
 		api.expectGetMixpanel({ optional: true });
-		api.expectGetDeviceStatus();
 		api.scope
 			.get(
 				/^\/v5\/device\?.+&\$expand=belongs_to__application\(\$select=app_name\)/,
@@ -103,7 +102,6 @@ describe('balena device', function () {
 		// e.g. When user has a device associated with app that user is no longer a collaborator of.
 		api.expectGetWhoAmI({ optional: true, persist: true });
 		api.expectGetMixpanel({ optional: true });
-		api.expectGetDeviceStatus();
 		api.scope
 			.get(
 				/^\/v5\/device\?.+&\$expand=belongs_to__application\(\$select=app_name\)/,

--- a/tests/test-data/api-response/device-missing-app.json
+++ b/tests/test-data/api-response/device-missing-app.json
@@ -11,6 +11,7 @@
 	  "is_on__commit": "18756d3386c25a044db66b89e0409804",
 	  "note": null,
 	  "is_online": false,
+	  "last_connectivity_event": "2019-11-23T00:26:35.074Z",
 	  "ip_address": "192.168.0.112",
 	  "mac_address": null,
 	  "os_version": "balenaOS 2.44.0+rev3",

--- a/tests/test-data/api-response/device-missing-app.json
+++ b/tests/test-data/api-response/device-missing-app.json
@@ -4,54 +4,19 @@
 	  "belongs_to__application": [
 	  ],
 	  "id": 1747415,
-	  "belongs_to__user": {
-		"__deferred": {
-		  "uri": "/resin/user(46272)"
-		},
-		"__id": 46272
-	  },
 	  "is_managed_by__device": null,
-	  "actor": 4180757,
-	  "should_be_running__release": null,
 	  "device_name": "sparkling-wood",
 	  "device_type": "raspberrypi4-64",
 	  "uuid": "fda508c8583011b8466c26abdd5159f2",
 	  "is_on__commit": "18756d3386c25a044db66b89e0409804",
 	  "note": null,
-	  "local_id": null,
-	  "status": "Idle",
 	  "is_online": false,
-	  "last_connectivity_event": "2019-11-23T00:26:35.074Z",
-	  "is_connected_to_vpn": false,
-	  "last_vpn_event": "2019-11-23T00:26:35.074Z",
 	  "ip_address": "192.168.0.112",
-	  "vpn_address": null,
-	  "public_address": "89.186.29.129",
+	  "mac_address": null,
 	  "os_version": "balenaOS 2.44.0+rev3",
-	  "os_variant": "dev",
 	  "supervisor_version": "10.3.7",
-	  "should_be_managed_by__supervisor_release": null,
-	  "is_managed_by__service_instance": {
-		"__deferred": {
-		  "uri": "/resin/service_instance(124111)"
-		},
-		"__id": 124111
-	  },
-	  "provisioning_progress": null,
-	  "provisioning_state": "",
-	  "download_progress": null,
 	  "is_web_accessible": false,
-	  "longitude": "22.5853",
-	  "latitude": "51.2712",
-	  "location": "Lublin, Lublin, Poland",
-	  "custom_longitude": "",
-	  "custom_latitude": "",
-	  "logs_channel": null,
-	  "is_locked_until__date": null,
-	  "is_accessible_by_support_until__date": null,
-	  "created_at": "2019-11-18T12:27:37.423Z",
-	  "is_active": true,
-	  "api_heartbeat_state": "offline",
+	  "overall_status": "idle",
 	  "__metadata": {
 		"uri": "/resin/device(@id)?@id=1747415"
 	  }

--- a/tests/test-data/api-response/device.json
+++ b/tests/test-data/api-response/device.json
@@ -15,6 +15,7 @@
 	  "is_on__commit": "18756d3386c25a044db66b89e0409804",
 	  "note": null,
 	  "is_online": false,
+	  "last_connectivity_event": "2019-11-23T00:26:35.074Z",
 	  "ip_address": "192.168.0.112",
 	  "mac_address": null,
 	  "os_version": "balenaOS 2.44.0+rev3",

--- a/tests/test-data/api-response/device.json
+++ b/tests/test-data/api-response/device.json
@@ -8,54 +8,19 @@
 		}
 	  ],
 	  "id": 1747415,
-	  "belongs_to__user": {
-		"__deferred": {
-		  "uri": "/resin/user(46272)"
-		},
-		"__id": 46272
-	  },
 	  "is_managed_by__device": null,
-	  "actor": 4180757,
-	  "should_be_running__release": null,
 	  "device_name": "sparkling-wood",
 	  "device_type": "raspberrypi4-64",
 	  "uuid": "fda508c8583011b8466c26abdd5159f2",
 	  "is_on__commit": "18756d3386c25a044db66b89e0409804",
 	  "note": null,
-	  "local_id": null,
-	  "status": "Idle",
 	  "is_online": false,
-	  "last_connectivity_event": "2019-11-23T00:26:35.074Z",
-	  "is_connected_to_vpn": false,
-	  "last_vpn_event": "2019-11-23T00:26:35.074Z",
 	  "ip_address": "192.168.0.112",
-	  "vpn_address": null,
-	  "public_address": "89.186.29.129",
+	  "mac_address": null,
 	  "os_version": "balenaOS 2.44.0+rev3",
-	  "os_variant": "dev",
 	  "supervisor_version": "10.3.7",
-	  "should_be_managed_by__supervisor_release": null,
-	  "is_managed_by__service_instance": {
-		"__deferred": {
-		  "uri": "/resin/service_instance(124111)"
-		},
-		"__id": 124111
-	  },
-	  "provisioning_progress": null,
-	  "provisioning_state": "",
-	  "download_progress": null,
 	  "is_web_accessible": false,
-	  "longitude": "22.5853",
-	  "latitude": "51.2712",
-	  "location": "Lublin, Lublin, Poland",
-	  "custom_longitude": "",
-	  "custom_latitude": "",
-	  "logs_channel": null,
-	  "is_locked_until__date": null,
-	  "is_accessible_by_support_until__date": null,
-	  "created_at": "2019-11-18T12:27:37.423Z",
-	  "is_active": true,
-	  "api_heartbeat_state": "offline",
+	  "overall_status": "offline",
 	  "__metadata": {
 		"uri": "/resin/device(@id)?@id=1747415"
 	  }


### PR DESCRIPTION
Depends on open-balena adding the mac_address &
the overall_status device fields, but the latest cli
version is probably already not working, since some
of its dependencies already use the v14 SDK which
needs the v6 model, that the open-balena-api doesn't
have yet either.

This also revealed (SDK pine client typings :grin:) that at some point we forgot to migrate the `last_seen` field, so before this it didn't show up.

Change-type: minor
See: https://www.flowdock.com/app/rulemotion/i-cli/threads/SaSXFlJEv-dpk9uUngWY225zv2D
See: https://github.com/balena-io/open-balena-api/issues/388
See: https://github.com/balena-io/open-balena-api/issues/338
See: https://github.com/balena-io/balena-sdk/issues/920
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

---
Please check the CONTRIBUTING.md file for relevant information and some
guidance. Keep in mind that the CLI is a cross-platform application that runs
on Windows, macOS and Linux. Tests will be automatically run by balena CI on
all three operating systems, but this will only help if you have added test
code that exercises the modified or added feature code.

Note that each commit message (currently only the first line) will be
automatically copied to the CHANGELOG.md file, so try writing it in a way
that describes the feature or fix for CLI users.

If there isn't a linked issue or if the linked issue doesn't quite match the
PR, please add a PR description to explain its purpose or the features that it
implements. Adding PR comments to blocks of code that aren't self explanatory
usually helps with the review process.

If the PR introduces security considerations or affects the development, build
or release process, please be sure to highlight this in the PR description.

Thank you very much for your contribution!
