### PR TITLE
Add ability to disable analytics for performance testing

### DIFF
--- a/lib/events.ts
+++ b/lib/events.ts
@@ -104,8 +104,11 @@ export async function trackCommand(commandSignature: string) {
 				});
 			});
 		}
-		// Don't actually call mixpanel.track() while running test cases
-		if (!process.env.BALENA_CLI_TEST_TYPE) {
+		// Don't actually call mixpanel.track() while running test cases, or if suppressed
+		if (
+			!process.env.BALENA_CLI_TEST_TYPE &&
+			!process.env.BALENARC_NO_ANALYTICS
+		) {
 			await mixpanel.track(`[CLI] ${commandSignature}`, {
 				distinct_id: username,
 				version: packageJSON.version,


### PR DESCRIPTION
Added the env var `BALENARC_NO_ANALYTICS` to disable analytics reporting for investigation of #1708 .  Will be helpful to have this in master I think for future tests, since analtyics backend is being reworked.

Change-type: patch
Connects-to: #1708
Signed-off-by: Scott Lowe <scott@balena.io>