### PR TITLE
devices: Fix "TypeError: Cannot read property 'slug' of undefined"

### DIFF
--- a/doc/cli.markdown
+++ b/doc/cli.markdown
@@ -513,8 +513,9 @@ You can filter the devices by application by using the `--application` option.
 
 The --json option is recommended when scripting the output of this command,
 because field names are less likely to change in JSON format and because it
-better represents data types like arrays and empty strings. The 'jq' utility
-may also be helpful in shell scripts (https://stedolan.github.io/jq/manual/).
+better represents data types like arrays, empty strings and null values.
+The 'jq' utility may be helpful for querying JSON fields in shell scripts
+(https://stedolan.github.io/jq/manual/).
 
 Examples:
 

--- a/tests/commands/device/devices.spec.ts
+++ b/tests/commands/device/devices.spec.ts
@@ -40,8 +40,9 @@ DESCRIPTION
 
   The --json option is recommended when scripting the output of this command,
   because field names are less likely to change in JSON format and because it
-  better represents data types like arrays and empty strings. The 'jq' utility
-  may also be helpful in shell scripts (https://stedolan.github.io/jq/manual/).
+  better represents data types like arrays, empty strings and null values.
+  The 'jq' utility may be helpful for querying JSON fields in shell scripts
+  (https://stedolan.github.io/jq/manual/).
 
 EXAMPLES
   $ balena devices


### PR DESCRIPTION
```
$ balena devices --debug
[debug] new argv=[/Users/paulo/.nvm/versions/node/v12.19.0/bin/node,/Users/paulo/balena/balena-io/balena-cli/bin/balena-dev,devices] length=3
Cannot read property 'slug' of undefined

TypeError: Cannot read property 'slug' of undefined
    at /Users/paulo/balena/balena-io/balena-cli/lib/commands/devices/index.ts:28:63
    at Array.map (<anonymous>)
    at DevicesCmd.run (/Users/paulo/balena/balena-io/balena-cli/lib/commands/devices/index.ts:22:27)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
    at DevicesCmd._run (/Users/paulo/balena/balena-io/balena-cli/node_modules/@oclif/command/lib/command.js:43:20)
    at Config.runCommand (/Users/paulo/balena/balena-io/balena-cli/node_modules/@oclif/config/lib/config.js:175:24)
    at CustomMain.run (/Users/paulo/balena/balena-io/balena-cli/node_modules/@oclif/command/lib/main.js:27:9)
    at CustomMain._run (/Users/paulo/balena/balena-io/balena-cli/node_modules/@oclif/command/lib/command.js:43:20)
    at async Promise.all (index 1)
    at oclifRun (/Users/paulo/balena/balena-io/balena-cli/lib/app.ts:119:2)
```

Change-type: patch
