### PR TITLE
Tests: add verification of 'pkg' warnings against saved output

### DIFF
--- a/automation/utils.ts
+++ b/automation/utils.ts
@@ -23,6 +23,69 @@ import * as shellEscape from 'shell-escape';
 export const MSYS2_BASH = 'C:\\msys64\\usr\\bin\\bash.exe';
 export const ROOT = path.join(__dirname, '..');
 
+/** Tap and buffer this process' stdout and stderr */
+export class StdOutTap {
+	public stdoutBuf: string[] = [];
+	public stderrBuf: string[] = [];
+	public allBuf: string[] = []; // both stdout and stderr
+
+	protected origStdoutWrite: typeof process.stdout.write;
+	protected origStderrWrite: typeof process.stdout.write;
+
+	constructor(protected printDots = false) {}
+
+	tap() {
+		this.origStdoutWrite = process.stdout.write;
+		this.origStderrWrite = process.stderr.write;
+
+		process.stdout.write = (chunk: string, ...args: any[]): boolean => {
+			this.stdoutBuf.push(chunk);
+			this.allBuf.push(chunk);
+			const str = this.printDots ? '.' : chunk;
+			return this.origStdoutWrite.call(process.stdout, str, ...args);
+		};
+
+		process.stderr.write = (chunk: string, ...args: any[]): boolean => {
+			this.stderrBuf.push(chunk);
+			this.allBuf.push(chunk);
+			const str = this.printDots ? '.' : chunk;
+			return this.origStderrWrite.call(process.stderr, str, ...args);
+		};
+	}
+
+	untap() {
+		process.stdout.write = this.origStdoutWrite;
+		process.stderr.write = this.origStderrWrite;
+		if (this.printDots) {
+			console.error('');
+		}
+	}
+}
+
+/**
+ * Diff strings by line, using the 'diff' npm package:
+ * https://www.npmjs.com/package/diff
+ */
+export function diffLines(str1: string, str2: string): string {
+	const { diffTrimmedLines } = require('diff');
+	const diffObjs = diffTrimmedLines(str1, str2);
+	const prefix = (chunk: string, char: string) =>
+		chunk
+			.split('\n')
+			.map((line: string) => `${char} ${line}`)
+			.join('\n');
+	const diffStr = diffObjs
+		.map((part: any) => {
+			return part.added
+				? prefix(part.value, '+')
+				: part.removed
+				? prefix(part.value, '-')
+				: prefix(part.value, ' ');
+		})
+		.join('\n');
+	return diffStr;
+}
+
 export function loadPackageJson() {
 	return require(path.join(ROOT, 'package.json'));
 }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5021,9 +5021,9 @@
       "integrity": "sha1-oqLie025mSjW2NRNXF9++9TLQ3I="
     },
     "diff": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
-      "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q=="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
     },
     "dir-glob": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -156,6 +156,7 @@
     "chai-as-promised": "^7.1.1",
     "cross-env": "^7.0.2",
     "deep-object-diff": "^1.1.0",
+    "diff": "^4.0.2",
     "ent": "^2.2.0",
     "filehound": "^1.17.4",
     "fs-extra": "^8.0.1",

