### PR TITLE
Fix preload --add-certificate, amend help for `version`, and revert `balenaCLI` styling in docs

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,7 +1,7 @@
 
 # About this issue tracker
 
-*balenaCLI (Command Line Interface) is a tool used to interact with the balena platform.
+*The balena CLI (Command Line Interface) is a tool used to interact with the balena platform.
 This GitHub issue tracker is used for bug reports and feature requests regarding the CLI
 tool. General and troubleshooting questions (such as setting up your project to work with a
 balenalib base image) are encouraged to be posted to the [balena
@@ -12,7 +12,7 @@ community can both contribute and benefit from the answers.*
 the same problem or feature please add comments to the existing issue.*
 
 *Thank you for your time and effort creating the issue report, and helping us improve
-balenaCLI!*
+the balena CLI!*
 
 ---
 
@@ -63,7 +63,7 @@ fixed it.
 
 # Specifications
 
-- **balenaCLI version:** e.g. 1.2.3 (output of the `"balena version -a"` command)
+- **balena CLI version:** e.g. 1.2.3 (output of the `"balena version -a"` command)
 - **Cloud backend: openBalena or balenaCloud?** If unsure, it will be balenaCloud
 - **Operating system version:** e.g. Windows 10, Ubuntu 18.04, macOS 10.14.5
 - **32/64 bit OS and processor:** e.g. 32-bit Windows on 64-bit Intel processor

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-balenaCLI is an open source project and your contribution is welcome!
+The balena CLI is an open source project and your contribution is welcome!
 
 * Install the dependencies listed in the [NPM Installation
   section](./INSTALL-ADVANCED.md#npm-installation) section of the installation instructions. Check

--- a/INSTALL-ADVANCED.md
+++ b/INSTALL-ADVANCED.md
@@ -1,4 +1,4 @@
-# balenaCLI Advanced Installation Options
+# balena CLI Advanced Installation Options
 
 **These are alternative, advanced installation options. Most users would prefer the [recommended,
 streamlined installation
@@ -8,11 +8,11 @@ There are 3 options to choose from to install balena's CLI:
 
 * [Executable Installer](#executable-installer): the easiest method on Windows and macOS, using the
   traditional graphical desktop application installers.
-* [Standalone Zip Package](#standalone-zip-package): these are plain zip files with the balenaCLI
+* [Standalone Zip Package](#standalone-zip-package): these are plain zip files with the balena CLI
   executable in them: extract and run. Available for all platforms: Linux, Windows, macOS.
   Recommended also for scripted installation in CI (continuous integration) environments.
 * [NPM Installation](#npm-installation): recommended for Node.js developers who may be interested
-  in integrating balenaCLI in their existing projects or workflow.
+  in integrating the balena CLI in their existing projects or workflow.
 
 Some specific CLI commands have a few extra installation steps: see section [Additional
 Dependencies](#additional-dependencies).
@@ -74,7 +74,7 @@ as described above.
 
 ## NPM Installation
 
-If you are a Node.js developer, you may wish to install balenaCLI via [npm](https://www.npmjs.com).
+If you are a Node.js developer, you may wish to install the balena CLI via [npm](https://www.npmjs.com).
 The npm installation involves building native (platform-specific) binary modules, which require
 some additional development tools to be installed first:
 
@@ -112,7 +112,7 @@ On **Windows (not WSL),** the dependencies above and additional ones can be met 
   
   `npm install -g --production windows-build-tools`
 
-With these dependencies in place, the balenaCLI installation command is:
+With these dependencies in place, the balena CLI installation command is:
 
 ```sh
 $ npm install balena-cli -g --production --unsafe-perm

--- a/INSTALL-LINUX.md
+++ b/INSTALL-LINUX.md
@@ -1,4 +1,4 @@
-# balenaCLI Installation Instructions for Linux
+# balena CLI Installation Instructions for Linux
 
 These instructions are for the recommended installation option. They are suitable for most Linux
 distributions, except notably for **Linux Alpine** or **Busybox**. For these distros, see [advanced
@@ -20,14 +20,14 @@ Selected operating system: **Linux**
 
 4. Check that the installation was successful by running the following commands on a
    command terminal:  
-   * `balena version` - should print balenaCLI's version
+   * `balena version` - should print the CLI's version
    * `balena help` - should print a list of available commands
 
-No further steps are required to run most balenaCLI commands. The `balena ssh`, `scan`, `build`,
+No further steps are required to run most CLI commands. The `balena ssh`, `scan`, `build`,
 `deploy` and `preload` commands may require additional software to be installed, as described
 below.
 
-To update balenaCLI to a new version, download a new release zip file and replace the previous
+To update the balena CLI to a new version, download a new release zip file and replace the previous
 installation folder. To uninstall, simply delete the folder and edit the PATH environment variable
 as described above.
 
@@ -39,7 +39,7 @@ These commands require [Docker](https://docs.docker.com/install/overview/) or
 [balenaEngine](https://www.balena.io/engine/) to be available (on a local or remote machine). Most
 users will simply follow [Docker's installation
 instructions](https://docs.docker.com/install/overview/) to install Docker on the same laptop (dev
-machine) where balenaCLI is installed. The [advanced installation
+machine) where the balena CLI is installed. The [advanced installation
 options](./INSTALL-ADVANCED.md) document describes other possibilities.
 
 ### balena ssh

--- a/INSTALL-MAC.md
+++ b/INSTALL-MAC.md
@@ -1,4 +1,4 @@
-# balenaCLI Installation Instructions for macOS
+# balena CLI Installation Instructions for macOS
 
 These instructions are for the recommended installation option. Advanced users may also be
 interested in [advanced installation options](./INSTALL-ADVANCED.md).
@@ -18,10 +18,10 @@ Selected operating system: **macOS**
 
 3. Check that the installation was successful by running the following commands on a
    command terminal:  
-   * `balena version` - should print balenaCLI's version
+   * `balena version` - should print the CLI's version
    * `balena help` - should print a list of available commands
 
-No further steps are required to run most balenaCLI commands. The `balena ssh`, `build`, `deploy`
+No further steps are required to run most CLI commands. The `balena ssh`, `build`, `deploy`
 and `preload` commands may require additional software to be installed, as described below.
 
 ## Additional Dependencies
@@ -32,7 +32,7 @@ These commands require [Docker](https://docs.docker.com/install/overview/) or
 [balenaEngine](https://www.balena.io/engine/) to be available (on a local or remote machine). Most
 users will simply follow [Docker's installation
 instructions](https://docs.docker.com/install/overview/) to install Docker on the same laptop (dev
-machine) where balenaCLI is installed. The [advanced installation
+machine) where the balena CLI is installed. The [advanced installation
 options](./INSTALL-ADVANCED.md) document describes other possibilities.
 
 ### balena ssh
@@ -62,7 +62,7 @@ present workaround is to either:
 
 * Downgrade Docker Desktop to version 18.06.1. Link: [Docker CE for
   Mac](https://docs.docker.com/docker-for-mac/release-notes/#docker-community-edition-18061-ce-mac73-2018-08-29)
-* Install balenaCLI on a Linux machine (as Docker for Linux still supports AUFS). A Linux Virtual
-  Machine also works, but a Docker container is _not_ recommended.
+* Install the balena CLI on a Linux machine (as Docker for Linux still supports AUFS). A Linux
+  Virtual Machine also works, but a Docker container is _not_ recommended.
 
 Long term, we are working on replacing AUFS with overlay2 for the affected device types.

--- a/INSTALL-WINDOWS.md
+++ b/INSTALL-WINDOWS.md
@@ -1,4 +1,4 @@
-# balenaCLI Installation Instructions for Windows
+# balena CLI Installation Instructions for Windows
 
 These instructions are for the recommended installation option. Advanced users may also be
 interested in [advanced installation options](./INSTALL-ADVANCED.md).
@@ -18,10 +18,10 @@ Selected operating system: **Windows**
 
 3. Check that the installation was successful by running the following commands on a
    command terminal:  
-   * `balena version` - should print balenaCLI's version
+   * `balena version` - should print the CLI's version
    * `balena help` - should print a list of available commands
 
-No further steps are required to run most balenaCLI commands. The `balena ssh`, `scan`, `build`,
+No further steps are required to run most CLI commands. The `balena ssh`, `scan`, `build`,
 `deploy`, `preload` and `os configure` commands may require additional software to be installed, as
 described below.
 
@@ -33,7 +33,7 @@ These commands require [Docker](https://docs.docker.com/install/overview/) or
 [balenaEngine](https://www.balena.io/engine/) to be available (on a local or remote machine). Most
 users will simply follow [Docker's installation
 instructions](https://docs.docker.com/install/overview/) to install Docker on the same laptop (dev
-machine) where balenaCLI is installed. The [advanced installation
+machine) where the balena CLI is installed. The [advanced installation
 options](./INSTALL-ADVANCED.md) document describes other possibilities.
 
 ### balena ssh
@@ -69,8 +69,8 @@ present workaround is to either:
 
 * Downgrade Docker Desktop to version 18.06.1. Link: [Docker CE for
   Windows](https://docs.docker.com/docker-for-windows/release-notes/#docker-community-edition-18061-ce-win73-2018-08-29)
-* Install balenaCLI on a Linux machine (as Docker for Linux still supports AUFS). A Linux Virtual
-  Machine also works, but a Docker container is _not_ recommended.
+* Install the balena CLI on a Linux machine (as Docker for Linux still supports AUFS). A Linux
+  Virtual Machine also works, but a Docker container is _not_ recommended.
 
 Long term, we are working on replacing AUFS with overlay2 for the affected device types.
 
@@ -78,5 +78,5 @@ Long term, we are working on replacing AUFS with overlay2 for the affected devic
 
 * The `balena os configure` command is currently not supported on Windows natively, but works with
   the [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/about) (WSL). When
-  using WSL, [install balenaCLI for
+  using WSL, [install the balena CLI for
   Linux](https://github.com/balena-io/balena-cli/blob/master/INSTALL-LINUX.md).

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,4 +1,4 @@
-# balenaCLI Installation Instructions
+# balena CLI Installation Instructions
 
 Please select your operating system:
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# balenaCLI
+# balena CLI
 
 The official balena Command Line Interface.
 
@@ -7,17 +7,17 @@ The official balena Command Line Interface.
 
 ## About
 
-balenaCLI is a Command Line Interface for [balenaCloud](https://www.balena.io/cloud/) or
+The balena CLI is a Command Line Interface for [balenaCloud](https://www.balena.io/cloud/) or
 [openBalena](https://www.balena.io/open/). It is a software tool available for Windows, macOS and
 Linux, used through a command prompt / terminal window. It can be used interactively or invoked in
-scripts. balenaCLI builds on the [balena API](https://www.balena.io/docs/reference/api/overview/)
+scripts. The balena CLI builds on the [balena API](https://www.balena.io/docs/reference/api/overview/)
 and the [balena SDK](https://www.balena.io/docs/reference/sdk/node-sdk/), and can also be directly
-imported in Node.js applications. balenaCLI is an [open-source project on
+imported in Node.js applications. The balena CLI is an [open-source project on
 GitHub](https://github.com/balena-io/balena-cli/), and your contribution is also welcome!
 
 ## Installation
 
-Check the [balenaCLI installation instructions on
+Check the [balena CLI installation instructions on
 GitHub](https://github.com/balena-io/balena-cli/blob/master/INSTALL.md).
 
 ## Choosing a shell (command prompt/terminal)
@@ -42,9 +42,9 @@ are supported. Alternative shells include:
     [comment](https://github.com/balena-io/balena-cli/issues/598#issuecomment-556513098).
 * Microsoft's [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/about)
   (WSL). In this case, a Linux distribution like Ubuntu is installed via the Microsoft Store, and a
-  balenaCLI release **for Linux** should be selected. See
-  [FAQ](https://github.com/balena-io/balena-cli/blob/master/TROUBLESHOOTING.md) for using balenaCLI
-  with WSL and Docker Desktop for Windows.
+  balena CLI release **for Linux** should be selected. See
+  [FAQ](https://github.com/balena-io/balena-cli/blob/master/TROUBLESHOOTING.md) for using the
+  balena CLI with WSL and Docker Desktop for Windows.
 
 On **macOS** and **Linux,** the standard terminal window is supported. Optionally, `bash` command
 auto completion may be enabled by copying the
@@ -106,7 +106,7 @@ server, it should be configured with the following rules in the `squid.conf` fil
 
 The `BALENARC_NO_PROXY` variable may be used to exclude specified destinations from proxying.
 
-> * This feature requires balenaCLI version 11.30.8 or later. In the case of the npm [installation
+> * This feature requires CLI version 11.30.8 or later. In the case of the npm [installation
 >   option](https://github.com/balena-io/balena-cli/blob/master/INSTALL.md), it also requires
 >   Node.js version 10.16.0 or later.
 > * To exclude a `balena ssh` target from proxying (IP address or `.local` hostname), the
@@ -148,19 +148,19 @@ If you come across any problems or would like to get in touch:
 
 ## Deprecation policy
 
-balenaCLI uses [semver versioning](https://semver.org/), with the concepts
+The balena CLI uses [semver versioning](https://semver.org/), with the concepts
 of major, minor and patch version releases.
 
-The latest release of a major version of balenaCLI will remain compatible with
+The latest release of a major version of the balena CLI will remain compatible with
 the balenaCloud backend services for at least one year from the date when the
-following major version is released. For example, balenaCLI v10.17.5, as the
+following major version is released. For example, balena CLI v10.17.5, as the
 latest v10 release, would remain compatible with the balenaCloud backend for one
 year from the date when v11.0.0 is released.
 
 At the end of this period, the older major version is considered deprecated and
 some of the functionality that depends on balenaCloud services may stop working
 at any time.
-Users are encouraged to regularly update balenaCLI to the latest version.
+Users are encouraged to regularly update the balena CLI to the latest version.
 
 ## Contributing (including editing documentation files)
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,23 +1,23 @@
-# balenaCLI FAQ & Troubleshooting
+# balena CLI FAQ & Troubleshooting
 
-## Where is balenaCLI's configuration file located?
+## Where is the balena CLI's configuration file located?
 
 The per-user configuration file lives in `$HOME/.balenarc.yml` or `%UserProfile%\_balenarc.yml`, in
 Unix based operating systems and Windows respectively.
 
-balenaCLI also attempts to read a `balenarc.yml` file in the current directory, which takes
+The balena CLI also attempts to read a `balenarc.yml` file in the current directory, which takes
 precedence over the per-user configuration file.
 
-## How do I point balenaCLI to the staging environment?
+## How do I point the balena CLI to the staging environment?
 
 Set the `BALENARC_BALENA_URL=balena-staging.com` environment variable, or add
-`balenaUrl: balena-staging.com` to balenaCLI's configuration file.
+`balenaUrl: balena-staging.com` to the balena CLI's configuration file.
 
-## How do I make balenaCLI persist data in another directory?
+## How do I make the balena CLI persist data in another directory?
 
-balenaCLI persists the session token, as well as cached assets, to `$HOME/.balena` or
+The balena CLI persists the session token, as well as cached assets, to `$HOME/.balena` or
 `%UserProfile%\_balena`. This directory can be changed by setting an environment variable,
-`BALENARC_DATA_DIRECTORY=/opt/balena`, or by adding `dataDirectory: /opt/balena` to balenaCLI's
+`BALENARC_DATA_DIRECTORY=/opt/balena`, or by adding `dataDirectory: /opt/balena` to the CLI's
 configuration file, replacing `/opt/balena` with the desired directory.
 
 ## After burning to an SD card, my device doesn't boot
@@ -64,9 +64,9 @@ Or in Windows:
 
 ## I get `EACCES: permission denied` when logging in
 
-balenaCLI stores the session token in `$HOME/.balena` or `C:\Users\<user>\_balena` in UNIX based
+The balena CLI stores the session token in `$HOME/.balena` or `C:\Users\<user>\_balena` in UNIX based
 operating systems and Windows respectively. This error usually indicates that the user doesn't have
-permissions over that directory, which can happen if balenaCLI was executed as the `root` user.
+permissions over that directory, which can happen if the CLI was executed as the `root` user.
 
 Try resetting the ownership by running:
 
@@ -76,7 +76,15 @@ $ sudo chown -R <user> $HOME/.balena
 
 ## Broken line wrapping / cursor behavior with `balena ssh`
 
-Users sometimes come across broken line wrapping or cursor behavior in text terminals, for example when long command lines are typed in a `balena ssh` session, or when using text editors like `vim` or `nano`. This is not something specific to balenaCLI, being also a commonly reported issue with standard remote terminal tools like `ssh` or `telnet`. It is often a remote shell configuration issue (files like `/etc/profile`, `~/.bash_profile`, `~/.bash_login`, `~/.profile` and the like), including UTF-8 misconfiguration, the use of unsupported ASCII control characters in shell prompt formatting (e.g. the `$PS1` env var) or the output of tools or log files that use colored text. The issue can sometimes be fixed by resizing the client terminal window, or by running one or more of the following commands on the shell:
+Users sometimes come across broken line wrapping or cursor behavior in text terminals, for example
+when long command lines are typed in a `balena ssh` session, or when using text editors like `vim`
+or `nano`. This is not something specific to the balena CLI, being also a commonly reported issue
+with standard remote terminal tools like `ssh` or `telnet`.  It is often a remote shell
+configuration issue (files like `/etc/profile`, `~/.bash_profile`, `~/.bash_login`, `~/.profile`
+and the like on the remote machine), including UTF-8 misconfiguration, the use of unsupported ASCII
+control characters in shell prompt formatting (e.g. the `$PS1` env var) or the output of tools or
+log files that use colored text. The issue can sometimes be fixed by simply resizing the client
+terminal window, or by running one or more of the following commands on the shell:
 
 ```sh
 export TERMINAL=linux

--- a/automation/capitanodoc/capitanodoc.ts
+++ b/automation/capitanodoc/capitanodoc.ts
@@ -26,7 +26,7 @@ import { MarkdownFileParser } from './utils';
  * some content to this object.
  */
 const capitanoDoc = {
-	title: 'balenaCLI Documentation',
+	title: 'balena CLI Documentation',
 	introduction: '',
 	categories: [
 		{

--- a/automation/capitanodoc/utils.ts
+++ b/automation/capitanodoc/utils.ts
@@ -57,7 +57,7 @@ export class MarkdownFileParser {
 	 * Extract the lines of a markdown document section with the given title.
 	 * For example, consider this sample markdown document:
 	 * ```
-	 *     # balenaCLI
+	 *     # balena CLI
 	 *
 	 *     ## Introduction
 	 *     Lorem ipsum dolor sit amet, consectetur adipiscing elit,

--- a/doc/cli.markdown
+++ b/doc/cli.markdown
@@ -1,16 +1,16 @@
-# balenaCLI Documentation
+# balena CLI Documentation
 
-balenaCLI is a Command Line Interface for [balenaCloud](https://www.balena.io/cloud/) or
+The balena CLI is a Command Line Interface for [balenaCloud](https://www.balena.io/cloud/) or
 [openBalena](https://www.balena.io/open/). It is a software tool available for Windows, macOS and
 Linux, used through a command prompt / terminal window. It can be used interactively or invoked in
-scripts. balenaCLI builds on the [balena API](https://www.balena.io/docs/reference/api/overview/)
+scripts. The balena CLI builds on the [balena API](https://www.balena.io/docs/reference/api/overview/)
 and the [balena SDK](https://www.balena.io/docs/reference/sdk/node-sdk/), and can also be directly
-imported in Node.js applications. balenaCLI is an [open-source project on
+imported in Node.js applications. The balena CLI is an [open-source project on
 GitHub](https://github.com/balena-io/balena-cli/), and your contribution is also welcome!
 
 ## Installation
 
-Check the [balenaCLI installation instructions on
+Check the [balena CLI installation instructions on
 GitHub](https://github.com/balena-io/balena-cli/blob/master/INSTALL.md).
 
 ## Choosing a shell (command prompt/terminal)
@@ -35,9 +35,9 @@ are supported. Alternative shells include:
     [comment](https://github.com/balena-io/balena-cli/issues/598#issuecomment-556513098).
 * Microsoft's [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/about)
   (WSL). In this case, a Linux distribution like Ubuntu is installed via the Microsoft Store, and a
-  balenaCLI release **for Linux** should be selected. See
-  [FAQ](https://github.com/balena-io/balena-cli/blob/master/TROUBLESHOOTING.md) for using balenaCLI
-  with WSL and Docker Desktop for Windows.
+  balena CLI release **for Linux** should be selected. See
+  [FAQ](https://github.com/balena-io/balena-cli/blob/master/TROUBLESHOOTING.md) for using the
+  balena CLI with WSL and Docker Desktop for Windows.
 
 On **macOS** and **Linux,** the standard terminal window is supported. Optionally, `bash` command
 auto completion may be enabled by copying the
@@ -99,7 +99,7 @@ server, it should be configured with the following rules in the `squid.conf` fil
 
 The `BALENARC_NO_PROXY` variable may be used to exclude specified destinations from proxying.
 
-> * This feature requires balenaCLI version 11.30.8 or later. In the case of the npm [installation
+> * This feature requires CLI version 11.30.8 or later. In the case of the npm [installation
 >   option](https://github.com/balena-io/balena-cli/blob/master/INSTALL.md), it also requires
 >   Node.js version 10.16.0 or later.
 > * To exclude a `balena ssh` target from proxying (IP address or `.local` hostname), the
@@ -136,19 +136,19 @@ If you come across any problems or would like to get in touch:
 
 ## Deprecation policy
 
-balenaCLI uses [semver versioning](https://semver.org/), with the concepts
+The balena CLI uses [semver versioning](https://semver.org/), with the concepts
 of major, minor and patch version releases.
 
-The latest release of a major version of balenaCLI will remain compatible with
+The latest release of a major version of the balena CLI will remain compatible with
 the balenaCloud backend services for at least one year from the date when the
-following major version is released. For example, balenaCLI v10.17.5, as the
+following major version is released. For example, balena CLI v10.17.5, as the
 latest v10 release, would remain compatible with the balenaCloud backend for one
 year from the date when v11.0.0 is released.
 
 At the end of this period, the older major version is considered deprecated and
 some of the functionality that depends on balenaCloud services may stop working
 at any time.
-Users are encouraged to regularly update balenaCLI to the latest version.
+Users are encouraged to regularly update the balena CLI to the latest version.
 
 
 # CLI Command Reference
@@ -941,7 +941,7 @@ Examples:
 
 #### --all
 
-No-op since balenaCLI v12.0.0.
+No-op since balena CLI v12.0.0.
 
 #### -a, --application APPLICATION
 
@@ -1302,8 +1302,8 @@ show additional commands
 
 ## version
 
-Display version information for balenaCLI and/or Node.js. Note that the
-balenaCLI executable installers for Windows and macOS, and the standalone
+Display version information for the balena CLI and/or Node.js. Note that the
+balena CLI executable installers for Windows and macOS, and the standalone
 zip packages, ship with a built-in copy of Node.js.  In this case, the
 reported version of Node.js regards this built-in copy, rather than any
 other `node` engine that may also be available on the command prompt.
@@ -1758,7 +1758,7 @@ A suitable key is automatically generated or fetched if this option is omitted.
 
 Note: This command is currently not supported on Windows natively. Windows users
 are advised to install the Windows Subsystem for Linux (WSL) with Ubuntu, and use
-the Linux release of balenaCLI:
+the Linux release of the balena CLI:
 https://docs.microsoft.com/en-us/windows/wsl/about
 
 Examples:
@@ -2177,7 +2177,7 @@ secrets.json file exists in the balena directory (usually $HOME/.balena),
 this file will be used instead.
 
 DOCKERIGNORE AND GITIGNORE FILES  
-By default, balenaCLI will use a single ".dockerignore" file (if any) at
+By default, the balena CLI will use a single ".dockerignore" file (if any) at
 the project root (--source directory) in order to decide which source files to
 exclude from the "build context" (tar stream) sent to balenaCloud, Docker
 daemon or balenaEngine. In a microservices (multicontainer) application, the
@@ -2202,7 +2202,7 @@ compatibility with the standard docker-compose tool, while still allowing a
 root .dockerignore file (at the overall project root) to filter files and
 folders that are outside service subdirectories.
 
-balenaCLI releases older than v12.0.0 also took .gitignore files into account.
+balena CLI releases older than v12.0.0 also took .gitignore files into account.
 This behavior is deprecated, but may still be enabled with the --gitignore (-g)
 option if compatibility is required. This option is mutually exclusive with
 --multi-dockerignore (-m) and will be removed in the CLI's next major version
@@ -2330,7 +2330,7 @@ left hand side of the = character will be treated as the variable name.
 
 #### -l, --convert-eol
 
-No-op and deprecated since balenaCLI v12.0.0
+No-op and deprecated since balena CLI v12.0.0
 
 #### --noconvert-eol
 
@@ -2342,7 +2342,7 @@ Have each service use its own .dockerignore file. See "balena help push".
 
 #### -G, --nogitignore
 
-No-op (default behavior) since balenaCLI v12.0.0. See "balena help push".
+No-op (default behavior) since balena CLI v12.0.0. See "balena help push".
 
 #### -g, --gitignore
 
@@ -2354,7 +2354,7 @@ required until your project can be adapted.
 
 ## settings
 
-Use this command to display current balenaCLI settings.
+Use this command to display the current balena CLI settings.
 
 Examples:
 
@@ -2454,7 +2454,7 @@ secrets.json file exists in the balena directory (usually $HOME/.balena),
 this file will be used instead.
 
 DOCKERIGNORE AND GITIGNORE FILES  
-By default, balenaCLI will use a single ".dockerignore" file (if any) at
+By default, the balena CLI will use a single ".dockerignore" file (if any) at
 the project root (--source directory) in order to decide which source files to
 exclude from the "build context" (tar stream) sent to balenaCloud, Docker
 daemon or balenaEngine. In a microservices (multicontainer) application, the
@@ -2479,7 +2479,7 @@ compatibility with the standard docker-compose tool, while still allowing a
 root .dockerignore file (at the overall project root) to filter files and
 folders that are outside service subdirectories.
 
-balenaCLI releases older than v12.0.0 also took .gitignore files into account.
+balena CLI releases older than v12.0.0 also took .gitignore files into account.
 This behavior is deprecated, but may still be enabled with the --gitignore (-g)
 option if compatibility is required. This option is mutually exclusive with
 --multi-dockerignore (-m) and will be removed in the CLI's next major version
@@ -2544,7 +2544,7 @@ Alternative Dockerfile name/path, relative to the source folder
 
 #### --logs
 
-No-op and deprecated since balenaCLI v12.0.0. Build logs are now shown by default.
+No-op and deprecated since balena CLI v12.0.0. Build logs are now shown by default.
 
 #### --nologs
 
@@ -2562,7 +2562,7 @@ Have each service use its own .dockerignore file. See "balena help build".
 
 #### -G, --nogitignore
 
-No-op (default behavior) since balenaCLI v12.0.0. See "balena help build".
+No-op (default behavior) since balena CLI v12.0.0. See "balena help build".
 
 #### --noparent-check
 
@@ -2574,7 +2574,7 @@ Path to a YAML or JSON file with passwords for a private Docker registry
 
 #### -l, --convert-eol
 
-No-op and deprecated since balenaCLI v12.0.0
+No-op and deprecated since balena CLI v12.0.0
 
 #### --noconvert-eol
 
@@ -2676,7 +2676,7 @@ secrets.json file exists in the balena directory (usually $HOME/.balena),
 this file will be used instead.
 
 DOCKERIGNORE AND GITIGNORE FILES  
-By default, balenaCLI will use a single ".dockerignore" file (if any) at
+By default, the balena CLI will use a single ".dockerignore" file (if any) at
 the project root (--source directory) in order to decide which source files to
 exclude from the "build context" (tar stream) sent to balenaCloud, Docker
 daemon or balenaEngine. In a microservices (multicontainer) application, the
@@ -2701,7 +2701,7 @@ compatibility with the standard docker-compose tool, while still allowing a
 root .dockerignore file (at the overall project root) to filter files and
 folders that are outside service subdirectories.
 
-balenaCLI releases older than v12.0.0 also took .gitignore files into account.
+balena CLI releases older than v12.0.0 also took .gitignore files into account.
 This behavior is deprecated, but may still be enabled with the --gitignore (-g)
 option if compatibility is required. This option is mutually exclusive with
 --multi-dockerignore (-m) and will be removed in the CLI's next major version
@@ -2767,7 +2767,7 @@ Alternative Dockerfile name/path, relative to the source folder
 
 #### --logs
 
-No-op and deprecated since balenaCLI v12.0.0. Build logs are now shown by default.
+No-op and deprecated since balena CLI v12.0.0. Build logs are now shown by default.
 
 #### --nologs
 
@@ -2785,7 +2785,7 @@ Have each service use its own .dockerignore file. See "balena help build".
 
 #### -G, --nogitignore
 
-No-op (default behavior) since balenaCLI v12.0.0. See "balena help build".
+No-op (default behavior) since balena CLI v12.0.0. See "balena help build".
 
 #### --noparent-check
 
@@ -2797,7 +2797,7 @@ Path to a YAML or JSON file with passwords for a private Docker registry
 
 #### -l, --convert-eol
 
-No-op and deprecated since balenaCLI v12.0.0
+No-op and deprecated since balena CLI v12.0.0
 
 #### --noconvert-eol
 

--- a/doc/cli.markdown
+++ b/doc/cli.markdown
@@ -2072,7 +2072,7 @@ the image file path
 
 #### -a, --app APP
 
-name, slug or numeric ID of the application to preload
+name of the application to preload
 
 #### -c, --commit COMMIT
 

--- a/doc/cli.markdown
+++ b/doc/cli.markdown
@@ -1302,7 +1302,11 @@ show additional commands
 
 ## version
 
-Display version information for balenaCLI and/or Node.js.
+Display version information for balenaCLI and/or Node.js. Note that the
+balenaCLI executable installers for Windows and macOS, and the standalone
+zip packages, ship with a built-in copy of Node.js.  In this case, the
+reported version of Node.js regards this built-in copy, rather than any
+other `node` engine that may also be available on the command prompt.
 
 The --json option is recommended when scripting the output of this command,
 because the JSON format is less likely to change and it better represents

--- a/lib/auth/index.ts
+++ b/lib/auth/index.ts
@@ -22,7 +22,7 @@ import { LoginServer } from './server';
  */
 
 /**
- * @summary Login to balenaCLI using the web dashboard
+ * @summary Login to the balena CLI using the web dashboard
  * @function
  * @public
  *

--- a/lib/auth/pages/error.ejs
+++ b/lib/auth/pages/error.ejs
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="x-ua-compatible" content="ie=edge">
-	<title>balenaCLI - Error</title>
+	<title>balena CLI - Error</title>
 	<meta name="description" content="">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<link rel="stylesheet" type="text/css" href="./static/style.css" inline>
@@ -13,7 +13,7 @@
 		<img class="icon" src="./static/images/sad.png" inline>
 		<h1>Something went wrong</h1>
 		<br>
-		<p>The balenaCLI login was not successful.</p>
+		<p>The balena CLI login was not successful.</p>
 		<br>
 		<br>
 		<a href="https://forums.balena.io/" class="button danger">Get help in our forums</a>

--- a/lib/auth/pages/success.ejs
+++ b/lib/auth/pages/success.ejs
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="x-ua-compatible" content="ie=edge">
-	<title>balenaCLI - Success</title>
+	<title>balena CLI - Success</title>
 	<meta name="description" content="">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<link rel="stylesheet" type="text/css" href="./static/style.css" inline>
@@ -13,7 +13,7 @@
 		<img class="icon" src="./static/images/happy.png" inline>
 		<h1>Success!</h1>
 		<br>
-		<p>The balenaCLI login was successful.</p>
+		<p>The balena CLI login was successful.</p>
 		<p>You may now close this page and return to the command prompt.</p>
 	</div>
 </body>

--- a/lib/commands/envs.ts
+++ b/lib/commands/envs.ts
@@ -161,7 +161,7 @@ export default class EnvsCmd extends Command {
 			? {
 					all: flags.boolean({
 						description: stripIndent`
-				No-op since balenaCLI v12.0.0.`,
+				No-op since balena CLI v12.0.0.`,
 						hidden: true,
 					}),
 			  }

--- a/lib/commands/os/configure.ts
+++ b/lib/commands/os/configure.ts
@@ -90,7 +90,7 @@ export default class OsConfigureCmd extends Command {
 
 		Note: This command is currently not supported on Windows natively. Windows users
 		are advised to install the Windows Subsystem for Linux (WSL) with Ubuntu, and use
-		the Linux release of balenaCLI:
+		the Linux release of the balena CLI:
 		https://docs.microsoft.com/en-us/windows/wsl/about
 	`;
 	public static examples = [
@@ -297,11 +297,11 @@ async function validateOptions(options: FlagsDef) {
 		throw new ExpectedError(stripIndent`
 			Unsupported platform error: the 'balena os configure' command currently requires
 			the Windows Subsystem for Linux in order to run on Windows. It was tested with
-			the Ubuntu 18.04 distribution from the Microsoft Store. With WSL, a balenaCLI
+			the Ubuntu 18.04 distribution from the Microsoft Store. With WSL, a balena CLI
 			release for Linux (rather than Windows) should be installed: for example, the
 			standalone zip package for Linux. (It is possible to have both a Windows CLI
 			release and a Linux CLI release installed simultaneously.) For more information
-			on WSL and the balenaCLI installation options, please check:
+			on WSL and the balena CLI installation options, please check:
 			- https://docs.microsoft.com/en-us/windows/wsl/about
 			- https://github.com/balena-io/balena-cli/blob/master/INSTALL.md
 		`);

--- a/lib/commands/preload.ts
+++ b/lib/commands/preload.ts
@@ -43,7 +43,7 @@ interface FlagsDef extends DockerConnectionCliFlags {
 	'splash-image'?: string;
 	'dont-check-arch': boolean;
 	'pin-device-to-release': boolean;
-	'add-certificate'?: string;
+	'add-certificate'?: string[];
 	help: void;
 }
 
@@ -84,7 +84,7 @@ export default class PreloadCmd extends Command {
 
 	public static flags: flags.Input<FlagsDef> = {
 		app: flags.string({
-			description: 'name, slug or numeric ID of the application to preload',
+			description: 'name of the application to preload',
 			char: 'a',
 		}),
 		commit: flags.string({
@@ -115,6 +115,7 @@ The file name must end with '.crt' and must not be already contained in the prel
 /etc/ssl/certs folder.
 Can be repeated to add multiple certificates.\
 `,
+			multiple: true,
 		}),
 		...dockerConnectionCliFlags,
 		// Redefining --dockerPort here (defined already in dockerConnectionCliFlags)
@@ -201,14 +202,7 @@ Can be repeated to add multiple certificates.\
 			);
 		}
 
-		let certificates: string[];
-		if (Array.isArray(options['add-certificate'])) {
-			certificates = options['add-certificate'];
-		} else if (options['add-certificate'] === undefined) {
-			certificates = [];
-		} else {
-			certificates = [options['add-certificate']];
-		}
+		const certificates: string[] = options['add-certificate'] || [];
 		for (const certificate of certificates) {
 			if (!certificate.endsWith('.crt')) {
 				throw new ExpectedError('Certificate file name must end with ".crt"');

--- a/lib/commands/push.ts
+++ b/lib/commands/push.ts
@@ -197,7 +197,7 @@ export default class PushCmd extends Command {
 			multiple: true,
 		}),
 		'convert-eol': flags.boolean({
-			description: 'No-op and deprecated since balenaCLI v12.0.0',
+			description: 'No-op and deprecated since balena CLI v12.0.0',
 			char: 'l',
 			hidden: true,
 		}),
@@ -212,7 +212,7 @@ export default class PushCmd extends Command {
 		}),
 		nogitignore: flags.boolean({
 			description:
-				'No-op (default behavior) since balenaCLI v12.0.0. See "balena help push".',
+				'No-op (default behavior) since balena CLI v12.0.0. See "balena help push".',
 			char: 'G',
 			hidden: true,
 		}),

--- a/lib/commands/settings.ts
+++ b/lib/commands/settings.ts
@@ -28,7 +28,7 @@ export default class SettingsCmd extends Command {
 	public static description = stripIndent`
 		Print current settings.
 
-		Use this command to display current balenaCLI settings.
+		Use this command to display the current balena CLI settings.
 `;
 	public static examples = ['$ balena settings'];
 

--- a/lib/commands/version.ts
+++ b/lib/commands/version.ts
@@ -34,7 +34,11 @@ export default class VersionCmd extends Command {
 	public static description = stripIndent`
 		Display version information for balenaCLI and/or Node.js.
 
-		Display version information for balenaCLI and/or Node.js.
+		Display version information for balenaCLI and/or Node.js. Note that the
+		balenaCLI executable installers for Windows and macOS, and the standalone
+		zip packages, ship with a built-in copy of Node.js.  In this case, the
+		reported version of Node.js regards this built-in copy, rather than any
+		other \`node\` engine that may also be available on the command prompt.
 
 		The --json option is recommended when scripting the output of this command,
 		because the JSON format is less likely to change and it better represents

--- a/lib/commands/version.ts
+++ b/lib/commands/version.ts
@@ -32,10 +32,10 @@ export interface JsonVersions {
 
 export default class VersionCmd extends Command {
 	public static description = stripIndent`
-		Display version information for balenaCLI and/or Node.js.
+		Display version information for the balena CLI and/or Node.js.
 
-		Display version information for balenaCLI and/or Node.js. Note that the
-		balenaCLI executable installers for Windows and macOS, and the standalone
+		Display version information for the balena CLI and/or Node.js. Note that the
+		balena CLI executable installers for Windows and macOS, and the standalone
 		zip packages, ship with a built-in copy of Node.js.  In this case, the
 		reported version of Node.js regards this built-in copy, rather than any
 		other \`node\` engine that may also be available on the command prompt.

--- a/lib/events.ts
+++ b/lib/events.ts
@@ -34,7 +34,7 @@ interface CachedUsername {
 }
 
 /**
- * Mixpanel.com analytics tracking (information on balenaCLI usage).
+ * Mixpanel.com analytics tracking (information on balena CLI usage).
  *
  * @param commandSignature A string like, for example:
  *      "push <applicationOrDevice>"
@@ -46,6 +46,9 @@ interface CachedUsername {
  * The username and command signature are also added as extra context
  * information in Sentry.io error reporting, for CLI debugging purposes
  * (mainly unexpected/unhandled exceptions -- see also `lib/errors.ts`).
+ *
+ * For more details on the data collected by balena generally, check this page:
+ * https://www.balena.io/docs/learn/more/collected-data/
  */
 export async function trackCommand(commandSignature: string) {
 	try {

--- a/lib/utils/compose_ts.ts
+++ b/lib/utils/compose_ts.ts
@@ -919,7 +919,7 @@ export const composeCliFlags: flags.Input<ComposeCliFlags> = {
 	}),
 	logs: flags.boolean({
 		description:
-			'No-op and deprecated since balenaCLI v12.0.0. Build logs are now shown by default.',
+			'No-op and deprecated since balena CLI v12.0.0. Build logs are now shown by default.',
 	}),
 	nologs: flags.boolean({
 		description:
@@ -938,7 +938,7 @@ export const composeCliFlags: flags.Input<ComposeCliFlags> = {
 		char: 'm',
 	}),
 	nogitignore: flags.boolean({
-		description: `No-op (default behavior) since balenaCLI v12.0.0. See "balena help build".`,
+		description: `No-op (default behavior) since balena CLI v12.0.0. See "balena help build".`,
 		char: 'G',
 	}),
 	'noparent-check': flags.boolean({
@@ -951,7 +951,7 @@ export const composeCliFlags: flags.Input<ComposeCliFlags> = {
 		char: 'R',
 	}),
 	'convert-eol': flags.boolean({
-		description: 'No-op and deprecated since balenaCLI v12.0.0',
+		description: 'No-op and deprecated since balena CLI v12.0.0',
 		char: 'l',
 	}),
 	'noconvert-eol': flags.boolean({

--- a/lib/utils/helpers.ts
+++ b/lib/utils/helpers.ts
@@ -69,7 +69,7 @@ export function stateToString(state: OperationState) {
  * bash/sh and the Windows cmd.exe in relation to escape characters.
  * @param msg Optional message for the user, before the password prompt
  * @param stderr Optional stream to which stderr should be piped
- * @param isCLIcmd (default: true) Whether the command array is a balenaCLI command
+ * @param isCLIcmd (default: true) Whether the command array is a balena CLI command
  * (e.g. ['internal', 'osinit', ...]), in which case process.argv[0] and argv[1] are
  * added as necessary, depending on whether the CLI is running as a standalone zip
  * package (with Node built in).

--- a/lib/utils/messages.ts
+++ b/lib/utils/messages.ts
@@ -69,7 +69,7 @@ this file will be used instead.`;
 
 export const dockerignoreHelp = `\
 DOCKERIGNORE AND GITIGNORE FILES  
-By default, balenaCLI will use a single ".dockerignore" file (if any) at
+By default, the balena CLI will use a single ".dockerignore" file (if any) at
 the project root (--source directory) in order to decide which source files to
 exclude from the "build context" (tar stream) sent to balenaCloud, Docker
 daemon or balenaEngine. In a microservices (multicontainer) application, the
@@ -94,7 +94,7 @@ compatibility with the standard docker-compose tool, while still allowing a
 root .dockerignore file (at the overall project root) to filter files and
 folders that are outside service subdirectories.
 
-balenaCLI releases older than v12.0.0 also took .gitignore files into account.
+balena CLI releases older than v12.0.0 also took .gitignore files into account.
 This behavior is deprecated, but may still be enabled with the --gitignore (-g)
 option if compatibility is required. This option is mutually exclusive with
 --multi-dockerignore (-m) and will be removed in the CLI's next major version

--- a/lib/utils/sudo.ts
+++ b/lib/utils/sudo.ts
@@ -31,7 +31,7 @@ import { stripIndent } from './lazy';
  * differences between bash/sh and the Windows cmd.exe in relation to escape
  * characters.
  * @param stderr Optional stream to which stderr should be piped
- * @param isCLIcmd (default: true) Whether the command array is a balenaCLI command
+ * @param isCLIcmd (default: true) Whether the command array is a balena CLI command
  * (e.g. ['internal', 'osinit', ...]), in which case process.argv[0] and argv[1] are
  * added as necessary, depending on whether the CLI is running as a standalone zip
  * package (with Node built in).

--- a/tests/commands/help.spec.ts
+++ b/tests/commands/help.spec.ts
@@ -87,7 +87,7 @@ ADDITIONAL COMMANDS
   tag set <tagKey> [value]               set a tag on an application, device or release
   tags                                   list all tags for an application, device or release
   util available-drives                  list available drives
-  version                                display version information for balenaCLI and/or Node.js
+  version                                display version information for the balena CLI and/or Node.js
   whoami                                 display account information for current user
 
 `;


### PR DESCRIPTION
* Revert `'balenaCLI'` styling (without space) as decided in:  
https://www.flowdock.com/app/rulemotion/r-product/threads/xrtkAC3uWDMJ4-4GkJL_Hmn8Jvb
* The update to `preload` help (`--app`) connects to issue #2068 
* The update to `version` help (Node.js version) connects to issue #2063 


Change-type: patch
