### PR TITLE
preload: Restore support for armv7 with custom preload image

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3792,9 +3792,9 @@
       }
     },
     "balena-preload": {
-      "version": "10.4.20",
-      "resolved": "https://registry.npmjs.org/balena-preload/-/balena-preload-10.4.20.tgz",
-      "integrity": "sha512-uKbccD1oh7BQ9XUMXYQvGklfws1v9+oaWkYxE0eheh+0GcHP+CVWr/TIUx+P3eplh7cAfeZAxw0wx0jp8H1Ttg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/balena-preload/-/balena-preload-10.5.0.tgz",
+      "integrity": "sha512-tgnTyOSOLB3HxIqlR1NFrTsy1eiiew5Vzmplb82/eZc/vJTrOqal2tFNn6aFay6UQ8+OASUJwANC99zBu1e8mQ==",
       "requires": {
         "archiver": "^3.1.1",
         "balena-sdk": "^15.44.0",
@@ -3828,9 +3828,9 @@
           }
         },
         "balena-sdk": {
-          "version": "15.45.0",
-          "resolved": "https://registry.npmjs.org/balena-sdk/-/balena-sdk-15.45.0.tgz",
-          "integrity": "sha512-lfz6x8yL7nV+zHTC2+w30Dtv7I5rz8IxoO6Ifjb4/ewkhz6LyX1/UhH/a4k83oaQMXIuoYnmwWE6iVx/zl9xXQ==",
+          "version": "15.48.0",
+          "resolved": "https://registry.npmjs.org/balena-sdk/-/balena-sdk-15.48.0.tgz",
+          "integrity": "sha512-wZnfeZhPSl04HsnovXheWJc0+yoQY6XMZ/iMt0hYFOMmhdtNSj8PQTnPRnlnxiXEjXOQ2mOUYcGCLpykeuAWPg==",
           "requires": {
             "@balena/es-version": "^1.0.0",
             "@types/lodash": "^4.14.168",
@@ -3938,9 +3938,9 @@
           }
         },
         "tslib": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
-          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
         },
         "zip-stream": {
           "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -204,7 +204,7 @@
     "balena-errors": "^4.7.1",
     "balena-image-fs": "^7.0.6",
     "balena-image-manager": "^7.0.3",
-    "balena-preload": "^10.4.20",
+    "balena-preload": "^v10.5.0",
     "balena-release": "^3.0.0",
     "balena-sdk": "^15.36.0",
     "balena-semver": "^2.3.0",


### PR DESCRIPTION
Depends-on: https://github.com/balena-io-modules/balena-preload/pull/251
Resolves: https://github.com/balena-io/balena-cli/issues/2290
Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>

If anyone could help out with testing this PR it would be much appreciated!

- [x] MacOS
- [ ] MacOS (M1)
- [x] Windows 10
- [x] Windows 11
- [x] Linux (armv7)
- [x] Linux (aarch64)
- [x] Linux (x86_64)
- [x] Linux w/ cgroups v2 (Fedora 33+ or Arch Linux)
