### PR TITLE
config generate: Fix "Application is ambiguous" when app slug is used

### DIFF
--- a/lib/commands/config/generate.ts
+++ b/lib/commands/config/generate.ts
@@ -130,7 +130,7 @@ export default class ConfigGenerateCmd extends Command {
 
 		await this.validateOptions(options);
 
-		let deviceType = options.deviceType;
+		let resourceDeviceType: string;
 		// Get device | application
 		let resource;
 		if (options.device != null) {
@@ -140,24 +140,26 @@ export default class ConfigGenerateCmd extends Command {
 					is_of__device_type: { $select: 'slug' },
 				},
 			})) as DeviceWithDeviceType & { belongs_to__application: PineDeferred };
-			deviceType = deviceType || resource.is_of__device_type[0].slug;
+			resourceDeviceType = resource.is_of__device_type[0].slug;
 		} else {
 			resource = (await balena.models.application.get(options.application!, {
 				$expand: {
 					is_for__device_type: { $select: 'slug' },
 				},
 			})) as ApplicationWithDeviceType;
-			deviceType = deviceType || resource.is_for__device_type[0].slug;
+			resourceDeviceType = resource.is_for__device_type[0].slug;
 		}
 
+		const deviceType = options.deviceType || resourceDeviceType;
+
 		const deviceManifest = await balena.models.device.getManifestBySlug(
-			deviceType!,
+			deviceType,
 		);
 
 		// Check compatibility if application and deviceType provided
 		if (options.application && options.deviceType) {
 			const appDeviceManifest = await balena.models.device.getManifestBySlug(
-				deviceType!,
+				resourceDeviceType,
 			);
 
 			const helpers = await import('../../utils/helpers');

--- a/lib/utils/config.ts
+++ b/lib/utils/config.ts
@@ -68,7 +68,7 @@ export async function generateBaseConfig(
 	};
 
 	const config = (await getBalenaSdk().models.os.getConfig(
-		application.app_name,
+		application.slug,
 		options,
 	)) as ImgConfig & { apiKey?: string };
 	// os.getConfig always returns a config for an app


### PR DESCRIPTION
Fixes two issues. First, the CLI incorrectly raises `BalenaAmbiguousApplication` when a fully-qualified slug is provided (as originally reported in https://github.com/balena-io/balena-cli/issues/1893#issuecomment-715635794):
```
$ ./bin/balena-dev config generate -a gh_paulo_castro/qemux86 --version 2.12.7 -o my-config.json
? Check for updates every X minutes 10
BalenaAmbiguousApplication: Application is ambiguous: qemux86
```
Second, PR #1969 accidentally broke the check for device type compatibility. The following command succeeds when it should not, as the `test-rpi` app (ARM) is not compatible with the Intel NUC device type:
```
$ ./bin/balena-dev config generate -a test-rpi --deviceType intel-nuc --version 2.12.7 -o my-config.json
? Network Connection ethernet
? Check for updates every X minutes 10
applicationId:         1301645
deviceType:            intel-nuc
userId:                43699
appUpdatePollInterval: 600000
listenPort:            48484
vpnPort:               443
apiEndpoint:           https://api.balena-cloud.com
vpnEndpoint:           vpn.balena-cloud.com
registryEndpoint:      registry2.balena-cloud.com
deltaEndpoint:         https://delta.balena-cloud.com
mixpanelToken:         9ef939ea64cb6cd8bbc96af72345d70d
apiKey:                bj63S5kBFCOvPGKKCVqRynuiP6a2kWX1```
```
The correct output should be:
```
$ ./bin/balena-dev config generate -a test-rpi --deviceType intel-nuc --version 2.12.7 -o my-config.json
BalenaInvalidDeviceType: Invalid device type: Device type intel-nuc is incompatible with application test-rpi
```

Connects-to: #1893 
Change-type: patch
