### PR TITLE
Livepush, logs: Automatically reconnect on 'Connection to device lost'

### DIFF
--- a/doc/cli.markdown
+++ b/doc/cli.markdown
@@ -1506,6 +1506,11 @@ device UUID, IP, or .local address
 
 ### Options
 
+#### --max-retry MAX-RETRY
+
+Maximum number of reconnection attempts on "connection lost" errors
+(use 0 to disable auto reconnection).
+
 #### -t, --tail
 
 continuously stream output

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -21,7 +21,10 @@ import { TypedError } from 'typed-error';
 import { getChalk, stripIndent } from './utils/lazy';
 import { getHelp } from './utils/messages';
 
-export class ExpectedError extends TypedError {}
+export class ExpectedError extends TypedError {
+	public code?: string;
+	public exitCode?: number;
+}
 
 export class NotLoggedInError extends ExpectedError {}
 
@@ -38,6 +41,8 @@ export class NoPortsDefinedError extends ExpectedError {
 		super('No ports have been provided.');
 	}
 }
+
+export class SIGINTError extends ExpectedError {}
 
 /**
  * instanceOf is a more reliable implementation of the plain `instanceof`
@@ -177,7 +182,7 @@ async function sentryCaptureException(error: Error) {
 		await Sentry.close(1000);
 	} catch (e) {
 		if (process.env.DEBUG) {
-			console.error('Timeout reporting error to sentry.io');
+			console.error('[debug] Timeout reporting error to sentry.io');
 		}
 	}
 }
@@ -212,8 +217,9 @@ export async function handleError(error: Error) {
 		if (!process.env.BALENARC_NO_SENTRY) {
 			await sentryCaptureException(error);
 		}
-
-		// Unhandled/unexpected error: ensure that the process terminates.
+	}
+	if (error instanceof SIGINTError || !isExpectedError) {
+		// SIGINT or unexpected error: ensure that the process terminates.
 		// The exit error code was set above through `process.exitCode`.
 		process.exit();
 	}
@@ -247,6 +253,7 @@ export const printExpectedErrorMessage = function (message: string) {
  * them and call this function.
  *
  * DEPRECATED: Use `throw new ExpectedError(<message>)` instead.
+ * If a specific process exit code x must be set, use process.exitCode = x
  */
 export function exitWithExpectedError(message: string | Error): never {
 	if (message instanceof Error) {

--- a/lib/utils/compose.js
+++ b/lib/utils/compose.js
@@ -366,15 +366,15 @@ export const pushAndUpdateServiceImages = function (
 			images.map(({ serviceImage, localImage, props, logs }, index) =>
 				Promise.all([
 					localImage.inspect().then((img) => img.Size),
-					retry(
+					retry({
 						// @ts-ignore
-						() => progress.push(localImage.name, reporters[index], opts),
-						3, // `times` - retry 3 times
+						func: () => progress.push(localImage.name, reporters[index], opts),
+						maxAttempts: 3, // try calling func 3 times (max)
 						// @ts-ignore
-						localImage.name, // `label` included in retry log messages
-						2000, // `delayMs` - wait 2 seconds before the 1st retry
-						1.4, // `backoffScaler` - wait multiplier for each retry
-					).finally(renderer.end),
+						label: localImage.name, // label for retry log messages
+						initialDelayMs: 2000, // wait 2 seconds before the 1st retry
+						backoffScaler: 1.4, // wait multiplier for each retry
+					}).finally(renderer.end),
 				])
 					.then(
 						/** @type {([number, string]) => void} */

--- a/lib/utils/device/deploy.ts
+++ b/lib/utils/device/deploy.ts
@@ -274,6 +274,8 @@ export async function deployToDevice(opts: DeviceDeployOptions): Promise<void> {
 		globalLogger.logLivepush('Watching for file changes...');
 		globalLogger.outputDeferredMessages();
 		await Promise.all(promises);
+
+		livepush.close();
 	} else {
 		if (opts.detached) {
 			return;

--- a/lib/utils/device/deploy.ts
+++ b/lib/utils/device/deploy.ts
@@ -28,6 +28,7 @@ import {
 import type { Readable } from 'stream';
 
 import { BALENA_ENGINE_TMP_PATH } from '../../config';
+import { ExpectedError } from '../../errors';
 import {
 	checkBuildSecretsRequirements,
 	loadProject,
@@ -37,7 +38,6 @@ import {
 import Logger = require('../logger');
 import { DeviceAPI, DeviceInfo } from './api';
 import * as LocalPushErrors from './errors';
-import { DeviceAPIError } from './errors';
 import LivepushManager from './live';
 import { displayBuildLog } from './logs';
 
@@ -76,7 +76,6 @@ async function environmentFromInput(
 	serviceNames: string[],
 	logger: Logger,
 ): Promise<ParsedEnvironment> {
-	const { exitWithExpectedError } = await import('../../errors');
 	// A normal environment variable regex, with an added part
 	// to find a colon followed servicename at the start
 	const varRegex = /^(?:([^\s:]+):)?([^\s]+?)=(.*)$/;
@@ -92,7 +91,7 @@ async function environmentFromInput(
 	for (const env of envs) {
 		const maybeMatch = env.match(varRegex);
 		if (maybeMatch == null) {
-			exitWithExpectedError(`Unable to parse environment variable: ${env}`);
+			throw new ExpectedError(`Unable to parse environment variable: ${env}`);
 		}
 		const match = maybeMatch!;
 		let service: string | undefined;
@@ -122,8 +121,6 @@ async function environmentFromInput(
 }
 
 export async function deployToDevice(opts: DeviceDeployOptions): Promise<void> {
-	const { exitWithExpectedError } = await import('../../errors');
-
 	// Resolve .local addresses to IP to avoid
 	// issue with Windows and rapid repeat lookups.
 	// see: https://github.com/balena-io/balena-cli/issues/1518
@@ -143,7 +140,7 @@ export async function deployToDevice(opts: DeviceDeployOptions): Promise<void> {
 		globalLogger.logDebug('Checking we can access device');
 		await api.ping();
 	} catch (e) {
-		exitWithExpectedError(
+		throw new ExpectedError(
 			`Could not communicate with local mode device at address ${opts.deviceHost}`,
 		);
 	}
@@ -157,7 +154,7 @@ export async function deployToDevice(opts: DeviceDeployOptions): Promise<void> {
 		const version = await api.getVersion();
 		globalLogger.logDebug(`Checking device version: ${version}`);
 		if (!semver.satisfies(version, '>=7.21.4')) {
-			exitWithExpectedError(versionError);
+			throw new ExpectedError(versionError);
 		}
 		if (!opts.nolive && !semver.satisfies(version, '>=9.7.0')) {
 			globalLogger.logWarn(
@@ -168,8 +165,8 @@ export async function deployToDevice(opts: DeviceDeployOptions): Promise<void> {
 	} catch (e) {
 		// Very old supervisor versions do not support /version endpoint
 		// a DeviceAPIError is expected in this case
-		if (e instanceof DeviceAPIError) {
-			exitWithExpectedError(versionError);
+		if (e instanceof LocalPushErrors.DeviceAPIError) {
+			throw new ExpectedError(versionError);
 		} else {
 			throw e;
 		}
@@ -209,7 +206,10 @@ export async function deployToDevice(opts: DeviceDeployOptions): Promise<void> {
 	if (!opts.nolive) {
 		buildLogs = {};
 	}
-	const buildTasks = await performBuilds(
+
+	const { awaitInterruptibleTask } = await import('../helpers');
+	const buildTasks = await awaitInterruptibleTask<typeof performBuilds>(
+		performBuilds,
 		project.composition,
 		tarStream,
 		docker,
@@ -269,10 +269,13 @@ export async function deployToDevice(opts: DeviceDeployOptions): Promise<void> {
 		}
 		globalLogger.logLivepush('Watching for file changes...');
 	}
-	await Promise.all(promises).finally(() => {
+	try {
+		await awaitInterruptibleTask(() => Promise.all(promises));
+	} finally {
 		// Stop watching files after log streaming ends (e.g. on SIGINT)
 		livepush?.close();
-	});
+		await livepush?.cleanup();
+	}
 }
 
 async function streamDeviceLogs(
@@ -441,7 +444,9 @@ export async function rebuildSingleTask(
 	);
 
 	if (task == null) {
-		throw new Error(`Could not find build task for service ${serviceName}`);
+		throw new ExpectedError(
+			`Could not find build task for service ${serviceName}`,
+		);
 	}
 
 	await assignDockerBuildOpts(docker, [task], opts);
@@ -610,8 +615,6 @@ export function generateTargetState(
 }
 
 async function inspectBuildResults(images: LocalImage[]): Promise<void> {
-	const { exitWithExpectedError } = await import('../../errors');
-
 	const failures: LocalPushErrors.BuildFailure[] = [];
 
 	_.each(images, (image) => {
@@ -624,6 +627,6 @@ async function inspectBuildResults(images: LocalImage[]): Promise<void> {
 	});
 
 	if (failures.length > 0) {
-		exitWithExpectedError(new LocalPushErrors.BuildError(failures).toString());
+		throw new LocalPushErrors.BuildError(failures).toString();
 	}
 }

--- a/lib/utils/device/errors.ts
+++ b/lib/utils/device/errors.ts
@@ -1,12 +1,29 @@
+/**
+ * @license
+ * Copyright 2018-2020 Balena Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import * as _ from 'lodash';
-import { TypedError } from 'typed-error';
+
+import { ExpectedError } from '../../errors';
 
 export interface BuildFailure {
 	error: Error;
 	serviceName: string;
 }
 
-export class BuildError extends TypedError {
+export class BuildError extends ExpectedError {
 	private failures: BuildFailure[];
 
 	public constructor(failures: BuildFailure[]) {
@@ -33,7 +50,7 @@ export class BuildError extends TypedError {
 	}
 }
 
-export class DeviceAPIError extends TypedError {}
+export class DeviceAPIError extends ExpectedError {}
 
 export class BadRequestDeviceAPIError extends DeviceAPIError {}
 export class ServiceUnavailableAPIError extends DeviceAPIError {}

--- a/lib/utils/device/live.ts
+++ b/lib/utils/device/live.ts
@@ -283,6 +283,7 @@ export class LivepushManager {
 		return monitor;
 	}
 
+	/** Stop the filesystem watcher, allowing the Node process to exit gracefully */
 	public close() {
 		for (const container of Object.values(this.containers)) {
 			container.monitor.close().catch((err) => {

--- a/lib/utils/device/live.ts
+++ b/lib/utils/device/live.ts
@@ -221,21 +221,14 @@ export class LivepushManager {
 		}
 
 		// Setup cleanup handlers for the device
-
-		// This is necessary because the `exit-hook` module is used by several
-		// dependencies, and will exit without calling the following handler.
-		// Once https://github.com/balena-io/balena-cli/issues/867 has been solved,
-		// we are free to (and definitely should) remove the below line
-		process.removeAllListeners('SIGINT');
-		process.on('SIGINT', async () => {
+		process.once('SIGINT', async () => {
 			this.logger.logLivepush('Cleaning up device...');
 			await Promise.all(
 				_.map(this.containers, (container) => {
 					container.livepush.cleanupIntermediateContainers();
 				}),
 			);
-
-			process.exit(0);
+			this.logger.logDebug('Cleaning up done.');
 		});
 	}
 

--- a/lib/utils/device/live.ts
+++ b/lib/utils/device/live.ts
@@ -290,6 +290,16 @@ export class LivepushManager {
 		return monitor;
 	}
 
+	public close() {
+		for (const container of Object.values(this.containers)) {
+			container.monitor.close().catch((err) => {
+				if (process.env.DEBUG) {
+					this.logger.logDebug(`chokidar.close() ${err.message}`);
+				}
+			});
+		}
+	}
+
 	public static preprocessDockerfile(content: string): string {
 		return new Dockerfile(content).generateLiveDockerfile();
 	}

--- a/lib/utils/device/live.ts
+++ b/lib/utils/device/live.ts
@@ -219,17 +219,17 @@ export class LivepushManager {
 				this.rebuildsCancelled[serviceName] = false;
 			}
 		}
+	}
 
-		// Setup cleanup handlers for the device
-		process.once('SIGINT', async () => {
-			this.logger.logLivepush('Cleaning up device...');
-			await Promise.all(
-				_.map(this.containers, (container) => {
-					container.livepush.cleanupIntermediateContainers();
-				}),
-			);
-			this.logger.logDebug('Cleaning up done.');
-		});
+	/** Delete intermediate build containers from the device */
+	public async cleanup() {
+		this.logger.logLivepush('Cleaning up device...');
+		await Promise.all(
+			_.map(this.containers, (container) =>
+				container.livepush.cleanupIntermediateContainers(),
+			),
+		);
+		this.logger.logDebug('Cleaning up done.');
 	}
 
 	protected setupFilesystemWatcher(

--- a/lib/utils/device/logs.ts
+++ b/lib/utils/device/logs.ts
@@ -42,12 +42,13 @@ export function displayDeviceLogs(
 		logs.on('data', (log) => {
 			displayLogLine(log, logger, system, filterServices);
 		});
-
-		logs.on('error', reject);
-		logs.on('end', () => {
-			logger.logError('Connection to device lost');
+		logs.once('error', reject);
+		logs.once('end', () => {
+			logger.logWarn('Connection to device lost');
 			resolve();
 		});
+		process.once('SIGINT', () => logs.emit('close'));
+		process.once('SIGTERM', () => logs.emit('close'));
 	});
 }
 

--- a/lib/utils/helpers.ts
+++ b/lib/utils/helpers.ts
@@ -204,39 +204,62 @@ function getApplication(
 	) as Promise<ApplicationWithDeviceType>;
 }
 
+const second = 1000; // 1000 milliseconds
+const minute = 60 * second;
 export const delay = promisify(setTimeout);
 
 /**
  * Call `func`, and if func() throws an error or returns a promise that
- * eventually rejects, retry it `times` many times, each time printing a
- * log message including the given `label` and the error that led to
- * retrying. Wait delayMs before the first retry, multiplying the wait
- * by backoffScaler for each further attempt.
+ * eventually rejects, retry it `times` many times, each time printing a log
+ * message including the given `label` and the error that led to retrying.
+ * Wait initialDelayMs before the first retry. Before each further retry,
+ * the delay is reduced by the time elapsed since the last retry, and
+ * increased by multiplying the result by backoffScaler.
  * @param func: The function to call and, if needed, retry calling
- * @param times: How many times to retry calling func()
+ * @param maxAttempts: How many times (max) to try calling func().
+ * func() will always be called at least once.
  * @param label: Label to include in the retry log message
- * @param startingDelayMs: How long to wait before the first retry
+ * @param initialDelayMs: How long to wait before the first retry
  * @param backoffScaler: Multiplier to previous wait time
- * @param count: Used "internally" for the recursive calls
+ * @param maxSingleDelayMs: Maximum interval between retries
  */
-export async function retry<T>(
-	func: () => T,
-	times: number,
-	label: string,
-	startingDelayMs = 1000,
+export async function retry<T>({
+	func,
+	maxAttempts,
+	label,
+	initialDelayMs = 1000,
 	backoffScaler = 2,
-): Promise<T> {
-	for (let count = 0; count < times - 1; count++) {
+	maxSingleDelayMs = 1 * minute,
+}: {
+	func: () => T;
+	maxAttempts: number;
+	label: string;
+	initialDelayMs?: number;
+	backoffScaler?: number;
+	maxSingleDelayMs?: number;
+}): Promise<T> {
+	let delayMs = initialDelayMs;
+	for (let count = 0; count < maxAttempts - 1; count++) {
+		const lastAttemptMs = Date.now();
 		try {
 			return await func();
 		} catch (err) {
-			const delayMS = backoffScaler ** count * startingDelayMs;
+			if (count) {
+				// use Math.max to work around system time changes, e.g. DST
+				const elapsedMs = Math.max(0, Date.now() - lastAttemptMs);
+				// reduce delayMs by the time elapsed since the last attempt
+				delayMs = Math.max(initialDelayMs, delayMs - elapsedMs);
+				// increase delayMs by the backoffScaler factor
+				delayMs = Math.min(maxSingleDelayMs, delayMs * backoffScaler);
+			}
+			const sec = delayMs / 1000;
+			const secStr = sec < 10 ? sec.toFixed(1) : Math.round(sec).toString();
 			console.log(
-				`Retrying "${label}" after ${(delayMS / 1000).toFixed(2)}s (${
-					count + 1
-				} of ${times}) due to: ${err}`,
+				`Retrying "${label}" after ${secStr}s (${count + 1} of ${
+					maxAttempts - 1
+				}) due to: ${err}`,
 			);
-			await delay(delayMS);
+			await delay(delayMs);
 		}
 	}
 	return await func();

--- a/patches/all/exit-hook+1.1.1.patch
+++ b/patches/all/exit-hook+1.1.1.patch
@@ -1,0 +1,17 @@
+diff --git a/node_modules/exit-hook/index.js b/node_modules/exit-hook/index.js
+index e18013f..3366356 100644
+--- a/node_modules/exit-hook/index.js
++++ b/node_modules/exit-hook/index.js
+@@ -14,9 +14,9 @@ function exit(exit, signal) {
+ 		el();
+ 	});
+ 
+-	if (exit === true) {
+-		process.exit(128 + signal);
+-	}
++	// if (exit === true) {
++	// 	process.exit(128 + signal);
++	// }
+ };
+ 
+ module.exports = function (cb) {

--- a/tests/commands/logs.spec.ts
+++ b/tests/commands/logs.spec.ts
@@ -46,20 +46,33 @@ describe('balena logs', function () {
 	itS('should reach the expected endpoints on a local device', async () => {
 		supervisor.expectGetPing();
 		supervisor.expectGetLogs();
+		supervisor.expectGetLogs();
 
-		const { err, out } = await runCommand('logs 1.2.3.4');
+		const { err, out } = await runCommand('logs 1.2.3.4 --max-retry 1');
 
-		expect(err).to.be.empty;
+		const errLines = cleanOutput(err, true);
+		const errMsg =
+			'Max retry count (1) exceeded while attempting to reconnect to the device';
+		if (process.env.DEBUG) {
+			expect(errLines).to.include(errMsg);
+		} else {
+			expect(errLines).to.have.members([errMsg]);
+		}
 
 		const removeTimestamps = (logLine: string) =>
 			logLine.replace(/(?<=\[Logs\]) \[.+?\]/, '');
 		const cleanedOut = cleanOutput(out, true).map((l) => removeTimestamps(l));
 
-		expect(cleanedOut).to.deep.equal([
+		expect(cleanedOut).to.have.members([
 			'[Logs] Streaming logs',
 			'[Logs] [bar] bar 8 (332) Linux 4e3f81149d71 4.19.75 #1 SMP PREEMPT Mon Mar 23 11:50:49 UTC 2020 aarch64 GNU/Linux',
 			'[Logs] [foo] foo 8 (200) Linux cc5df60d89ee 4.19.75 #1 SMP PREEMPT Mon Mar 23 11:50:49 UTC 2020 aarch64 GNU/Linux',
-			'[Error] Connection to device lost',
+			'[Warn] Connection to device lost',
+			'Retrying "Streaming logs" after 1.0s (1 of 1) due to: DeviceConnectionLostError: Connection to device lost',
+			'[Logs] Streaming logs',
+			'[Logs] [bar] bar 8 (332) Linux 4e3f81149d71 4.19.75 #1 SMP PREEMPT Mon Mar 23 11:50:49 UTC 2020 aarch64 GNU/Linux',
+			'[Logs] [foo] foo 8 (200) Linux cc5df60d89ee 4.19.75 #1 SMP PREEMPT Mon Mar 23 11:50:49 UTC 2020 aarch64 GNU/Linux',
+			'[Warn] Connection to device lost',
 		]);
 	});
 });


### PR DESCRIPTION
This PR started with #1828, then extended to include automatic reconnections to the device on `balena logs <ip-address>` and `balena push <ip-address>`, and then to cover CTRL-C handling on all platforms (it was specially buggy on Windows) for the `push <myApp>`, `push <myApp> --detached`, `push <ip-address>` and `logs` commands. I got into fixing CTRL-C because I was using it to test the issues with CLI process getting stuck on "connection lost".

This PR has not fixed CTRL-C handling for the `build` and `deploy` commands, which have a different code base. CTRL-C is broken there too... But it was too much for a single PR. 😀 

Resolves: #1828
Change-type: minor
