### PR TITLE
Fix issue with subclassed errors and instanceof

### DIFF
--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -23,19 +23,36 @@ import { getHelp } from './utils/messages';
 
 export class ExpectedError extends TypedError {}
 
-export class NotLoggedInError extends ExpectedError {}
+// Note: Because of a nasty TS limitation re extending builtins, instanceof was not working correctly with
+// subclassed errors.  The workaround is to set their prototypes manually.
+// https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#extending-built-ins-like-error-array-and-map-may-no-longer-work
+// https://github.com/microsoft/TypeScript/issues/13965
 
-export class InsufficientPrivilegesError extends ExpectedError {}
+export class NotLoggedInError extends ExpectedError {
+	constructor(m: string) {
+		super(m);
+		Object.setPrototypeOf(this, ExpectedError.prototype);
+	}
+}
+
+export class InsufficientPrivilegesError extends ExpectedError {
+	constructor(m: string) {
+		super(m);
+		Object.setPrototypeOf(this, ExpectedError.prototype);
+	}
+}
 
 export class InvalidPortMappingError extends ExpectedError {
 	constructor(mapping: string) {
 		super(`'${mapping}' is not a valid port mapping.`);
+		Object.setPrototypeOf(this, ExpectedError.prototype);
 	}
 }
 
 export class NoPortsDefinedError extends ExpectedError {
 	constructor() {
 		super('No ports have been provided.');
+		Object.setPrototypeOf(this, ExpectedError.prototype);
 	}
 }
 
@@ -147,6 +164,7 @@ const EXPECTED_ERROR_REGEXES = [
 	/^BalenaApplicationNotFound/, // balena-sdk
 	/^BalenaDeviceNotFound/, // balena-sdk
 	/^BalenaExpiredToken/, // balena-sdk
+	/Request error: Unauthorized$/, // balena-sdk
 	/^BalenaInvalidDeviceType/, // balena-sdk
 	/^Missing \w+$/, // Capitano,
 	/^Missing \d+ required arg/, // oclif parser: RequiredArgsError

--- a/tests/errors.spec.ts
+++ b/tests/errors.spec.ts
@@ -25,6 +25,13 @@ import { expect } from 'chai';
 import * as sinon from 'sinon';
 import * as ErrorsModule from '../build/errors';
 import { getHelp } from '../build/utils/messages';
+import {
+	ExpectedError,
+	NotLoggedInError,
+	InsufficientPrivilegesError,
+	InvalidPortMappingError,
+	NoPortsDefinedError,
+} from '../lib/errors';
 
 function red(s: string) {
 	if (process.env.CI) {
@@ -126,6 +133,7 @@ describe('handleError() function', () => {
 		'to be one of', // oclif
 		'must also be provided when using', // oclif
 		'Expected an integer', // oclif
+		'BalenaRequestError: Request error: Unauthorized', // sdk
 	];
 
 	messagesToMatch.forEach((message) => {
@@ -204,5 +212,20 @@ describe('printExpectedErrorMessage() function', () => {
 		expect(consoleError.getCall(0).args[0]).to.equal(errorMessage + '\n');
 
 		consoleError.restore();
+	});
+});
+
+describe('custom subclassed errors', () => {
+	// We ran into an issue where subclassed errors were not working with instanceof, due to
+	// a TS limitation re extending builtins.  Workaround required setting correct prototypes manually.
+	// https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#extending-built-ins-like-error-array-and-map-may-no-longer-work
+	// https://github.com/microsoft/TypeScript/issues/13965
+
+	it('Subclasses of ExpectedError should work properly with instanceof', () => {
+		expect(new NotLoggedInError('') instanceof ExpectedError).to.be.true;
+		expect(new InsufficientPrivilegesError('') instanceof ExpectedError).to.be
+			.true;
+		expect(new InvalidPortMappingError('') instanceof ExpectedError).to.be.true;
+		expect(new NoPortsDefinedError() instanceof ExpectedError).to.be.true;
 	});
 });


### PR DESCRIPTION
This works around a limitation of typescript regarding `instanceof` and extended builtins (like errors).  This was causing the `is(error instanceof ExpectedError)` test to fail leading to errors being submitted to sentry which should not have been.  

Have also added `Request error: Unauthorized` to the list of error patterns to match and ignore.

Change-type: patch
Resolves: #2035
Signed-off-by: Scott Lowe <scott@balena.io>
