### PR TITLE
Improve command suggestions, add topic help

### DIFF
--- a/doc/cli.markdown
+++ b/doc/cli.markdown
@@ -2082,7 +2082,7 @@ Sample registry-secrets YAML file:
 		password: '{escaped contents of the GCR keyfile.json file}'
 ```
 For a sample project using registry secrets with the Google Container Registry,
-check: https://github.com/balena-io-playground/sample-gcr-registry-secrets
+check: https://github.com/balena-io-examples/sample-gcr-registry-secrets
 
 If the --registry-secrets option is not specified, and a secrets.yml or
 secrets.json file exists in the balena directory (usually $HOME/.balena),
@@ -2358,7 +2358,7 @@ Sample registry-secrets YAML file:
 		password: '{escaped contents of the GCR keyfile.json file}'
 ```
 For a sample project using registry secrets with the Google Container Registry,
-check: https://github.com/balena-io-playground/sample-gcr-registry-secrets
+check: https://github.com/balena-io-examples/sample-gcr-registry-secrets
 
 If the --registry-secrets option is not specified, and a secrets.yml or
 secrets.json file exists in the balena directory (usually $HOME/.balena),
@@ -2580,7 +2580,7 @@ Sample registry-secrets YAML file:
 		password: '{escaped contents of the GCR keyfile.json file}'
 ```
 For a sample project using registry secrets with the Google Container Registry,
-check: https://github.com/balena-io-playground/sample-gcr-registry-secrets
+check: https://github.com/balena-io-examples/sample-gcr-registry-secrets
 
 If the --registry-secrets option is not specified, and a secrets.yml or
 secrets.json file exists in the balena directory (usually $HOME/.balena),

--- a/lib/actions-oclif/device/rm.ts
+++ b/lib/actions-oclif/device/rm.ts
@@ -82,7 +82,7 @@ export default class DeviceRmCmd extends Command {
 		);
 
 		// Remove
-		for (const uuid of params.uuid.split(',')) {
+		for (const uuid of uuids) {
 			try {
 				await balena.models.device.remove(tryAsInteger(uuid));
 			} catch (err) {

--- a/lib/help.ts
+++ b/lib/help.ts
@@ -40,6 +40,27 @@ export default class BalenaHelp extends Help {
 			return;
 		}
 
+		// If they've typed a topic (e.g. `balena os`) that isn't also a command (e.g. `balena device`)
+		// then list the associated commands.
+		const topicCommands = this.config.commands.filter((c) => {
+			return c.id.startsWith(`${subject}:`);
+		});
+		if (topicCommands.length > 0) {
+			console.log(`${chalk.yellow(subject)} commands include:`);
+			console.log(this.formatCommands(topicCommands));
+			console.log(
+				`\nRun ${chalk.cyan.bold(
+					'balena help -v',
+				)} for a list of all available commands,`,
+			);
+			console.log(
+				` or ${chalk.cyan.bold(
+					'balena help <command>',
+				)} for detailed help on a specific command.`,
+			);
+			return;
+		}
+
 		throw new ExpectedError(`command ${chalk.cyan.bold(subject)} not found`);
 	}
 

--- a/lib/utils/messages.ts
+++ b/lib/utils/messages.ts
@@ -61,7 +61,7 @@ Sample registry-secrets YAML file:
 		password: '{escaped contents of the GCR keyfile.json file}'
 \`\`\`
 For a sample project using registry secrets with the Google Container Registry,
-check: https://github.com/balena-io-playground/sample-gcr-registry-secrets
+check: https://github.com/balena-io-examples/sample-gcr-registry-secrets
 
 If the --registry-secrets option is not specified, and a secrets.yml or
 secrets.json file exists in the balena directory (usually $HOME/.balena),

--- a/patches/all/@oclif+config+1.17.0.patch
+++ b/patches/all/@oclif+config+1.17.0.patch
@@ -1,0 +1,15 @@
+diff --git a/node_modules/@oclif/config/lib/config.js b/node_modules/@oclif/config/lib/config.js
+index aba1da9..830f800 100644
+--- a/node_modules/@oclif/config/lib/config.js
++++ b/node_modules/@oclif/config/lib/config.js
+@@ -165,7 +165,9 @@ class Config {
+         debug('runCommand %s %o', id, argv);
+         const c = this.findCommand(id);
+         if (!c) {
+-            await this.runHook('command_not_found', { id });
++            // argv added to command_not_found hook
++            // We should try to upstream this change
++            await this.runHook('command_not_found', { id, argv });
+             throw new errors_1.CLIError(`command ${id} not found`);
+         }
+         const command = c.load();


### PR DESCRIPTION
```
$ balena scann
scann is not a recognized balena command.

Did you mean: ? 
  scan

Run balena help -v for a list of available commands,
 or balena help <command> for detailed help on a specific command.
```
```
$ balena env renamee

env commands include:
  env add <name> [value]   add env or config variable to application(s), device(s) or service(s)
  env rename <id> <value>  change the value of a config or env var for an app, device or service
  env rm <id>              remove a config or env var from an application, device or service

Run balena help -v for a list of all available commands,
 or balena help <command> for detailed help on a specific command.
```

```
$ balena enve rename

enve is not a recognized balena command.

Did you mean: ? 
  env rename
  envs

Run balena help -v for a list of available commands,
 or balena help <command> for detailed help on a specific command.
```
