### PR TITLE
Rename supported docker-compose overlay file

### DIFF
--- a/lib/utils/compose_ts.ts
+++ b/lib/utils/compose_ts.ts
@@ -172,7 +172,7 @@ async function mergeDevComposeOverlay(
 	composeStr: string,
 	projectRoot: string,
 ) {
-	const devOverlayFilename = 'docker-compose.dev.yml';
+	const devOverlayFilename = 'docker-compose.override.yml';
 	const devOverlayPath = path.join(projectRoot, devOverlayFilename);
 
 	if (await exists(devOverlayPath)) {


### PR DESCRIPTION
This amends a previous commit allowing users to specify a docker-compose.override.yml instead of a docker-compose.dev.yml file, which is merged in local pushes, and allows extra/alternative services to be declared.
Change-type: minor
Signed-off-by: