### PR TITLE
Patch oclif/dev-cli to fix permission issues with .deb packaging

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "resin.io",
     "git"
   ],
-  "author": "Juan Cruz Viotti <juan@balena.io>",
   "license": "Apache-2.0",
   "engines": {
     "node": ">=10.20.0"

--- a/patches/all/@oclif+dev-cli+1.22.2.patch
+++ b/patches/all/@oclif+dev-cli+1.22.2.patch
@@ -1,3 +1,18 @@
+diff --git a/node_modules/@oclif/dev-cli/lib/commands/pack/deb.js b/node_modules/@oclif/dev-cli/lib/commands/pack/deb.js
+index 51bce6e..a38f00f 100644
+--- a/node_modules/@oclif/dev-cli/lib/commands/pack/deb.js
++++ b/node_modules/@oclif/dev-cli/lib/commands/pack/deb.js
+@@ -37,8 +37,8 @@ class PackDeb extends command_1.Command {
+             await qq.write([workspace, 'DEBIAN/control'], scripts.control(buildConfig, debArch(arch)));
+             await qq.chmod([workspace, 'usr/lib', config.dirname, 'bin', config.bin], 0o755);
+             await qq.x(`ln -s "../lib/${config.dirname}/bin/${config.bin}" "${workspace}/usr/bin/${config.bin}"`);
+-            await qq.x(`chown -R root "${workspace}"`);
+-            await qq.x(`chgrp -R root "${workspace}"`);
++            await qq.x(`sudo chown -R root "${workspace}"`);
++            await qq.x(`sudo chgrp -R root "${workspace}"`);
+             await qq.x(`dpkg --build "${workspace}" "${qq.join(dist, `${versionedDebBase}.deb`)}"`);
+         };
+         const arches = _.uniq(buildConfig.targets
 diff --git a/node_modules/@oclif/dev-cli/lib/commands/pack/macos.js b/node_modules/@oclif/dev-cli/lib/commands/pack/macos.js
 index cd771cd..4a66939 100644
 --- a/node_modules/@oclif/dev-cli/lib/commands/pack/macos.js


### PR DESCRIPTION
Small patch-package patch to fix permission issues with oclif's .deb package builder script.  Note there's already an upstream PR for this (over one year old), but the dev-cli repo does not seem to be actively maintained.

Change-type: patch
Signed-off-by: Scott Lowe <scott@balena.io>