### PR TITLE
Improve error message to access balena settings

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2534,18 +2534,6 @@
         "balena-settings-storage": "^7.0.0",
         "jwt-decode": "^2.2.0",
         "tslib": "^2.0.0"
-      },
-      "dependencies": {
-        "balena-settings-storage": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/balena-settings-storage/-/balena-settings-storage-7.0.0.tgz",
-          "integrity": "sha512-gufzVJznyt9e1CvpBuLe2caU5KcEwl1YHCbK5OMz09zXDA2OMAICPXsLlViK+KiuZwZrBx3tyU2FZjAzRZFgwQ==",
-          "requires": {
-            "@types/node": "^10.17.26",
-            "balena-errors": "^4.7.1",
-            "tslib": "^2.0.0"
-          }
-        }
       }
     },
     "balena-config-json": {
@@ -2793,11 +2781,12 @@
       }
     },
     "balena-settings-storage": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/balena-settings-storage/-/balena-settings-storage-6.0.1.tgz",
-      "integrity": "sha512-jdDoKzbJXlF696EZSbwD6lZ1dMe98aUtx7btFE4j4PRCSeh2BWx5P5VLGh9Bk3sH2FUcqYg0iw/wdKvkcv44oA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/balena-settings-storage/-/balena-settings-storage-7.0.0.tgz",
+      "integrity": "sha512-gufzVJznyt9e1CvpBuLe2caU5KcEwl1YHCbK5OMz09zXDA2OMAICPXsLlViK+KiuZwZrBx3tyU2FZjAzRZFgwQ==",
       "requires": {
         "@types/node": "^10.17.26",
+        "balena-errors": "^4.7.1",
         "tslib": "^2.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -204,7 +204,7 @@
     "balena-sdk": "^15.20.0",
     "balena-semver": "^2.3.0",
     "balena-settings-client": "^4.0.5",
-    "balena-settings-storage": "^6.0.1",
+    "balena-settings-storage": "^7.0.0",
     "balena-sync": "^11.0.2",
     "bluebird": "^3.7.2",
     "body-parser": "^1.19.0",


### PR DESCRIPTION
Resolves: #1667  
Change-type: patch 
Depends-on:  https://github.com/balena-io-modules/balena-errors/pull/47 and https://github.com/balena-io-modules/balena-settings-storage/pull/29

- [x] Blocked until new version of balena-sdk is properly generated

### Windows Error message:
```
You don't have sufficient privileges to access balena settings.

Balena stores the session token in C:\Users\<user>\_balena.
This error usually indicates that the user doesn't have permissions over that directory,
which can happen if balena was executed as the root user.

Try resetting the ownership by opening a new Command Prompt as administrator and running: `takeown /f %USERPROFILE%\_balena /r`

Additional information may be available with the `--debug` flag.
For help, visit our support forums: https://forums.balena.io
For bug reports or feature requests, see: https://github.com/balena-io/balena-cli/issues/
```

### UNIX error message:
```
You don't have sufficient privileges to access balena settings.

Balena stores the session token in $HOME/.balena.
This error usually indicates that the user doesn't have permissions over that directory,
which can happen if balena was executed as the root user.

Try resetting the ownership by running: `sudo chown -R $(whoami) $HOME/.balena`

Additional information may be available with the `--debug` flag.
For help, visit our support forums: https://forums.balena.io
For bug reports or feature requests, see: https://github.com/balena-io/balena-cli/issues/
```
