### PR TITLE
preload: Catch sfdisk errors that result in an endless spinner

### DIFF
--- a/lib/commands/preload.ts
+++ b/lib/commands/preload.ts
@@ -169,6 +169,14 @@ Can be repeated to add multiple certificates.\
 		try {
 			const fs = await import('fs');
 			await fs.promises.access(params.image);
+			const path = await import('path');
+			if (path.extname(params.image) === '.zip') {
+				console.warn(stripIndent`
+					------------------------------------------------------------------------------
+					Warning: A zip file is only accepted for the Intel Edison device type.
+					------------------------------------------------------------------------------
+					`);
+			}
 		} catch (error) {
 			throw new ExpectedError(
 				`The provided image path does not exist: ${params.image}`,

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3443,9 +3443,9 @@
       }
     },
     "balena-preload": {
-      "version": "10.4.7",
-      "resolved": "https://registry.npmjs.org/balena-preload/-/balena-preload-10.4.7.tgz",
-      "integrity": "sha512-lsE0aVhgm7pPFVm1Rvt12RvZpP4pN8N5mXDEvETh6o16RQLNwJAek9HzBY0yenM/D0CEoFjRkI/QavCiSdgn+A==",
+      "version": "10.4.8",
+      "resolved": "https://registry.npmjs.org/balena-preload/-/balena-preload-10.4.8.tgz",
+      "integrity": "sha512-HENu1BfBW+f9VthtpentxU24inhGI1pJX1Q42Qv+iHyXoBxbd2GzCW88vvWjRbll8j+jM25PzkSABqxFRWYXMA==",
       "requires": {
         "archiver": "^3.1.1",
         "balena-sdk": "^15.3.1",

--- a/package.json
+++ b/package.json
@@ -205,7 +205,7 @@
     "balena-errors": "^4.7.1",
     "balena-image-fs": "^7.0.6",
     "balena-image-manager": "^7.0.3",
-    "balena-preload": "^10.4.7",
+    "balena-preload": "^10.4.8",
     "balena-release": "^3.0.0",
     "balena-sdk": "^15.36.0",
     "balena-semver": "^2.3.0",


### PR DESCRIPTION
See: https://github.com/balena-io-modules/balena-preload/pull/247
Resolves: #1810, #2045
Change-type: patch
Changelog-entry: preload: Catch sfdisk errors that result in an endless spinner
Signed-off-by: Kyle Harding <kyle@balena.io>