### PR TITLE
device move: Add '-name', '-uuid' and '-id' application and device options

### DIFF
--- a/doc/cli.markdown
+++ b/doc/cli.markdown
@@ -675,13 +675,45 @@ comma-separated list (no blank spaces) of device UUIDs to be moved
 
 ### Options
 
-#### -a, --application APPLICATION
+#### --uuid UUID
 
-application name
+comma-separated list of device UUIDs
+
+#### --id ID
+
+comma-separated list of numeric device database IDs
 
 #### --app APP
 
-same as '--application'
+alias for --application
+
+#### --app-name APP-NAME
+
+alias for --application-name
+
+#### --app-uuid APP-UUID
+
+alias for --application-uuid
+
+#### --app-id APP-ID
+
+alias for --application-id
+
+#### --application APPLICATION
+
+application name, UUID or numeric database ID
+
+#### --application-name APPLICATION-NAME
+
+application name
+
+#### --application-uuid APPLICATION-UUID
+
+application UUID
+
+#### --application-id APPLICATION-ID
+
+application numeric database ID
 
 ## device os-update &#60;uuid&#62;
 

--- a/lib/utils/common-flags.ts
+++ b/lib/utils/common-flags.ts
@@ -29,10 +29,54 @@ export const app = flags.string({
 	description: "same as '--application'",
 });
 
+/**
+ * "ArgFlag" refers to flags that are alternatives to positional arguments,
+ * for example: `balena deploy 1234567` vs. `balena deploy --uuid 1234567`
+ */
+export function mkAppArgFlagCombo() {
+	return {
+		name: mkStrAppArgFlag('name'),
+		uuid: mkStrAppArgFlag('uuid'),
+		id: mkIntAppArgFlag('id'),
+	};
+}
+
+export function mkAppFlagCombo() {
+	return {
+		app: mkStrAppFlag('app'),
+		'app-name': mkStrAppFlag('app-name'),
+		'app-uuid': mkStrAppFlag('app-uuid'),
+		'app-id': mkIntAppFlag('app-id'),
+		application: mkStrAppFlag('application'),
+		'application-name': mkStrAppFlag('applicaton-name'),
+		'application-uuid': mkStrAppFlag('applicaton-uuid'),
+		'application-id': mkIntAppFlag('applicaton-id'),
+	};
+}
+
 export const device = flags.string({
 	char: 'd',
 	description: 'device UUID',
 });
+
+/**
+ * "ArgFlag" refers to flags that are alternatives to positional arguments,
+ * for example: `device move 1234567` vs. `device move --uuid 1234567`
+ */
+export function mkDeviceArgFlagCombo(isCommaList: boolean) {
+	return {
+		uuid: mkStrDeviceArgFlag('uuid', isCommaList),
+		id: mkStrDeviceArgFlag('id', isCommaList),
+	};
+}
+
+export function mkDeviceFlagCombo() {
+	return {
+		device: mkStrDeviceFlag('device'),
+		'device-uuid': mkStrDeviceFlag('device-uuid'),
+		'device-id': mkIntDeviceFlag('device-id'),
+	};
+}
 
 export const help: IBooleanFlag<void> = flags.help({ char: 'h' });
 
@@ -75,3 +119,147 @@ export const drive = flags.string({
 		Check \`balena util available-drives\` for available options.
 	`,
 });