--- a/tests/test-data/pkg/expected-warnings-darwin.txt
+++ b/tests/test-data/pkg/expected-warnings-darwin.txt
@@ -1,0 +1,78 @@
+> Warning Cannot resolve 'path.join(...pathComponents)'
+  build/actions/help_ts.js
+  Dynamic require may fail at run time, because the requested file
+  is unknown at compilation time and not included into executable.
+  Use a string literal as an argument for 'require', or leave it
+  as is and specify the resolved file name in 'scripts' option.
+> Warning Cannot resolve ''./' + command'
+  node_modules/balena-sync/build/capitano/index.js
+  Dynamic require may fail at run time, because the requested file
+  is unknown at compilation time and not included into executable.
+  Use a string literal as an argument for 'require', or leave it
+  as is and specify the resolved file name in 'scripts' option.
+> Warning Cannot resolve ''./' + target'
+  node_modules/balena-sync/build/sync/index.js
+  Dynamic require may fail at run time, because the requested file
+  is unknown at compilation time and not included into executable.
+  Use a string literal as an argument for 'require', or leave it
+  as is and specify the resolved file name in 'scripts' option.
+> Warning Cannot include file %1 into executable.
+  The file must be distributed with executable as %2.
+  %1: node_modules/open/xdg-open
+  %2: path-to-executable/xdg-open
+> Warning Cannot include file %1 into executable.
+  The file must be distributed with executable as %2.
+  %1: node_modules/open/xdg-open
+  %2: path-to-executable/xdg-open
+> Warning Cannot include file %1 into executable.
+  The file must be distributed with executable as %2.
+  %1: node_modules/drivelist/build/Release/drivelist.node
+  %2: path-to-executable/drivelist.node
+> Warning Cannot include file %1 into executable.
+  The file must be distributed with executable as %2.
+  %1: node_modules/drivelist/scripts/darwin.sh
+  %2: path-to-executable/drivelist/darwin.sh
+> Warning Cannot include file %1 into executable.
+  The file must be distributed with executable as %2.
+  %1: node_modules/drivelist/scripts/linux.sh
+  %2: path-to-executable/drivelist/linux.sh
+> Warning Cannot include file %1 into executable.
+  The file must be distributed with executable as %2.
+  %1: node_modules/drivelist/scripts/win32.bat
+  %2: path-to-executable/drivelist/win32.bat
+> Warning Cannot include file %1 into executable.
+  The file must be distributed with executable as %2.
+  %1: node_modules/drivelist/build/Release/drivelist.node
+  %2: path-to-executable/drivelist.node
+> Warning Cannot include file %1 into executable.
+  The file must be distributed with executable as %2.
+  %1: node_modules/drivelist/scripts/darwin.sh
+  %2: path-to-executable/drivelist/darwin.sh
+> Warning Cannot include file %1 into executable.
+  The file must be distributed with executable as %2.
+  %1: node_modules/drivelist/scripts/linux.sh
+  %2: path-to-executable/drivelist/linux.sh
+> Warning Cannot include file %1 into executable.
+  The file must be distributed with executable as %2.
+  %1: node_modules/drivelist/scripts/win32.bat
+  %2: path-to-executable/drivelist/win32.bat
+> Warning Cannot include addon %1 into executable.
+  The addon must be distributed with executable as %2.
+  %1: node_modules/xxhash/build/Release/hash.node
+  %2: path-to-executable/hash.node
+> Warning Cannot include addon %1 into executable.
+  The addon must be distributed with executable as %2.
+  %1: node_modules/fsevents/fsevents.node
+  %2: path-to-executable/fsevents.node
+> Warning Cannot include addon %1 into executable.
+  The addon must be distributed with executable as %2.
+  %1: node_modules/fsevents/fsevents.node
+  %2: path-to-executable/fsevents.node
+> Warning Cannot include file %1 into executable.
+  The file must be distributed with executable as %2.
+  %1: node_modules/opn/xdg-open
+  %2: path-to-executable/xdg-open
+> Warning Cannot include file %1 into executable.
+  The file must be distributed with executable as %2.
+  %1: node_modules/opn/xdg-open
+  %2: path-to-executable/xdg-open

