### PR TITLE
fix proxy support bullet point spacing

### DIFF
--- a/doc/cli.markdown
+++ b/doc/cli.markdown
@@ -68,7 +68,6 @@ HTTP(S) proxies can be configured through any of the following methods, in prece
   file](https://www.npmjs.com/package/balena-settings-client#documentation). It may be:
   * A string in URL format, e.g. `proxy: 'http://localhost:8000'`
   * An object in the format:
-
     ```yaml
     proxy:
         protocol: 'http'


### PR DESCRIPTION
component: Make `Proxy Support` sub-bullet point spacing uniform

Change-type: patch
Signed-off-by: Genadi Naydenov genadi@balena.com

Resolves: balena-io/docs#797