### PR TITLE
Workaround balena-dev/oclif compatibility issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,31 +21,6 @@ Before opening a PR, test your changes with `npm test`. Keep compatibility in mi
 meant to run on Linux, macOS and Windows. balena CI will run test code on all three platforms, but
 this will only help if you add some test cases for your new code!
 
-## ./bin/balena-dev and oclif
-
-When using `./bin/balena-dev`, it is currently necessary to manually edit the `oclif` section of
-`package.json` to replace `./build` with `./lib` as follows:
-
-Change from:
-```
-  "oclif": {
-    "commands": "./build/commands",
-    "hooks": {
-      "prerun": "./build/hooks/prerun/track"
-```
-
-To:
-```
-  "oclif": {
-    "commands": "./lib/commands",
-    "hooks": {
-      "prerun": "./lib/hooks/prerun/track"
-```
-
-And then remember to change it back before pushing the pull request. This is obviously error prone
-and inconvenient, and improvement suggestions are welcome: is there a better solution than
-automatically editing `package.json`? It is doable, if it is what needs to be done.
-
 ## Semantic versioning, commit messages and the ChangeLog
 
 The CLI version numbering adheres to [Semantic Versioning](http://semver.org/). The following

--- a/bin/balena
+++ b/bin/balena
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+// tslint:disable:no-var-requires
+
 // We boost the threadpool size as ext2fs can deadlock with some
 // operations otherwise, if the pool runs out.
 process.env.UV_THREADPOOL_SIZE = '64';
@@ -10,7 +12,7 @@ process.env.OCLIF_TS_NODE = 0;
 // Use fast-boot to cache require lookups, speeding up startup
 require('fast-boot2').start({
 	cacheScope: __dirname + '/..',
-	cacheFile: __dirname + '/.fast-boot.json'
+	cacheFile: __dirname + '/.fast-boot.json',
 });
 
 // Set the desired es version for downstream modules that support it

--- a/bin/balena-dev
+++ b/bin/balena-dev
@@ -5,19 +5,24 @@
 // Before opening a PR you should build and test your changes using bin/balena
 // ****************************************************************************
 
+// tslint:disable:no-var-requires
+
 // We boost the threadpool size as ext2fs can deadlock with some
 // operations otherwise, if the pool runs out.
 process.env.UV_THREADPOOL_SIZE = '64';
+
+const path = require('path');
+const rootDir = path.join(__dirname, '..');
 
 // Allow balena-dev to work with oclif by temporarily
 // pointing oclif config options to lib/ instead of build/
 modifyOclifPaths();
 // Undo changes on exit
-process.on('exit', function() {
+process.on('exit', function () {
 	modifyOclifPaths(true);
 });
 // Undo changes in case of ctrl-v
-process.on('SIGINT', function() {
+process.on('SIGINT', function () {
 	modifyOclifPaths(true);
 });
 
@@ -30,8 +35,6 @@ require('fast-boot2').start({
 // Set the desired es version for downstream modules that support it
 require('@balena/es-version').set('es2018');
 
-const path = require('path');
-const rootDir = path.join(__dirname, '..');
 // Note: before ts-node v6.0.0, 'transpile-only' (no type checking) was the
 // default option. We upgraded ts-node and found that adding 'transpile-only'
 // was necessary to avoid a mysterious 'null' error message. On the plus side,
@@ -46,20 +49,26 @@ require('../lib/app').run();
 // Modify package.json oclif paths from build/ -> lib/, or vice versa
 function modifyOclifPaths(revert) {
 	const fs = require('fs');
-	const path = './package.json';
+	const packageJsonPath = path.join(rootDir, 'package.json');
 
-	const packageJson = fs.readFileSync(path, 'utf8');
+	const packageJson = fs.readFileSync(packageJsonPath, 'utf8');
 	const packageObj = JSON.parse(packageJson);
 
-	if(!packageObj.oclif) { return; }
+	if (!packageObj.oclif) {
+		return;
+	}
 
 	let oclifSectionText = JSON.stringify(packageObj.oclif);
-	if(!revert) {
-		oclifSectionText = oclifSectionText.replace(/build/g, 'lib')
+	if (!revert) {
+		oclifSectionText = oclifSectionText.replace(/\/build\//g, '/lib/');
 	} else {
-		oclifSectionText = oclifSectionText.replace(/lib/g, 'build')
+		oclifSectionText = oclifSectionText.replace(/\/lib\//g, '/build/');
 	}
 
 	packageObj.oclif = JSON.parse(oclifSectionText);
-	fs.writeFileSync(path, `${JSON.stringify(packageObj,  null, 2)}\n`, 'utf8');
+	fs.writeFileSync(
+		packageJsonPath,
+		`${JSON.stringify(packageObj, null, 2)}\n`,
+		'utf8',
+	);
 }

--- a/bin/balena-dev
+++ b/bin/balena-dev
@@ -1,13 +1,25 @@
 #!/usr/bin/env node
 
 // ****************************************************************************
-// THIS IS FOR DEV PERROSES ONLY AND WILL NOT BE PART OF THE PUBLISHED PACKAGE
+// THIS IS FOR DEV PURPOSES ONLY AND WILL NOT BE PART OF THE PUBLISHED PACKAGE
 // Before opening a PR you should build and test your changes using bin/balena
 // ****************************************************************************
 
 // We boost the threadpool size as ext2fs can deadlock with some
 // operations otherwise, if the pool runs out.
 process.env.UV_THREADPOOL_SIZE = '64';
+
+// Allow balena-dev to work with oclif by temporarily
+// pointing oclif config options to lib/ instead of build/
+modifyOclifPaths();
+// Undo changes on exit
+process.on('exit', function() {
+	modifyOclifPaths(true);
+});
+// Undo changes in case of ctrl-v
+process.on('SIGINT', function() {
+	modifyOclifPaths(true);
+});
 
 // Use fast-boot to cache require lookups, speeding up startup
 require('fast-boot2').start({
@@ -30,3 +42,24 @@ require('ts-node').register({
 	transpileOnly: true,
 });
 require('../lib/app').run();
+
+// Modify package.json oclif paths from build/ -> lib/, or vice versa
+function modifyOclifPaths(revert) {
+	const fs = require('fs');
+	const path = './package.json';
+
+	const packageJson = fs.readFileSync(path, 'utf8');
+	const packageObj = JSON.parse(packageJson);
+
+	if(!packageObj.oclif) { return; }
+
+	let oclifSectionText = JSON.stringify(packageObj.oclif);
+	if(!revert) {
+		oclifSectionText = oclifSectionText.replace(/build/g, 'lib')
+	} else {
+		oclifSectionText = oclifSectionText.replace(/lib/g, 'build')
+	}
+
+	packageObj.oclif = JSON.parse(oclifSectionText);
+	fs.writeFileSync(path, `${JSON.stringify(packageObj,  null, 2)}\n`, 'utf8');
+}

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "catch-uncommitted": "ts-node --transpile-only automation/run.ts catch-uncommitted",
     "ci": "npm run test && npm run catch-uncommitted",
     "watch": "gulp watch",
-    "lint": "balena-lint -e ts -e js --typescript --fix automation/ lib/ typings/ tests/ gulpfile.js",
+    "lint": "balena-lint -e ts -e js --typescript --fix automation/ lib/ typings/ tests/ bin/balena bin/balena-dev gulpfile.js",
     "update": "ts-node --transpile-only ./automation/update-module.ts",
     "prepare": "echo {} > bin/.fast-boot.json",
     "prepublishOnly": "npm run build"


### PR DESCRIPTION
Works around balena-dev/oclif compatibility issues, but modifying the oclif config
stored in package.json (using lib/ instead of /bin in paths), and undoing changes after execution.

Change-type: patch
Signed-off-by: Scott Lowe <scott@balena.io>
