### PR TITLE
macOS GUI installer: Update signing certificate name

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     },
     "macos": {
       "identifier": "io.balena.cli",
-      "sign": "Developer ID Installer: Rulemotion Ltd (66H43P8FRG)"
+      "sign": "Developer ID Installer: Balena Ltd (66H43P8FRG)"
     },
     "plugins": [
       "@oclif/plugin-help"


### PR DESCRIPTION
The name of the old / current certificate issued in June 2019 is:
`Developer ID Installer: Rulemotion Ltd (66H43P8FRG)`

The name of the new certificate issued in Feb / Mar 2021 is:
`Developer ID Installer: Balena Ltd (66H43P8FRG)`

Change-type: patch
