### PR TITLE
docker: Improve handling of Docker-in-Docker errors

### DIFF
--- a/docker/DOCKER.md
+++ b/docker/DOCKER.md
@@ -68,7 +68,7 @@ These environment variables are available for additional functionality included 
 In most cases these are optional, but some examples will highlight when environment variables are required.
 
 - `-e "SSH_PRIVATE_KEY=$(</path/to/priv/key)"`: copy your private SSH key file contents as an environment variable
-- `-e "DOCKERD=1"`: enable the included Docker-in-Docker daemon (requires `--cap-add SYS_ADMIN`)
+- `-e "DOCKERD=1"`: enable the included Docker-in-Docker daemon (requires `--privileged`)
 
 ## Keeping the CLI image up to date
 
@@ -269,8 +269,6 @@ $ docker run --rm -it -v "balena_data:/root/.balena" \
 > exit
 ```
 
-
-
 ### preload
 
 - <https://www.balena.io/docs/reference/balena-cli/#os-download-type>
@@ -284,7 +282,7 @@ The easiest way to run this command is to use the included Docker-in-Docker daem
 ```bash
 $ docker run --rm -it -v "balena_data:/root/.balena" \
     -v "docker_data:/var/lib/docker" \
-    -e "DOCKERD=1" --cap-add SYS_ADMIN \
+    -e "DOCKERD=1" --privileged \
     balenalib/amd64-debian-balenacli /bin/bash
 
 > balena os download raspberrypi3 -o raspberry-pi.img
@@ -331,7 +329,7 @@ This bind mount is required so the CLI has access to your app sources.
 ```bash
 $ docker run --rm -it -v "balena_data:/root/.balena" \
     -v "docker_data:/var/lib/docker" \
-    -e DOCKERD=1 --cap-add SYS_ADMIN \
+    -e DOCKERD=1 --privileged \
     -v "$PWD:$PWD" -w "$PWD" \
     balenalib/amd64-debian-balenacli /bin/bash
 

--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -41,3 +41,6 @@ ENTRYPOINT [ "/usr/src/app/init.sh" ]
 CMD [ "help" ]
 
 ENV SSH_AUTH_SOCK "/ssh-agent"
+
+# docker data must be a volume or tmpfs
+VOLUME /var/lib/docker

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -41,3 +41,6 @@ ENTRYPOINT [ "/usr/src/app/init.sh" ]
 CMD [ "help" ]
 
 ENV SSH_AUTH_SOCK "/ssh-agent"
+
+# docker data must be a volume or tmpfs
+VOLUME /var/lib/docker

--- a/docker/docker-init.sh
+++ b/docker/docker-init.sh
@@ -4,7 +4,12 @@
 if [ "${DOCKERD}" = "1" ]
 then
     [ -e /var/run/docker.sock ] && rm /var/run/docker.sock
-    dockerd &
+    dockerd --log-driver=local 2>&1 | tee /tmp/dockerd.log &
+    while ! grep -q 'API listen on' /tmp/dockerd.log
+    do
+        grep -q 'Error starting daemon' /tmp/dockerd.log && exit 1
+        sleep 1
+    done
 fi
 
 # load private ssh key if one is provided


### PR DESCRIPTION
The `local` logging driver captures output from container’s stdout/stderr
and writes them to an internal storage that is optimized for performance and disk use.

We also want to capture these logs on startup to wait for success/failure.

Advise the use of `--privileged` when running Docker-in-Docker to avoid
various permissions issues encountered in testing.

Change-type: patch
Changlelog-entry: docker: Improve handling of Docker-in-Docker errors
Signed-off-by: Kyle Harding <kyle@balena.io>