### PR TITLE
preload: Update balena-preload to 10.4.7

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3443,9 +3443,9 @@
       }
     },
     "balena-preload": {
-      "version": "10.4.6",
-      "resolved": "https://registry.npmjs.org/balena-preload/-/balena-preload-10.4.6.tgz",
-      "integrity": "sha512-/wcAd8LNMTEbIWsNiXUJZov1SZBTjr0A4fpOJAkDn9woCSm4UBsNQfOJ3Wj7eYB1G5meD1XmmCTxQwa9suZa6A==",
+      "version": "10.4.7",
+      "resolved": "https://registry.npmjs.org/balena-preload/-/balena-preload-10.4.7.tgz",
+      "integrity": "sha512-lsE0aVhgm7pPFVm1Rvt12RvZpP4pN8N5mXDEvETh6o16RQLNwJAek9HzBY0yenM/D0CEoFjRkI/QavCiSdgn+A==",
       "requires": {
         "archiver": "^3.1.1",
         "balena-sdk": "^15.3.1",

--- a/package.json
+++ b/package.json
@@ -204,7 +204,7 @@
     "balena-errors": "^4.7.1",
     "balena-image-fs": "^7.0.6",
     "balena-image-manager": "^7.0.3",
-    "balena-preload": "^10.4.6",
+    "balena-preload": "^10.4.7",
     "balena-release": "^3.0.0",
     "balena-sdk": "^15.31.0",
     "balena-semver": "^2.3.0",


### PR DESCRIPTION

Resolves: https://github.com/balena-io/balena-cli/issues/2231
Change-type: patch
Changelog-entry: preload: Avoid hardcoded registry2 URLs with openBalena
Signed-off-by: Kyle Harding <kyle@balena.io>
