### PR TITLE
scan: Print production devices' info on scan

### DIFF
--- a/doc/cli.markdown
+++ b/doc/cli.markdown
@@ -1524,6 +1524,11 @@ Only show system logs. This can be used in combination with --service.
 
 Scan for balenaOS devices on your local network.
 
+The output includes device information collected through balenaEngine for
+devices running a development image of balenaOS. Devices running a production
+image do not expose balenaEngine (on TCP port 2375), which is why less
+information is printed about them.
+
 Examples:
 
 	$ balena scan

--- a/typings/balena-sync/index.d.ts
+++ b/typings/balena-sync/index.d.ts
@@ -23,6 +23,7 @@ declare module 'balena-sync' {
 	export interface LocalBalenaOsDevice {
 		address: string;
 		host: string;
+		osVariant: string;
 		port: number;
 	}
 


### PR DESCRIPTION
I have 2 devices one prod, one dev, the output now is:
```
Scanning for local balenaOS devices... Reporting scan results
- 
  host:      9xxxxx9.local
  address:   192.168.1.12
  osVariant: production
- 
  host:          9xxxxx4.local
  address:       192.168.1.3
  osVariant:     development
  dockerInfo: 
    Containers:        2
    ContainersRunning: 2
    ContainersPaused:  0
    ContainersStopped: 0
    Images:            3
    Driver:            overlay2
    SystemTime:        2020-11-30T14:21:38.807447971Z
    KernelVersion:     5.4.58
    OperatingSystem:   balenaOS 2.58.6+rev1
    Architecture:      aarch64
  dockerVersion: 
    Version:    19.03.13-dev
    ApiVersion: 1.40
```

Hey @pdcastro @srlowe how should we make it clear that the 192.168.1.12 is a production variant?
edit: I added an osVariant property. And now all the production devices should appear at the top of the list.