--- a/tests/test-data/pkg/expected-warnings-linux.txt
+++ b/tests/test-data/pkg/expected-warnings-linux.txt
@@ -1,0 +1,70 @@
+> Warning Cannot resolve 'path.join(...pathComponents)'
+  build/actions/help_ts.js
+  Dynamic require may fail at run time, because the requested file
+  is unknown at compilation time and not included into executable.
+  Use a string literal as an argument for 'require', or leave it
+  as is and specify the resolved file name in 'scripts' option.
+> Warning Cannot resolve ''./' + command'
+  node_modules/balena-sync/build/capitano/index.js
+  Dynamic require may fail at run time, because the requested file
+  is unknown at compilation time and not included into executable.
+  Use a string literal as an argument for 'require', or leave it
+  as is and specify the resolved file name in 'scripts' option.
+> Warning Cannot resolve ''./' + target'
+  node_modules/balena-sync/build/sync/index.js
+  Dynamic require may fail at run time, because the requested file
+  is unknown at compilation time and not included into executable.
+  Use a string literal as an argument for 'require', or leave it
+  as is and specify the resolved file name in 'scripts' option.
+> Warning Cannot include file %1 into executable.
+  The file must be distributed with executable as %2.
+  %1: node_modules/open/xdg-open
+  %2: path-to-executable/xdg-open
+> Warning Cannot include file %1 into executable.
+  The file must be distributed with executable as %2.
+  %1: node_modules/open/xdg-open
+  %2: path-to-executable/xdg-open
+> Warning Cannot include file %1 into executable.
+  The file must be distributed with executable as %2.
+  %1: node_modules/drivelist/build/Release/drivelist.node
+  %2: path-to-executable/drivelist.node
+> Warning Cannot include file %1 into executable.
+  The file must be distributed with executable as %2.
+  %1: node_modules/drivelist/scripts/darwin.sh
+  %2: path-to-executable/drivelist/darwin.sh
+> Warning Cannot include file %1 into executable.
+  The file must be distributed with executable as %2.
+  %1: node_modules/drivelist/scripts/linux.sh
+  %2: path-to-executable/drivelist/linux.sh
+> Warning Cannot include file %1 into executable.
+  The file must be distributed with executable as %2.
+  %1: node_modules/drivelist/scripts/win32.bat
+  %2: path-to-executable/drivelist/win32.bat
+> Warning Cannot include file %1 into executable.
+  The file must be distributed with executable as %2.
+  %1: node_modules/drivelist/build/Release/drivelist.node
+  %2: path-to-executable/drivelist.node
+> Warning Cannot include file %1 into executable.
+  The file must be distributed with executable as %2.
+  %1: node_modules/drivelist/scripts/darwin.sh
+  %2: path-to-executable/drivelist/darwin.sh
+> Warning Cannot include file %1 into executable.
+  The file must be distributed with executable as %2.
+  %1: node_modules/drivelist/scripts/linux.sh
+  %2: path-to-executable/drivelist/linux.sh
+> Warning Cannot include file %1 into executable.
+  The file must be distributed with executable as %2.
+  %1: node_modules/drivelist/scripts/win32.bat
+  %2: path-to-executable/drivelist/win32.bat
+> Warning Cannot include addon %1 into executable.
+  The addon must be distributed with executable as %2.
+  %1: node_modules/xxhash/build/Release/hash.node
+  %2: path-to-executable/hash.node
+> Warning Cannot include file %1 into executable.
+  The file must be distributed with executable as %2.
+  %1: node_modules/opn/xdg-open
+  %2: path-to-executable/xdg-open
+> Warning Cannot include file %1 into executable.
+  The file must be distributed with executable as %2.
+  %1: node_modules/opn/xdg-open
+  %2: path-to-executable/xdg-open

