### PR TITLE
docker: Install official static docker binaries

### DIFF
--- a/docker/DOCKER.md
+++ b/docker/DOCKER.md
@@ -397,12 +397,12 @@ export BALENA_DISTRO="debian"
 # provide the architecture where you will be testing the image
 export BALENA_ARCH="amd64"
 
-# optionally register QEMU binfmt if building for other architectures (eg. armv7hf)
-$ docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+# optionally register QEMU binfmt if building for other architectures (eg. rpi)
+docker run --rm --privileged multiarch/qemu-user-static:5.2.0-2 --reset -p yes
 
 # build and tag an image with docker
 docker build . -f docker/${BALENA_DISTRO}/Dockerfile \
-    --build-arg "BUILD_BASE=balenalib/${BALENA_ARCH}-${BALENA_DISTRO}-node:12.19.1-build" \
-    --build-arg "RUN_BASE=balenalib/${BALENA_ARCH}-${BALENA_DISTRO}-node:12.19.1-run" \
+    --build-arg "BUILD_BASE=balenalib/${BALENA_ARCH}-${BALENA_DISTRO}-node:12.19-build" \
+    --build-arg "RUN_BASE=balenalib/${BALENA_ARCH}-${BALENA_DISTRO}-node:12.19-run" \
     --tag "balenalib/${BALENA_ARCH}-${BALENA_DISTRO}-balenacli"
 ```

--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -3,6 +3,26 @@ ARG RUN_BASE=balenalib/amd64-alpine-node:12.19.1-run
 
 FROM ${BUILD_BASE} as build
 
+WORKDIR /usr/src/docker
+
+ARG DOCKER_VERSION=19.03.8
+
+# set pipefail before running shell commands with a pipe
+# https://github.com/hadolint/hadolint/wiki/DL4006
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# install official static docker binaries
+# https://github.com/docker-library/docker/blob/master/20.10/Dockerfile
+RUN case "$(apk --print-arch)" in \
+        'aarch64') DOCKER_ARCH='aarch64' ;; \
+        'armhf') DOCKER_ARCH='armel' ;; \
+        'armv7') DOCKER_ARCH='armhf' ;; \
+        'x86_64') DOCKER_ARCH='x86_64' ;; \
+        'x86') DOCKER_ARCH='x86_64' ;; \
+        *) echo >&2 "error: unsupported architecture ($(apk --print-arch))"; exit 1 ;; \
+    esac && \
+    curl -L https://download.docker.com/linux/static/stable/$DOCKER_ARCH/docker-$DOCKER_VERSION.tgz | tar xzv --strip-components 1
+
 WORKDIR /usr/src/app
 
 COPY . .
@@ -18,17 +38,18 @@ RUN npm prune --production
 
 FROM ${RUN_BASE}
 
+# https://github.com/balena-io/balena-cli/blob/master/INSTALL-LINUX.md#additional-dependencies
+RUN install_packages avahi ca-certificates jq openssh
+
 WORKDIR /usr/src/app
 
-COPY --from=build /usr/src/app/ .
+COPY --from=build /usr/src/app/ /usr/src/app/
+COPY --from=build /usr/src/docker/ /usr/local/bin/
 
 ENV PATH $PATH:/usr/src/app/bin
 
-# fail early if balena binary won't run
-RUN balena --version
-
-# https://github.com/balena-io/balena-cli/blob/master/INSTALL-LINUX.md#additional-dependencies
-RUN install_packages avahi bash ca-certificates docker jq openssh
+# fail if binaries are missing or won't run
+RUN echo -n "balena CLI version " && balena --version && dockerd --version && docker --version
 
 COPY docker/docker-init.sh init.sh
 

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -3,6 +3,25 @@ ARG RUN_BASE=balenalib/amd64-debian-node:12.19.1-run
 
 FROM ${BUILD_BASE} as build
 
+WORKDIR /usr/src/docker
+
+ARG DOCKER_VERSION=19.03.8
+
+# set pipefail before running shell commands with a pipe
+# https://github.com/hadolint/hadolint/wiki/DL4006
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# install official static docker binaries
+# https://github.com/docker-library/docker/blob/master/20.10/Dockerfile
+RUN case "$(dpkg --print-architecture)" in \
+        'arm64') DOCKER_ARCH='aarch64' ;; \
+        'amd64') DOCKER_ARCH='x86_64' ;; \
+        'armhf') DOCKER_ARCH='armel' ;; \
+        'i386') DOCKER_ARCH='x86_64' ;; \
+        *) echo >&2 "error: unsupported architecture ($(dpkg --print-architecture))"; exit 1 ;; \
+    esac && \
+    curl -L https://download.docker.com/linux/static/stable/$DOCKER_ARCH/docker-$DOCKER_VERSION.tgz | tar xzv --strip-components 1
+
 WORKDIR /usr/src/app
 
 COPY . .
@@ -18,17 +37,20 @@ RUN npm prune --production
 
 FROM ${RUN_BASE}
 
+# https://github.com/balena-io/balena-cli/blob/master/INSTALL-LINUX.md#additional-dependencies
+RUN install_packages avahi-daemon ca-certificates iptables jq openssh-client && \
+    update-alternatives --set iptables /usr/sbin/iptables-legacy && \
+    update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
+
 WORKDIR /usr/src/app
 
-COPY --from=build /usr/src/app/ .
+COPY --from=build /usr/src/app/ /usr/src/app/
+COPY --from=build /usr/src/docker/ /usr/local/bin/
 
 ENV PATH $PATH:/usr/src/app/bin
 
-# fail early if balena binary won't run
-RUN balena --version
-
-# https://github.com/balena-io/balena-cli/blob/master/INSTALL-LINUX.md#additional-dependencies
-RUN install_packages avahi-daemon ca-certificates docker.io jq openssh-client
+# fail if binaries are missing or won't run
+RUN echo -n "balena CLI version " && balena --version && dockerd --version && docker --version
 
 COPY docker/docker-init.sh init.sh
 


### PR DESCRIPTION
We saw fewer environmental issues when running the alpine container vs debian, likely due to the differences in the docker versions (20 vs 18).

(private link) https://www.flowdock.com/app/rulemotion/r-beginners/threads/pnN3-UtI9EqD1oeJ2DZUzbFlvs9

This PR will install the same static docker binaries on both platforms.

Change-type: patch
Changelog-entry: docker: Install official static docker binaries
Signed-off-by: Kyle Harding <kyle@balena.io>