### PR TITLE
os download: Improve error message for misspelled device type names

### DIFF
--- a/lib/commands/os/download.ts
+++ b/lib/commands/os/download.ts
@@ -95,6 +95,11 @@ export default class OsDownloadCmd extends Command {
 
 		const { downloadOSImage } = await import('../../utils/cloud');
 
-		await downloadOSImage(params.type, options.output, options.version);
+		try {
+			await downloadOSImage(params.type, options.output, options.version);
+		} catch (e) {
+			e.deviceTypeSlug = params.type;
+			throw e;
+		}
 	}
 }

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -174,6 +174,13 @@ const messages: {
 	BalenaExpiredToken: () => stripIndent`
 		Looks like the session token has expired.
 		Try logging in again with the "balena login" command.`,
+
+	BalenaInvalidDeviceType: (error: Error & { deviceTypeSlug?: string }) => {
+		const slug = error.deviceTypeSlug ? `"${error.deviceTypeSlug}"` : 'slug';
+		return stripIndent`
+			Device type ${slug} not recognized. Perhaps misspelled?
+			Check available device types with "balena devices supported"`;
+	},
 };
 
 // TODO remove these regexes when we have a way of uniquely indentifying errors.


### PR DESCRIPTION
Change-type: patch
See: https://www.flowdock.com/app/rulemotion/i-cli/threads/hIJdzM8vBkXo9G21xMfqEzodQP6

Before this PR:
```
$ balena os download raspberry-pi4 -o balena.img
Getting device operating system for raspberry-pi4
OS version not specified: using latest stable version
BalenaInvalidDeviceType: Invalid device type: No such device type
```

After this PR:
```
$ balena os download raspberry-pi4 -o balena.img
Getting device operating system for raspberry-pi4
OS version not specified: using latest stable version
Device type "raspberry-pi4" not recognized. Perhaps misspelled?
Check available device types with "balena devices supported"
```
