### PR TITLE
preload: Update to Docker 20.10 with cgroups v2 support

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3442,9 +3442,9 @@
       }
     },
     "balena-preload": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/balena-preload/-/balena-preload-10.4.1.tgz",
-      "integrity": "sha512-/DHvtF7qPg3cfHfZxP3+EInqtqlwD/czTyIxBMnieZb/4UMISL/6fXPFsVYhxTwAeNmTsBaH+KTj4Owb5Lz5AA==",
+      "version": "10.4.2",
+      "resolved": "https://registry.npmjs.org/balena-preload/-/balena-preload-10.4.2.tgz",
+      "integrity": "sha512-IObDEgpR6+0M6UJhNVHun9dez8Nz6/fpVFowR08BkhBcfy5vR+cff+5AGMgNqg7fwcHgdqKT9MN5gab35PB3/Q==",
       "requires": {
         "archiver": "^3.1.1",
         "balena-sdk": "^15.3.1",

--- a/package.json
+++ b/package.json
@@ -203,7 +203,7 @@
     "balena-errors": "^4.7.1",
     "balena-image-fs": "^7.0.6",
     "balena-image-manager": "^7.0.3",
-    "balena-preload": "^10.4.1",
+    "balena-preload": "^10.4.2",
     "balena-release": "^3.0.0",
     "balena-sdk": "^15.31.0",
     "balena-semver": "^2.3.0",


### PR DESCRIPTION
Update balena-preload from 10.4.1 to 10.4.2.

Change-type: patch
Changelog-entry: preload: Update to Docker 20.10 with cgroups v2 support
Signed-off-by: Kyle Harding <kyle@balena.io>

Resolves: https://github.com/balena-io/balena-cli/issues/2250