+
+/** Check that exactly one of the given options or positional args are used. */
+export async function checkExclusiveArgFlags(
+	positionalArgs: { [name: string]: any },
+	exclusiveOpts: { [name: string]: any },
+) {
+	const _ = await import('lodash');
+	const { ExpectedError } = await import('../errors');
+	const filter = (obj: { [name: string]: any }) =>
+		_.transform<string, any>(obj, (newObj, value, key) => {
+			if (value) {
+				newObj[key] = value;
+			}
+		});
+	const filteredArgs = filter(positionalArgs);
+	const filteredOpts = filter(exclusiveOpts);
+	const filteredPosKeys = Object.keys(filteredArgs);
+	const filteredOptKeys = Object.keys(filteredOpts);
+	if (filteredPosKeys.length && filteredOptKeys.length) {
+		throw new ExpectedError(
+			`The "${filteredPosKeys.join('" or "')}" positional argument${
+				filteredPosKeys.length === 1 ? '' : 's'
+			} cannot be used with the "--${filteredOptKeys.join('" or "--')}" option${
+				filteredOptKeys.length === 1 ? '' : 's'
+			}`,
+		);
+	}
+
+	if (filteredPosKeys.length === 0 && filteredOptKeys.length === 0) {
+		const posKeys = Object.keys(positionalArgs);
+		const optKeys = Object.keys(exclusiveOpts);
+		throw new ExpectedError(
+			`At least one "${posKeys.join('" or "')}" positional argument${
+				posKeys.length === 1 ? '' : 's'
+			} or "--${optKeys.join('" or "--')}" option${
+				optKeys.length === 1 ? '' : 's'
+			} must be provided`,
+		);
+	}
+}
+
+function mkExclusive(
+	names: string[],
+	suffixes: string[],
+	except: string[] = [],
+): string[] {
+	const exclusiveFlags: string[] = [];
+	for (const name of names) {
+		for (const suffix of suffixes) {
+			const flag = name && suffix ? `${name}-${suffix}` : name || suffix;
+			if (!except.includes(flag)) {
+				exclusiveFlags.push(flag);
+			}
+		}
+	}
+	return exclusiveFlags;
+}
+
+function mkAppFlagOpts(name: string) {
+	const [prefix, suffix] = name.split('-');
+	const description =
+		prefix === 'app'
+			? `alias for --${name.replace('app', 'application')}`
+			: suffix === 'id'
+			? 'application numeric database ID'
+			: suffix === 'uuid'
+			? 'application UUID'
+			: suffix === 'name'
+			? 'application name'
+			: 'application name, UUID or numeric database ID';
+	return {
+		description,
+		exclusive: mkExclusive(
+			['app', 'application'],
+			['', 'name', 'uuid', 'id'],
+			[name],
+		),
+		hidden: false, // name.includes('-'),
+	};
+}
+
+function mkAppArgFlagOpts(name: string) {
+	return {
+		description: `application ${
+			['uuid', 'id'].includes(name) ? name.toUpperCase() : name
+		} (alternative to positional argument)`,
+		exclusive: mkExclusive([''], ['name', 'uuid', 'id'], [name]),
+		hidden: false,
+	};
+}
+
+function mkStrAppFlag(name: string) {
+	return flags.string(mkAppFlagOpts(name));
+}
+
+function mkIntAppFlag(name: string) {
+	return flags.integer(mkAppFlagOpts(name));
+}
+
+function mkStrAppArgFlag(name: string) {
+	return flags.string(mkAppArgFlagOpts(name));
+}
+
+function mkIntAppArgFlag(name: string) {
+	return flags.integer(mkAppArgFlagOpts(name));
+}
+
+function mkDeviceFlagOpts(name: string) {
+	return {
+		description: `device ${name}`,
+		exclusive: mkExclusive(['device'], ['', 'uuid', 'id'], [name]),
+		hidden: name.includes('-'),
+	};
+}
+
+function mkDeviceArgFlagOpts(name: string, isCommaList: boolean) {
+	const descriptionParts: string[] = [];
+	descriptionParts.push(isCommaList ? 'comma-separated list of ' : '');
+	descriptionParts.push(
+		name === 'id'
+			? 'numeric device database ID'
+			: name === 'uuid'
+			? 'device UUID'
+			: `device ${name}`,
+	);
+	descriptionParts.push(isCommaList ? 's' : '');
+	return {
+		description: descriptionParts.join(''),
+		exclusive: mkExclusive([''], ['uuid', 'id'], [name]),
+		hidden: false,
+	};
+}
+
+function mkIntDeviceFlag(name: string) {
+	return flags.integer(mkDeviceFlagOpts(name));
+}
+
+function mkStrDeviceFlag(name: string) {
+	return flags.string(mkDeviceFlagOpts(name));
+}
+
+function mkStrDeviceArgFlag(name: string, isCommaList: boolean) {
+	return flags.string(mkDeviceArgFlagOpts(name, isCommaList));
+}

--- a/tests/commands/device/device-move.spec.ts
+++ b/tests/commands/device/device-move.spec.ts
@@ -26,12 +26,20 @@ USAGE
   $ balena device move <uuid(s)>
 
 ARGUMENTS
-  <uuid>  comma-separated list (no blank spaces) of device UUIDs to be moved
+  [uuid]  comma-separated list (no blank spaces) of device UUIDs to be moved
 
 OPTIONS
-  -a, --application <application>  application name
-  -h, --help                       show CLI help
-  --app <app>                      same as '--application'
+  -h, --help                             show CLI help
+  --app <app>                            alias for --application
+  --app-id <app-id>                      alias for --application-id
+  --app-name <app-name>                  alias for --application-name
+  --app-uuid <app-uuid>                  alias for --application-uuid
+  --application <application>            application name, UUID or numeric database ID
+  --application-id <application-id>      application numeric database ID
+  --application-name <application-name>  application name
+  --application-uuid <application-uuid>  application UUID
+  --id <id>                              comma-separated list of numeric device database IDs
+  --uuid <uuid>                          comma-separated list of device UUIDs
 
 DESCRIPTION
   Move one or more devices to another application.
@@ -71,9 +79,8 @@ describe('balena device move', function () {
 		const { out, err } = await runCommand('device move');
 		const errLines = cleanOutput(err);
 
-		expect(errLines[0]).to.equal('Missing 1 required argument:');
-		expect(errLines[1]).to.equal(
-			'uuid : comma-separated list (no blank spaces) of device UUIDs to be moved',
+		expect(errLines[0]).to.equal(
+			'At least one "uuid" positional argument or "--uuid" or "--id" options must be provided',
 		);
 		expect(out).to.eql([]);
 	});


### PR DESCRIPTION
Proof of concept on how to avoid ambiguity when specifying a device or application given its UUID, database ID, or name. See:

* https://www.flowdock.com/app/rulemotion/i-cli/threads/g26bVg0Nc518ZZknqxtX0GmWhwb
* #1842 
* #1843

Change-type: minor
