### PR TITLE
build, deploy: Fix error handling when QEMU download fails

### DIFF
--- a/tests/commands/build.spec.ts
+++ b/tests/commands/build.spec.ts
@@ -257,12 +257,16 @@ describe('balena build', function () {
 		const qemuMod = require(qemuModPath);
 		const qemuBinPath = await qemuMod.getQemuPath(arch);
 		try {
+			// patch fs.access and fs.stat to pretend that a copy of the Qemu binary
+			// already exists locally, thus preventing a download during tests
 			mock(fsModPath, {
 				...fsMod,
 				promises: {
 					...fsMod.promises,
 					access: async (p: string) =>
 						p === qemuBinPath ? undefined : fsMod.promises.access(p),
+					stat: async (p: string) =>
+						p === qemuBinPath ? { size: 1 } : fsMod.promises.stat(p),
 				},
 			});
 			mock(qemuModPath, {


### PR DESCRIPTION
Fixes a bug where the CLI would leave behind zero-length QEMU executable files if the user specified an invalid architecture on the command line for the build/deploy commands, e.g. `--arch foo` instead of `--arch armv7hf`, and subsequent executions would no longer re-download QEMU because a QEMU file already existed (despite being corrupt).

Sample broken files before this PR:
```
# ls -l ~/.balena/bin/
total 5476
-rw-r--r-- 1 root root       0 Dec 17 23:57 qemu-execve-arm-v4.0.0+balena2
-rwxr-xr-x 1 root root 5606984 Dec 17 23:30 qemu-execve-armv7hf-v4.0.0+balena2
-rw-r--r-- 1 root root       0 Dec 17 23:57 qemu-execve-i386-v4.0.0+balena2
-rw-r--r-- 1 root root       0 Dec 17 23:57 qemu-execve-x86-v4.0.0+balena2
```

This PR also "standardizes" the cached file names to use the "QEMU arch" instead of the "balena arch", meaning that there can only be 2 variants on disk: `arm` and `aarch64` (as opposed to multiple other archs like `rpi`, `armv7hf`, `i386` etc).

Note: this PR is a spin-off PR #2145 (commit extracted from there, to simplify that PR).

Change-type: patch
