### PR TITLE
os/configure: Fix broken NetworkManager URL

### DIFF
--- a/doc/cli.markdown
+++ b/doc/cli.markdown
@@ -2084,7 +2084,7 @@ profiles for additional network interfaces, such as cellular/GSM or additional
 WiFi or ethernet connections. This option may be passed multiple times in case there
 are multiple files to inject. See connection profile examples and reference at:
 https://www.balena.io/docs/reference/OS/network/2.x/
-https://developer.gnome.org/NetworkManager/stable/nm-settings.html
+https://developer.gnome.org/NetworkManager/stable/ref-settings.html
 
 The --device-api-key option is deprecated and will be removed in a future release.
 A suitable key is automatically generated or fetched if this option is omitted.

--- a/lib/commands/os/configure.ts
+++ b/lib/commands/os/configure.ts
@@ -84,7 +84,7 @@ export default class OsConfigureCmd extends Command {
 		WiFi or ethernet connections. This option may be passed multiple times in case there
 		are multiple files to inject. See connection profile examples and reference at:
 		https://www.balena.io/docs/reference/OS/network/2.x/
-		https://developer.gnome.org/NetworkManager/stable/nm-settings.html
+		https://developer.gnome.org/NetworkManager/stable/ref-settings.html
 
 		${deviceApiKeyDeprecationMsg.split('\n').join('\n\t\t')}
 


### PR DESCRIPTION
Update the broken NM URL to match the rest of the documentation.

Change-type: patch
Connects-to: balena-io/docs/#1757 balena-io/docs/#1522
Changelog-entry: os/configure: Fix broken NetworkManager URL
Signed-off-by: Mark Corbin <mark@balena.io>
