### PR TITLE
build/deploy: Update QEMU to speed up emulated builds 

### DIFF
--- a/lib/utils/qemu.ts
+++ b/lib/utils/qemu.ts
@@ -19,7 +19,7 @@ import type * as Dockerode from 'dockerode';
 import { getBalenaSdk, stripIndent } from './lazy';
 import Logger = require('./logger');
 
-export const QEMU_VERSION = 'v4.0.0+balena2';
+export const QEMU_VERSION = 'v5.2.0+balena1';
 export const QEMU_BIN_NAME = 'qemu-execve';
 
 export function qemuPathInContext(context: string) {
@@ -96,7 +96,7 @@ export function installQemu(arch: string) {
 				const installStream = fs.createWriteStream(qemuPath);
 
 				const qemuArch = balenaArchToQemuArch(arch);
-				const fileVersion = QEMU_VERSION.replace(/^v/, '').replace('+', '.');
+				const fileVersion = QEMU_VERSION.replace('+', '.');
 				const urlFile = encodeURIComponent(
 					`qemu-${fileVersion}-${qemuArch}.tar.gz`,
 				);


### PR DESCRIPTION
QEMU v5 has quite a few improvements over v4, and the speed
difference when emulating arm is quite noticible.

We tested this with, and without, our single-core limitation
patch and have not been able to reproduce the stability
issues we were seeing in v4 so the patch was removed in
this release.

Change-type: patch
Connects-to: balena-io/balena-io#2340
Signed-off-by: Kyle Harding <kyle@balena.io>

---
Please check the CONTRIBUTING.md file for relevant information and some
guidance. Keep in mind that the CLI is a cross-platform application that runs
on Windows, macOS and Linux. Tests will be automatically run by balena CI on
all three operating systems, but this will only help if you have added test
code that exercises the modified or added feature code.

Note that each commit message (currently only the first line) will be
automatically copied to the CHANGELOG.md file, so try writing it in a way
that describes the feature or fix for CLI users.

If there isn't a linked issue or if the linked issue doesn't quite match the
PR, please add a PR description to explain its purpose or the features that it
implements. Adding PR comments to blocks of code that aren't self explanatory
usually helps with the review process.

If the PR introduces security considerations or affects the development, build
or release process, please be sure to highlight this in the PR description.

Thank you very much for your contribution!