--- a/tests/test-data/pkg/expected-warnings-win32.txt
+++ b/tests/test-data/pkg/expected-warnings-win32.txt
@@ -1,0 +1,72 @@
+> Warning Cannot resolve 'path.join(...pathComponents)'
+  build\actions\help_ts.js
+  Dynamic require may fail at run time, because the requested file
+  is unknown at compilation time and not included into executable.
+  Use a string literal as an argument for 'require', or leave it
+  as is and specify the resolved file name in 'scripts' option.
+> Warning Cannot find module 'net-keepalive' from 'build\utils\device'
+  %1: build\utils\device\api.js
+> Warning Cannot resolve ''./' + command'
+  node_modules\balena-sync\build\capitano\index.js
+  Dynamic require may fail at run time, because the requested file
+  is unknown at compilation time and not included into executable.
+  Use a string literal as an argument for 'require', or leave it
+  as is and specify the resolved file name in 'scripts' option.
+> Warning Cannot resolve ''./' + target'
+  node_modules\balena-sync\build\sync\index.js
+  Dynamic require may fail at run time, because the requested file
+  is unknown at compilation time and not included into executable.
+  Use a string literal as an argument for 'require', or leave it
+  as is and specify the resolved file name in 'scripts' option.
+> Warning Cannot include file %1 into executable.
+  The file must be distributed with executable as %2.
+  %1: node_modules\open\xdg-open
+  %2: path-to-executable/xdg-open
+> Warning Cannot include file %1 into executable.
+  The file must be distributed with executable as %2.
+  %1: node_modules\open\xdg-open
+  %2: path-to-executable/xdg-open
+> Warning Cannot include file %1 into executable.
+  The file must be distributed with executable as %2.
+  %1: node_modules\drivelist\build\Release\drivelist.node
+  %2: path-to-executable/drivelist.node
+> Warning Cannot include file %1 into executable.
+  The file must be distributed with executable as %2.
+  %1: node_modules\drivelist\scripts\darwin.sh
+  %2: path-to-executable/drivelist/darwin.sh
+> Warning Cannot include file %1 into executable.
+  The file must be distributed with executable as %2.
+  %1: node_modules\drivelist\scripts\linux.sh
+  %2: path-to-executable/drivelist/linux.sh
+> Warning Cannot include file %1 into executable.
+  The file must be distributed with executable as %2.
+  %1: node_modules\drivelist\scripts\win32.bat
+  %2: path-to-executable/drivelist/win32.bat
+> Warning Cannot include file %1 into executable.
+  The file must be distributed with executable as %2.
+  %1: node_modules\drivelist\build\Release\drivelist.node
+  %2: path-to-executable/drivelist.node
+> Warning Cannot include file %1 into executable.
+  The file must be distributed with executable as %2.
+  %1: node_modules\drivelist\scripts\darwin.sh
+  %2: path-to-executable/drivelist/darwin.sh
+> Warning Cannot include file %1 into executable.
+  The file must be distributed with executable as %2.
+  %1: node_modules\drivelist\scripts\linux.sh
+  %2: path-to-executable/drivelist/linux.sh
+> Warning Cannot include file %1 into executable.
+  The file must be distributed with executable as %2.
+  %1: node_modules\drivelist\scripts\win32.bat
+  %2: path-to-executable/drivelist/win32.bat
+> Warning Cannot include addon %1 into executable.
+  The addon must be distributed with executable as %2.
+  %1: node_modules\xxhash\build\Release\hash.node
+  %2: path-to-executable/hash.node
+> Warning Cannot include file %1 into executable.
+  The file must be distributed with executable as %2.
+  %1: node_modules\opn\xdg-open
+  %2: path-to-executable/xdg-open
+> Warning Cannot include file %1 into executable.
+  The file must be distributed with executable as %2.
+  %1: node_modules\opn\xdg-open
+  %2: path-to-executable/xdg-open


### PR DESCRIPTION
Change-type: patch

When `pkg` runs, it produces warnings such as:
```
> Warning Cannot resolve ''./' + target'
  /Users/paulo/balena/balena-io/balena-cli/node_modules/balena-sync/build/sync/index.js
  Dynamic require may fail at run time, because the requested file
  is unknown at compilation time and not included into executable.
  Use a string literal as an argument for 'require', or leave it
  as is and specify the resolved file name in 'scripts' option.
> Warning Cannot include file %1 into executable.
  The file must be distributed with executable as %2.
  %1: node_modules/open/xdg-open
  %2: path-to-executable/xdg-open
> Warning Cannot include file %1 into executable.
  The file must be distributed with executable as %2.
  %1: node_modules/open/xdg-open
  %2: path-to-executable/xdg-open
> Warning Cannot include file %1 into executable.
  The file must be distributed with executable as %2.
  %1: node_modules/drivelist/build/Release/drivelist.node
  %2: path-to-executable/drivelist.node
...
```
They are usually harmless, until they aren't: when changes are made to dependencies and `pkg` produces new warnings for actually problematic issues. This PR commits the known harmless output to a text file, then compares the `pkg` output against it. If the output doesn't match, a diff is printed and the CLI build fails.