### PR TITLE
balena deploy: Retrieve the cpu arch as part of the device type resource

### DIFF
--- a/tests/commands/deploy.spec.ts
+++ b/tests/commands/deploy.spec.ts
@@ -79,8 +79,7 @@ describe('balena deploy', function () {
 		docker = new DockerMock();
 		api.expectGetWhoAmI({ optional: true, persist: true });
 		api.expectGetMixpanel({ optional: true });
-		api.expectGetConfigDeviceTypes();
-		api.expectGetApplication();
+		api.expectGetApplication({ expandArchitecture: true });
 		api.expectGetRelease();
 		api.expectGetUser();
 		api.expectGetService({ serviceName: 'main' });

--- a/tests/nock/balena-api-mock.ts
+++ b/tests/nock/balena-api-mock.ts
@@ -35,6 +35,7 @@ export class BalenaAPIMock extends NockMock {
 		notFound = false,
 		optional = false,
 		persist = false,
+		expandArchitecture = false,
 	} = {}) {
 		const interceptor = this.optGet(/^\/v6\/application($|[(?])/, {
 			optional,
@@ -45,7 +46,12 @@ export class BalenaAPIMock extends NockMock {
 		} else {
 			interceptor.replyWithFile(
 				200,
-				path.join(apiResponsePath, 'application-GET-v6-expanded-app-type.json'),
+				path.join(
+					apiResponsePath,
+					!expandArchitecture
+						? 'application-GET-v6-expanded-app-type.json'
+						: 'application-GET-v6-expanded-app-type-cpu-arch.json',
+				),
 				jHeader,
 			);
 		}

--- a/tests/test-data/api-response/application-GET-v6-expanded-app-type-cpu-arch.json
+++ b/tests/test-data/api-response/application-GET-v6-expanded-app-type-cpu-arch.json
@@ -1,0 +1,53 @@
+{
+	"d": [
+		{
+			"application_type": [
+				{
+					"name": "Starter",
+					"slug": "microservices-starter",
+					"supports_multicontainer": true,
+					"is_legacy": false,
+					"__metadata": {}
+				}
+			],
+			"id": 1301645,
+			"user": {
+				"__deferred": {
+					"uri": "/resin/user(43699)"
+				},
+				"__id": 43699
+			},
+			"organization": [
+				{
+					"handle": "gh_user"
+				}
+			],
+			"depends_on__application": null,
+			"actor": 3423895,
+			"app_name": "testApp",
+			"slug": "gh_user/testApp",
+			"should_be__running_release": [
+				{
+					"commit": "96eec431d57e6976d3a756df33fde7e2"
+				}
+			],
+			"is_for__device_type": [
+				{
+					"slug": "raspberrypi3",
+					"is_of__cpu_architecture": [
+						{
+							"slug": "armv7hf"
+						}
+					]
+				}
+			],
+			"should_track_latest_release": true,
+			"is_accessible_by_support_until__date": null,
+			"is_public": false,
+			"is_host": false,
+			"__metadata": {
+				"uri": "/resin/application(@id)?@id=1301645"
+			}
+		}
+	]
+}


### PR DESCRIPTION
Connects-to: #2318
Change-type: patch
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

<!-- You can remove tags that do not apply. -->
Resolves: # <!-- Refer an issue of this repository that this PR fixes -->  
Change-type: major|minor|patch <!-- See https://semver.org/ -->  
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->  
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->  

---
Please check the CONTRIBUTING.md file for relevant information and some
guidance. Keep in mind that the CLI is a cross-platform application that runs
on Windows, macOS and Linux. Tests will be automatically run by balena CI on
all three operating systems, but this will only help if you have added test
code that exercises the modified or added feature code.

Note that each commit message (currently only the first line) will be
automatically copied to the CHANGELOG.md file, so try writing it in a way
that describes the feature or fix for CLI users.

If there isn't a linked issue or if the linked issue doesn't quite match the
PR, please add a PR description to explain its purpose or the features that it
implements. Adding PR comments to blocks of code that aren't self explanatory
usually helps with the review process.

If the PR introduces security considerations or affects the development, build
or release process, please be sure to highlight this in the PR description.

Thank you very much for your contribution!
