### PR TITLE
docker: Add support for aarch64-alpine images

### DIFF
--- a/.resinci.yml
+++ b/.resinci.yml
@@ -20,6 +20,14 @@ docker:
   builds:
     - path: .
       dockerfile: ./docker/alpine/Dockerfile
+      docker_repo: balenalib/aarch64-debian-balenacli
+      args:
+        - BUILD_BASE=balenalib/aarch64-alpine-node:12.19.0-build-20201101
+        - RUN_BASE=balenalib/aarch64-alpine-node:12.19.0-run-20201101
+      publish: true
+
+    - path: .
+      dockerfile: ./docker/alpine/Dockerfile
       docker_repo: balenalib/amd64-alpine-balenacli
       args:
         - BUILD_BASE=balenalib/amd64-alpine-node:12.19.1-build-20201211

--- a/docker/DOCKER.md
+++ b/docker/DOCKER.md
@@ -10,7 +10,7 @@ so they include many of the features you see there.
 - Multiple Architectures:
     - `rpi`
     - `armv7hf`
-    - `aarch64` (debian only)
+    - `aarch64`
     - `amd64`
     - `i386`
 - Multiple Distributions
@@ -402,7 +402,7 @@ $ docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 
 # build and tag an image with docker
 docker build . -f docker/${BALENA_DISTRO}/Dockerfile \
-    --build-arg "BUILD_BASE=balenalib/${BALENA_ARCH}-${BALENA_DISTRO}-node:12.19.1-build" \
-    --build-arg "RUN_BASE=balenalib/${BALENA_ARCH}-${BALENA_DISTRO}-node:12.19.1-run" \
+    --build-arg "BUILD_BASE=balenalib/${BALENA_ARCH}-${BALENA_DISTRO}-node:12.19-build" \
+    --build-arg "RUN_BASE=balenalib/${BALENA_ARCH}-${BALENA_DISTRO}-node:12.19-run" \
     --tag "balenalib/${BALENA_ARCH}-${BALENA_DISTRO}-balenacli"
 ```


### PR DESCRIPTION
Depends-on: https://github.com/balena-io/balena-cli/pull/2168
Change-type: patch
Changelog-entry: docker: Add support for aarch64-alpine images
Signed-off-by: Kyle Harding <kyle@balena.io>