### PR TITLE
ssh: fix incorrect service name parsing in local mode

### DIFF
--- a/lib/utils/device/ssh.ts
+++ b/lib/utils/device/ssh.ts
@@ -50,7 +50,7 @@ export async function performLocalDeviceSSH(
 		});
 
 		const regex = new RegExp(`(^|\\/)${escapeRegExp(opts.service)}_\\d+_\\d+`);
-		const nameRegex = /\/?([a-zA-Z0-9_]+)_\d+_\d+/;
+		const nameRegex = /\/?([a-zA-Z0-9_-]+)_\d+_\d+/;
 		let allContainers: ContainerInfo[];
 		try {
 			allContainers = await docker.listContainers();


### PR DESCRIPTION
Silly bug that was bothering me for some time now :P

Resolves: #2252
Change-type: patch
Signed-off-by: Tomás Migone <tomas@balena.io>
