### PR TITLE
apps: Fix "column.match is not a function" when --verbose is used

### DIFF
--- a/lib/commands/apps.ts
+++ b/lib/commands/apps.ts
@@ -56,7 +56,7 @@ export default class AppsCmd extends Command {
 	public static primary = true;
 
 	public async run() {
-		const { flags: options } = this.parse<FlagsDef, {}>(AppsCmd);
+		this.parse<FlagsDef, {}>(AppsCmd);
 
 		const balena = getBalenaSdk();
 
@@ -85,7 +85,7 @@ export default class AppsCmd extends Command {
 			getVisuals().table.horizontal(applications, [
 				'id',
 				'app_name',
-				options.verbose || 'slug',
+				'slug',
 				'device_type',
 				'online_devices',
 				'device_count',


### PR DESCRIPTION
```
$ balena apps --verbose
column.match is not a function

Additional information may be available with the `--debug` flag.

For further help or support, visit:
https://www.balena.io/docs/reference/balena-cli/#support-faq-and-troubleshooting
```

Happened as a result of the `v12` feature switch removal in #2116 -
https://github.com/balena-io/balena-cli/pull/2116/files#diff-706fbb5e5469ab6b5209855b65a3aec467bf9f0bf253b4051737d98604d94570R88

Change-type: patch
