### PR TITLE
push: Add --release-tag flag

### DIFF
--- a/doc/cli.markdown
+++ b/doc/cli.markdown
@@ -2544,6 +2544,7 @@ Examples:
 	$ balena push myApp
 	$ balena push myApp --source <source directory>
 	$ balena push myApp -s <source directory>
+	$ balena push myApp --release-tag key1 "" key2 "value2 with spaces"
 	
 	$ balena push 10.0.0.1
 	$ balena push 10.0.0.1 --source <source directory>
@@ -2657,6 +2658,12 @@ No-op (default behavior) since balena CLI v12.0.0. See "balena help push".
 Consider .gitignore files in addition to the .dockerignore file. This reverts
 to the CLI v11 behavior/implementation (deprecated) if compatibility is
 required until your project can be adapted.
+
+#### --release-tag RELEASE-TAG
+
+Set release tags if the push to a cloud application is successful. Multiple
+arguments may be provided, alternating tag keys and values (see examples).
+Hint: Empty values may be specified with "" (bash, cmd.exe) or '""' (PowerShell).
 
 # Settings
 

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -180,6 +180,7 @@ const messages: {
 // related issue https://github.com/balena-io/balena-sdk/issues/1025
 // related issue https://github.com/balena-io/balena-cli/issues/2126
 const EXPECTED_ERROR_REGEXES = [
+	/cannot also be provided when using/, // Exclusive flag errors are all expected
 	/^BalenaSettingsPermissionError/, // balena-settings-storage
 	/^BalenaAmbiguousApplication/, // balena-sdk
 	/^BalenaAmbiguousDevice/, // balena-sdk


### PR DESCRIPTION
If the --release-tag flag is set when using the push command then the provided tag is going to be used as a tag/release_version on the produced release.
eg `balena push MyApp --release-tag v1.0`
will result in
<img width="451" alt="Screenshot 2020-12-16 at 4 56 07 PM" src="https://user-images.githubusercontent.com/7872396/102364898-a4bbb300-3fbf-11eb-8371-d2e40bf97f8c.png">

 