### PR TITLE
v13 preparations: Standardize command data output

### DIFF
--- a/lib/command.ts
+++ b/lib/command.ts
@@ -21,6 +21,7 @@ import {
 	NotAvailableInOfflineModeError,
 } from './errors';
 import { stripIndent } from './utils/lazy';
+import * as output from './framework/output';
 
 export default abstract class BalenaCommand extends Command {
 	/**
@@ -167,4 +168,7 @@ export default abstract class BalenaCommand extends Command {
 			await this.getStdin();
 		}
 	}
+
+	protected outputMessage = output.outputMessage;
+	protected outputData = output.outputData;
 }

--- a/lib/framework/index.ts
+++ b/lib/framework/index.ts
@@ -1,0 +1,19 @@
+/*
+Copyright 2020 Balena
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import type { DataOutputOptions, DataSetOutputOptions } from './output';
+
+export { DataOutputOptions, DataSetOutputOptions };

--- a/lib/framework/output.ts
+++ b/lib/framework/output.ts
@@ -1,0 +1,158 @@
+/*
+Copyright 2020 Balena
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { getCliUx, getChalk } from '../utils/lazy';
+
+export interface DataOutputOptions {
+	fields?: string;
+	json?: boolean;
+}
+
+export interface DataSetOutputOptions extends DataOutputOptions {
+	filter?: string;
+	'no-header'?: boolean;
+	'no-truncate'?: boolean;
+	sort?: string;
+}
+
+/**
+ * Output message to STDERR
+ */
+export function outputMessage(msg: string) {
+	// Messages go to STDERR
+	console.error(msg);
+}
+
+/**
+ * Output result data to STDOUT
+ *  Supports:
+ *   - arrays of items (displayed in a tabular way),
+ *   - single items (displayed in a field per row format).
+ *
+ * @param data Array of data objects to output
+ * @param fields Array of fieldnames, specifying the fields and display order
+ * @param options Output options
+ */
+export async function outputData(
+	data: any[] | {},
+	fields: string[],
+	options: DataOutputOptions | DataSetOutputOptions,
+) {
+	if (Array.isArray(data)) {
+		await outputDataSet(data, fields, options as DataSetOutputOptions);
+	} else {
+		await outputDataItem(data, fields, options as DataOutputOptions);
+	}
+}
+
+/**
+ * Wraps the cli.ux table implementation, to output tabular data
+ *
+ * @param data Array of data objects to output
+ * @param fields Array of fieldnames, specifying the fields and display order
+ * @param options Output options
+ */
+async function outputDataSet(
+	data: any[],
+	fields: string[],
+	options: DataSetOutputOptions,
+) {
+	// Oclif expects fields to be specified in the format used in table headers (though lowercase)
+	// By replacing underscores with spaces here, we can support both header format and actual field name
+	// (e.g. as seen in json output).
+	options.fields = options.fields?.replace(/_/g, ' ');
+	options.filter = options.filter?.replace(/_/g, ' ');
+	options.sort = options.sort?.replace(/_/g, ' ');
+
+	getCliUx().table(
+		data,
+		// Convert fields array to column object keys
+		// that cli.ux expects.  We can later add support
+		// for both formats if beneficial
+		fields.reduce((ac, a) => ({ ...ac, [a]: {} }), {}),
+		{
+			...options,
+			...(options.json
+				? {
+						output: 'json',
+				  }
+				: {}),
+			columns: options.fields,
+			printLine,
+		},
+	);
+}
+
+/**
+ * Outputs a single data object (like `resin-cli-visuals table.vertical`),
+ *  but supporting a subset of options from `cli-ux table` (--json and --fields)
+ *
+ * @param data Array of data objects to output
+ * @param fields Array of fieldnames, specifying the fields and display order
+ * @param options Output options
+ */
+async function outputDataItem(
+	data: any,
+	fields: string[],
+	options: DataOutputOptions,
+) {
+	const outData: typeof data = {};
+
+	// Convert comma separated list of fields in `options.fields` to array of correct format.
+	// Note, user may have specified the true field name (e.g. `some_field`),
+	// or the format displayed in headers (e.g. `Some field`, case insensitive).
+	const userSelectedFields = options.fields?.split(',').map((f) => {
+		return f.toLowerCase().trim().replace(/ /g, '_');
+	});
+
+	// Order and filter the fields based on `fields` parameter and `options.fields`
+	(userSelectedFields || fields).forEach((fieldName) => {
+		if (fields.includes(fieldName)) {
+			outData[fieldName] = data[fieldName];
+		}
+	});
+
+	if (options.json) {
+		printLine(JSON.stringify(outData, undefined, 2));
+	} else {
+		const chalk = getChalk();
+		const { capitalize } = await import('lodash');
+
+		// Find longest key, so we can align results
+		const longestKeyLength = getLongestObjectKeyLength(outData);
+
+		// Output one field per line
+		for (const [k, v] of Object.entries(outData)) {
+			const shim = ' '.repeat(longestKeyLength - k.length);
+			const kDisplay = capitalize(k.replace(/_/g, ' '));
+			printLine(`${chalk.bold(kDisplay) + shim} : ${v}`);
+		}
+	}
+}
+
+function getLongestObjectKeyLength(o: any): number {
+	return Object.keys(o).length >= 1
+		? Object.keys(o).reduce((a, b) => {
+				return a.length > b.length ? a : b;
+		  }).length
+		: 0;
+}
+
+function printLine(s: any) {
+	// Duplicating oclif cli-ux's default implementation here,
+	// but using this one explicitly for ease of testing
+	process.stdout.write(s + '\n');
+}

--- a/lib/utils/common-flags.ts
+++ b/lib/utils/common-flags.ts
@@ -16,11 +16,12 @@
  */
 
 import { flags } from '@oclif/command';
-
-import type { IBooleanFlag } from '@oclif/parser/lib/flags';
 import { stripIndent } from './lazy';
 import { lowercaseIfSlug } from './normalization';
+
 import { isV13 } from './version';
+import type { IBooleanFlag } from '@oclif/parser/lib/flags';
+import type { DataOutputOptions, DataSetOutputOptions } from '../framework';
 
 export const v13: IBooleanFlag<boolean> = flags.boolean({
 	description: stripIndent`\
@@ -125,3 +126,37 @@ export const json: IBooleanFlag<boolean> = flags.boolean({
 	description: 'produce JSON output instead of tabular output',
 	default: false,
 });
+
+export const dataOutputFlags: flags.Input<DataOutputOptions> = {
+	fields: flags.string({
+		description: 'only show provided fields (comma-separated)',
+	}),
+	json: flags.boolean({
+		char: 'j',
+		exclusive: ['no-truncate'],
+		description: 'output in json format',
+		default: false,
+	}),
+};
+
+export const dataSetOutputFlags: flags.Input<DataOutputOptions> &
+	flags.Input<DataSetOutputOptions> = {
+	...dataOutputFlags,
+	filter: flags.string({
+		description:
+			'filter results by substring matching of a given field, eg: --filter field=foo',
+	}),
+	'no-header': flags.boolean({
+		exclusive: ['json'],
+		description: 'hide table header from output',
+		default: false,
+	}),
+	'no-truncate': flags.boolean({
+		exclusive: ['json'],
+		description: 'do not truncate output to fit screen',
+		default: false,
+	}),
+	sort: flags.string({
+		description: `field to sort by (prepend '-' for descending order)`,
+	}),
+};

--- a/package.json
+++ b/package.json
@@ -220,6 +220,7 @@
     "chalk": "^3.0.0",
     "chokidar": "^3.4.3",
     "cli-truncate": "^2.1.0",
+    "cli-ux": "^5.5.1",
     "color-hash": "^1.0.3",
     "columnify": "^1.5.2",
     "common-tags": "^1.7.2",

--- a/tests/framework/output.spec.ts
+++ b/tests/framework/output.spec.ts
@@ -1,0 +1,255 @@
+/**
+ * @license
+ * Copyright 2020-2021 Balena Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* tslint:disable: prefer-const no-empty */
+
+import rewire = require('rewire');
+import sinon = require('sinon');
+import { expect } from 'chai';
+
+const dataItem = {
+	name: 'item1',
+	id: 1,
+	thing_color: 'blue',
+	thing_shape: 'square',
+};
+
+const dataSet = [
+	{
+		name: 'item1',
+		id: 1,
+		thing_color: 'red',
+		thing_shape: 'square',
+	},
+	{
+		name: 'item2',
+		id: 2,
+		thing_color: 'blue',
+		thing_shape: 'round',
+	},
+];
+
+describe('outputData', function () {
+	let outputData: any;
+	let outputDataSetSpy: any;
+	let outputDataItemSpy: any;
+
+	this.beforeEach(() => {
+		const output = rewire('../../build/framework/output');
+
+		outputDataSetSpy = sinon.spy();
+		outputDataItemSpy = sinon.spy();
+
+		output.__set__('outputDataSet', outputDataSetSpy);
+		output.__set__('outputDataItem', outputDataItemSpy);
+
+		outputData = output.__get__('outputData');
+	});
+
+	it('should call outputDataSet function when data param is an array', async () => {
+		await outputData(dataSet);
+		expect(outputDataSetSpy.called).to.be.true;
+		expect(outputDataItemSpy.called).to.be.false;
+	});
+
+	it('should call outputDataItem function when data param is an object', async () => {
+		await outputData(dataItem);
+		expect(outputDataSetSpy.called).to.be.false;
+		expect(outputDataItemSpy.called).to.be.true;
+	});
+});
+
+describe('outputDataSet', function () {
+	let outputDataSet: any;
+	let printLineSpy: any;
+
+	this.beforeEach(() => {
+		const output = rewire('../../build/framework/output');
+		printLineSpy = sinon.spy();
+		output.__set__('printLine', printLineSpy);
+		outputDataSet = output.__get__('outputDataSet');
+	});
+
+	it('should only output fields specified in `fields` param, in that order', async () => {
+		const fields = ['id', 'name', 'thing_color'];
+		const options = {};
+
+		await outputDataSet(dataSet, fields, options);
+
+		// check correct number of rows (2 data, 2 header)
+		expect(printLineSpy.callCount).to.equal(4);
+		const headerLine = printLineSpy.firstCall.firstArg.toLowerCase();
+		// check we have fields we specified
+		fields.forEach((f) => {
+			expect(headerLine).to.include(f.replace(/_/g, ' '));
+		});
+		// check we don't have fields we didn't specify
+		expect(headerLine).to.not.include('thing_shape');
+		// check order
+		// split header using the `name` column as delimiter
+		const splitHeader = headerLine.split('name');
+		expect(splitHeader[0]).to.include('id');
+		expect(splitHeader[1]).to.include('thing');
+	});
+
+	/*
+	it('should output fields in the order specified in `fields` param', async () => {
+		const fields = ['thing_color', 'id', 'name'];
+		const options = {};
+
+		await outputDataSet(dataSet, fields, options);
+
+		const headerLine = printLineSpy.firstCall.firstArg.toLowerCase();
+		// split header using the `it` column as delimiter
+		const splitHeader = headerLine.split('id');
+		expect(splitHeader[0]).to.include('thing');
+		expect(splitHeader[1]).to.include('name');
+	});
+	 */
+
+	it('should only output fields specified in `options.fields` if present', async () => {
+		const fields = ['name', 'id', 'thing_color', 'thing_shape'];
+		const options = {
+			// test all formats
+			fields: 'Name,thing_color,Thing shape',
+		};
+
+		await outputDataSet(dataSet, fields, options);
+
+		const headerLine = printLineSpy.firstCall.firstArg.toLowerCase();
+		// check we have fields we specified
+		expect(headerLine).to.include('name');
+		expect(headerLine).to.include('thing color');
+		expect(headerLine).to.include('thing shape');
+		// check we don't have fields we didn't specify
+		expect(headerLine).to.not.include('id');
+	});
+
+	it('should output records in order specified by `options.sort` if present', async () => {
+		const fields = ['name', 'id', 'thing_color', 'thing_shape'];
+		const options = {
+			sort: 'thing shape',
+			'no-header': true,
+		};
+
+		await outputDataSet(dataSet, fields, options);
+
+		// blue should come before red
+		expect(printLineSpy.getCall(0).firstArg).to.include('blue');
+		expect(printLineSpy.getCall(1).firstArg).to.include('red');
+	});
+
+	it('should only output records that match filter specified by `options.filter` if present', async () => {
+		const fields = ['name', 'id', 'thing_color', 'thing_shape'];
+		const options = {
+			filter: 'thing color=red',
+			'no-header': true,
+		};
+
+		await outputDataSet(dataSet, fields, options);
+
+		// check correct number of rows (1 matched data, no-header)
+		expect(printLineSpy.callCount).to.equal(1);
+		expect(printLineSpy.getCall(0).firstArg).to.include('red');
+	});
+
+	it('should output data in json format, if `options.json` true', async () => {
+		const fields = ['name', 'thing_color', 'thing_shape'];
+		const options = {
+			json: true,
+		};
+
+		// TODO: I've run into an oclif cli-ux bug, where numbers are output as strings in json
+		//  (this can be seen by including 'id' in the fields list above).
+		//  Issue opened: https://github.com/oclif/cli-ux/issues/309
+		//  For now removing id for this test.
+		const clonedDataSet = JSON.parse(JSON.stringify(dataSet));
+		clonedDataSet.forEach((d: any) => {
+			delete d.id;
+		});
+
+		const expectedJson = JSON.stringify(clonedDataSet, undefined, 2);
+
+		await outputDataSet(dataSet, fields, options);
+
+		expect(printLineSpy.callCount).to.equal(1);
+		expect(printLineSpy.getCall(0).firstArg).to.equal(expectedJson);
+	});
+});
+
+describe('outputDataItem', function () {
+	let outputDataItem: any;
+	let printLineSpy: any;
+
+	this.beforeEach(() => {
+		const output = rewire('../../build/framework/output');
+		printLineSpy = sinon.spy();
+		output.__set__('printLine', printLineSpy);
+		outputDataItem = output.__get__('outputDataItem');
+	});
+
+	it('should only output fields specified in `fields` param, in that order', async () => {
+		const fields = ['id', 'name', 'thing_color'];
+		const options = {};
+
+		await outputDataItem(dataItem, fields, options);
+
+		// check correct number of rows (3 fields)
+		expect(printLineSpy.callCount).to.equal(3);
+		// check we have fields we specified
+		fields.forEach((f, index) => {
+			const kvPair = printLineSpy.getCall(index).firstArg.split(':');
+			expect(kvPair[0].toLowerCase()).to.include(f.replace(/_/g, ' '));
+			expect(kvPair[1]).to.include((dataItem as any)[f]);
+		});
+	});
+
+	it('should only output fields specified in `options.fields` if present', async () => {
+		const fields = ['name', 'id', 'thing_color', 'thing_shape'];
+		const options = {
+			// test all formats
+			fields: 'Name,thing_color,Thing shape',
+		};
+
+		const expectedFields = ['name', 'thing_color', 'thing_shape'];
+
+		await outputDataItem(dataItem, fields, options);
+
+		// check correct number of rows (3 fields)
+		expect(printLineSpy.callCount).to.equal(3);
+		// check we have fields we specified
+		expectedFields.forEach((f, index) => {
+			const kvPair = printLineSpy.getCall(index).firstArg.split(':');
+			expect(kvPair[0].toLowerCase()).to.include(f.replace(/_/g, ' '));
+			expect(kvPair[1]).to.include((dataItem as any)[f]);
+		});
+	});
+
+	it('should output data in json format, if `options.json` true', async () => {
+		const fields = ['name', 'id', 'thing_color', 'thing_shape'];
+		const options = {
+			json: true,
+		};
+
+		const expectedJson = JSON.stringify(dataItem, undefined, 2);
+
+		await outputDataItem(dataItem, fields, options);
+
+		expect(printLineSpy.callCount).to.equal(1);
+		expect(printLineSpy.getCall(0).firstArg).to.equal(expectedJson);
+	});
+});


### PR DESCRIPTION
This provides a standard interface at the framework level for commands to output data.  Tabular output is now provided by the oclif `cli-ux` package (following on form Page's PoC), which brings features such as filtering, sorting and json output as standard.  Single-record output support has been implemented to follow the same conventions (and provide a subset of the same features).

One issue was how to specify the field names in options like `--sort`, `--filter`, `--fields`.  Oclif cli-ux expects these to be specified using the format shown in the tabular output (which differs from the actual field names: first word capitalized and underscores replaced by spaces).  However, since we can also output in json this didn't seem ideal, so it now allows field names to be specified in either the header format (case insensitive) or the actual field name.

For the sake of review simplicity, only two commands have been updated to use this.  Once merged we can implement for all commands (behind v13 switch).

```
$ balena apps
Id      App name     Slug            Device type           Device count Online devices 
1760161 1234567      sl/1234567      aio-3288c             2            0                       
1768078 balena-sound sl/balena-sound raspberry-pi          0            0                     
1546690 cliApp       sl/cliapp       raspberrypi4-64       3            0                         
1585605 DebugApp     sl/debugapp     fincm3                2            0              
```
```
$ balena apps --sort "-device count"
Id      App name     Slug            Device type           Device count Online devices
1546690 cliApp       sl/cliapp       raspberrypi4-64       3            0         
1760161 1234567      sl/1234567      aio-3288c             2            0 
1585605 DebugApp     sl/debugapp     fincm3                2            0                        
1768078 balena-sound sl/balena-sound raspberry-pi          0            0                     
 ```
```
$ balena apps --fields "slug,device count"
Slug            Device count 
sl/1234567      2                   
sl/balena-sound 0            
sl/cliapp       3                   
sl/debugapp     2            
```
```
$ balena apps --filter "device type=raspberry"
Id      App name     Slug            Device type     Device count Online devices 
1768078 balena-sound sl/balena-sound raspberry-pi    0            0              
1546690 cliApp       sl/cliapp       raspberrypi4-64 3            0              
```
```
$ balena apps --json
[
  {
    "id": "1760161",
    "app_name": "1234567",
    "slug": "sl/1234567",
    "device_type": "aio-3288c",
    "device_count": "2",
    "online_devices": "0"
  },
  ...
]
```
```
$ balena app sl/balena-sound
App name    : balena-sound
Id          : 1768078
Device type : raspberry-pi
Slug        : sl/balena-sound
Commit      : c47e79d135676a2a7b547b1de0f117eb
```
```
$ balena app sl/balena-sound --json
{
  "app_name": "balena-sound",
  "id": 1768078,
  "device_type": "raspberry-pi",
  "slug": "sl/balena-sound",
  "commit": "c47e79d135676a2a7b547b1de0f117eb"
}
```
```
balena help apps
List all applications.

USAGE
  $ balena apps

OPTIONS
  -h, --help         show CLI help
  --fields <fields>  only show provided fields (comma-separated)
  --filter <filter>  filter results by partial string match, eg: name=foo
  --json             output in json format
  --no-header        hide table header from output
  --no-truncate      do not truncate output to fit screen
  --sort <sort>      field to sort by (prepend '-' for descending)

DESCRIPTION
...
```
```
$ balena help app
Display information about a single application.

USAGE
  $ balena app <application>

ARGUMENTS
  <application>  application name, slug (preferred), or numeric ID (deprecated)

OPTIONS
  -h, --help         show CLI help
  --fields <fields>  only show provided fields (comma-separated)
  --json             output in json format

DESCRIPTION
...
```

