### PR TITLE
v13 preparations: Add feature switch for removal of '--gitignore' (push, build)

### DIFF
--- a/doc/cli.markdown
+++ b/doc/cli.markdown
@@ -2926,15 +2926,15 @@ Don't convert line endings from CRLF (Windows format) to LF (Unix format).
 
 Have each service use its own .dockerignore file. See "balena help push".
 
-#### -G, --nogitignore
-
-No-op (default behavior) since balena CLI v12.0.0. See "balena help push".
-
 #### -g, --gitignore
 
 Consider .gitignore files in addition to the .dockerignore file. This reverts
 to the CLI v11 behavior/implementation (deprecated) if compatibility is
 required until your project can be adapted.
+
+#### -G, --nogitignore
+
+No-op (default behavior) since balena CLI v12.0.0. See "balena help push".
 
 #### --release-tag RELEASE-TAG
 
@@ -3159,13 +3159,13 @@ Consider .gitignore files in addition to the .dockerignore file. This reverts
 to the CLI v11 behavior/implementation (deprecated) if compatibility is required
 until your project can be adapted.
 
-#### -m, --multi-dockerignore
-
-Have each service use its own .dockerignore file. See "balena help build".
-
 #### -G, --nogitignore
 
 No-op (default behavior) since balena CLI v12.0.0. See "balena help build".
+
+#### -m, --multi-dockerignore
+
+Have each service use its own .dockerignore file. See "balena help build".
 
 #### --noparent-check
 
@@ -3398,13 +3398,13 @@ Consider .gitignore files in addition to the .dockerignore file. This reverts
 to the CLI v11 behavior/implementation (deprecated) if compatibility is required
 until your project can be adapted.
 
-#### -m, --multi-dockerignore
-
-Have each service use its own .dockerignore file. See "balena help build".
-
 #### -G, --nogitignore
 
 No-op (default behavior) since balena CLI v12.0.0. See "balena help build".
+
+#### -m, --multi-dockerignore
+
+Have each service use its own .dockerignore file. See "balena help build".
 
 #### --noparent-check
 

--- a/lib/commands/build.ts
+++ b/lib/commands/build.ts
@@ -266,7 +266,7 @@ ${dockerignoreHelp}
 			inlineLogs: composeOpts.inlineLogs,
 			convertEol: composeOpts.convertEol,
 			dockerfilePath: composeOpts.dockerfilePath,
-			nogitignore: composeOpts.nogitignore,
+			nogitignore: composeOpts.nogitignore, // v13: delete this line
 			multiDockerignore: composeOpts.multiDockerignore,
 		});
 	}

--- a/lib/commands/deploy.ts
+++ b/lib/commands/deploy.ts
@@ -314,7 +314,7 @@ ${dockerignoreHelp}
 					inlineLogs: composeOpts.inlineLogs,
 					convertEol: composeOpts.convertEol,
 					dockerfilePath: composeOpts.dockerfilePath,
-					nogitignore: composeOpts.nogitignore,
+					nogitignore: composeOpts.nogitignore, // v13: delete this line
 					multiDockerignore: composeOpts.multiDockerignore,
 				});
 				builtImagesByService = _.keyBy(builtImages, 'serviceName');

--- a/lib/commands/push.ts
+++ b/lib/commands/push.ts
@@ -47,8 +47,8 @@ interface FlagsDef {
 	pull: boolean;
 	'noparent-check': boolean;
 	'registry-secrets'?: string;
-	gitignore?: boolean;
-	nogitignore?: boolean;
+	gitignore?: boolean; // v13: delete this flag
+	nogitignore?: boolean; // v13: delete this flag
 	nolive: boolean;
 	detached: boolean;
 	service?: string[];
@@ -237,11 +237,20 @@ export default class PushCmd extends Command {
 				'Have each service use its own .dockerignore file. See "balena help push".',
 			char: 'm',
 			default: false,
-			exclusive: ['gitignore'],
+			exclusive: ['gitignore'], // v13: delete this line
 		}),
 		...(isV13()
 			? {}
 			: {
+					gitignore: flags.boolean({
+						description: stripIndent`
+					Consider .gitignore files in addition to the .dockerignore file. This reverts
+					to the CLI v11 behavior/implementation (deprecated) if compatibility is
+					required until your project can be adapted.`,
+						char: 'g',
+						default: false,
+						exclusive: ['multi-dockerignore'],
+					}),
 					nogitignore: flags.boolean({
 						description:
 							'No-op (default behavior) since balena CLI v12.0.0. See "balena help push".',
@@ -250,15 +259,6 @@ export default class PushCmd extends Command {
 						default: false,
 					}),
 			  }),
-		gitignore: flags.boolean({
-			description: stripIndent`
-		Consider .gitignore files in addition to the .dockerignore file. This reverts
-		to the CLI v11 behavior/implementation (deprecated) if compatibility is
-		required until your project can be adapted.`,
-			char: 'g',
-			default: false,
-			exclusive: ['multi-dockerignore'],
-		}),
 		'release-tag': flags.string({
 			description: stripIndent`
 				Set release tags if the image build is successful (balenaCloud only). Multiple
@@ -378,7 +378,7 @@ export default class PushCmd extends Command {
 			source: options.source,
 			auth: token,
 			baseUrl,
-			nogitignore: !options.gitignore,
+			nogitignore: !options.gitignore, // v13: delete this line
 			sdk,
 			opts,
 		};
@@ -422,7 +422,7 @@ export default class PushCmd extends Command {
 				multiDockerignore: options['multi-dockerignore'],
 				nocache: options.nocache,
 				pull: options.pull,
-				nogitignore: !options.gitignore,
+				nogitignore: !options.gitignore, // v13: delete this line
 				noParentCheck: options['noparent-check'],
 				nolive: options.nolive,
 				detached: options.detached,

--- a/lib/utils/compose-types.d.ts
+++ b/lib/utils/compose-types.d.ts
@@ -51,7 +51,7 @@ export interface ComposeOpts {
 	dockerfilePath?: string;
 	inlineLogs?: boolean;
 	multiDockerignore: boolean;
-	nogitignore: boolean;
+	nogitignore: boolean; // v13: delete this line
 	noParentCheck: boolean;
 	projectName: string;
 	projectPath: string;
@@ -63,9 +63,9 @@ export interface ComposeCliFlags {
 	dockerfile?: string;
 	logs: boolean;
 	nologs: boolean;
-	gitignore: boolean;
+	gitignore?: boolean; // v13: delete this line
+	nogitignore?: boolean; // v13: delete this line
 	'multi-dockerignore': boolean;
-	nogitignore: boolean;
 	'noparent-check': boolean;
 	'registry-secrets'?: RegistrySecrets;
 	'convert-eol': boolean;
@@ -102,6 +102,6 @@ interface TarDirectoryOptions {
 	composition?: Composition;
 	convertEol?: boolean;
 	multiDockerignore?: boolean;
-	nogitignore: boolean;
+	nogitignore: boolean; // v13: delete this line
 	preFinalizeCallback?: (pack: Pack) => void | Promise<void>;
 }

--- a/lib/utils/compose.js
+++ b/lib/utils/compose.js
@@ -18,6 +18,7 @@
 import * as path from 'path';
 import { ExpectedError } from '../errors';
 import { getChalk } from './lazy';
+import { isV13 } from './version';
 
 /**
  * @returns Promise<{import('./compose-types').ComposeOpts}>
@@ -25,7 +26,7 @@ import { getChalk } from './lazy';
 export function generateOpts(options) {
 	const { promises: fs } = require('fs');
 
-	if (options.gitignore && options['multi-dockerignore']) {
+	if (!isV13() && options.gitignore && options['multi-dockerignore']) {
 		throw new ExpectedError(
 			'The --gitignore and --multi-dockerignore options cannot be used together',
 		);
@@ -37,7 +38,7 @@ export function generateOpts(options) {
 		convertEol: !options['noconvert-eol'],
 		dockerfilePath: options.dockerfile,
 		multiDockerignore: !!options['multi-dockerignore'],
-		nogitignore: !options.gitignore,
+		nogitignore: !options.gitignore, // v13: delete this line
 		noParentCheck: options['noparent-check'],
 	}));
 }
@@ -92,6 +93,8 @@ export function createProject(composePath, composeStr, projectName = null) {
  * @param {string} dir Source directory
  * @param {import('./compose-types').TarDirectoryOptions} param
  * @returns {Promise<import('stream').Readable>}
+ *
+ * v13: delete this function
  */
 export async function originalTarDirectory(dir, param) {
 	let {

--- a/lib/utils/device/deploy.ts
+++ b/lib/utils/device/deploy.ts
@@ -57,7 +57,7 @@ export interface DeviceDeployOptions {
 	registrySecrets: RegistrySecrets;
 	multiDockerignore: boolean;
 	nocache: boolean;
-	nogitignore: boolean;
+	nogitignore: boolean; // v13: delete this line
 	noParentCheck: boolean;
 	nolive: boolean;
 	pull: boolean;
@@ -182,7 +182,7 @@ export async function deployToDevice(opts: DeviceDeployOptions): Promise<void> {
 		convertEol: opts.convertEol,
 		dockerfilePath: opts.dockerfilePath,
 		multiDockerignore: opts.multiDockerignore,
-		nogitignore: opts.nogitignore,
+		nogitignore: opts.nogitignore, // v13: delete this line
 		noParentCheck: opts.noParentCheck,
 		projectName: 'local',
 		projectPath: opts.source,
@@ -201,7 +201,7 @@ export async function deployToDevice(opts: DeviceDeployOptions): Promise<void> {
 		composition: project.composition,
 		convertEol: opts.convertEol,
 		multiDockerignore: opts.multiDockerignore,
-		nogitignore: opts.nogitignore,
+		nogitignore: opts.nogitignore, // v13: delete this line
 	});
 
 	// Try to detect the device information
@@ -426,7 +426,7 @@ export async function rebuildSingleTask(
 		composition,
 		convertEol: opts.convertEol,
 		multiDockerignore: opts.multiDockerignore,
-		nogitignore: opts.nogitignore,
+		nogitignore: opts.nogitignore, // v13: delete this line
 	});
 
 	const task = _.find(

--- a/lib/utils/ignore.ts
+++ b/lib/utils/ignore.ts
@@ -27,6 +27,7 @@ import { ExpectedError } from '../errors';
 
 const { toPosixPath } = MultiBuild.PathUtils;
 
+// v13: delete this enum
 export enum IgnoreFileType {
 	DockerIgnore,
 	GitIgnore,
@@ -42,6 +43,8 @@ interface IgnoreEntry {
  * This class is used by the CLI v10 / v11 "original" tarDirectory function
  * in `compose.js`. It is still around for the benefit of the `--gitignore`
  * option, but is expected to be deleted in CLI v13.
+ *
+ * v13: delete this class
  */
 export class FileIgnorer {
 	private dockerIgnoreEntries: IgnoreEntry[];

--- a/lib/utils/messages.ts
+++ b/lib/utils/messages.ts
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import { isV13 } from './version';
+
 export const reachingOut = `\
 For further help or support, visit:
 https://www.balena.io/docs/reference/balena-cli/#support-faq-and-troubleshooting
@@ -48,7 +50,8 @@ used. Find out more at: https://git.io/JRHUW#deprecation-policy
  * where the length of the dash rows matches the length of the longest line.
  */
 export function warnify(msg: string, prefix = '[Warn] ') {
-	const lines = msg.split('\n').map((l) => `${prefix}${l}`);
+	let lines = msg.split('\n');
+	lines = prefix ? lines.map((l) => `${prefix}${l}`) : lines;
 	const maxLength = Math.max(...lines.map((l) => l.length));
 	const hr = '-'.repeat(maxLength);
 	return [hr, ...lines, hr].join('\n');
@@ -85,7 +88,7 @@ If the --registry-secrets option is not specified, and a secrets.yml or
 secrets.json file exists in the balena directory (usually $HOME/.balena),
 this file will be used instead.`;
 
-export const dockerignoreHelp =
+const dockerignoreHelpV12 =
 	'DOCKERIGNORE AND GITIGNORE FILES  \n' +
 	`By default, the balena CLI will use a single ".dockerignore" file (if any) at
 the project root (--source directory) in order to decide which source files to
@@ -137,6 +140,60 @@ adding counter patterns to the applicable .dockerignore file(s), for example
 \`!mysubmodule/.git\`. For documentation on pattern format, see:
 - https://docs.docker.com/engine/reference/builder/#dockerignore-file
 - https://www.npmjs.com/package/@balena/dockerignore`;
+
+const dockerignoreHelpV13 =
+	'DOCKERIGNORE AND GITIGNORE FILES  \n' +
+	`By default, the balena CLI will use a single ".dockerignore" file (if any) at
+the project root (--source directory) in order to decide which source files to
+exclude from the "build context" (tar stream) sent to balenaCloud, Docker
+daemon or balenaEngine.  In a microservices (multicontainer) fleet, the
+source directory is the directory that contains the "docker-compose.yml" file.
+
+The --multi-dockerignore (-m) option may be used with microservices
+(multicontainer) fleets that define a docker-compose.yml file. When this
+option is used, each service subdirectory (defined by the \`build\` or
+\`build.context\` service properties in the docker-compose.yml file) is
+filtered separately according to a .dockerignore file defined in the service
+subdirectory. If no .dockerignore file exists in a service subdirectory, then
+only the default .dockerignore patterns (see below) apply for that service
+subdirectory.
+
+When the --multi-dockerignore (-m) option is used, the .dockerignore file (if
+any) defined at the overall project root will be used to filter files and
+subdirectories other than service subdirectories. It will not have any effect
+on service subdirectories, whether or not a service subdirectory defines its
+own .dockerignore file. Multiple .dockerignore files are not merged or added
+together, and cannot override or extend other files. This behavior maximizes
+compatibility with the standard docker-compose tool, while still allowing a
+root .dockerignore file (at the overall project root) to filter files and
+folders that are outside service subdirectories.
+
+balena CLI v11 also took .gitignore files into account. This behavior was
+deprecated in CLI v12 and removed in CLI v13. Please use .dockerignore files
+instead.
+
+Default .dockerignore patterns  \n` +
+	`A few default/hardcoded dockerignore patterns are "merged" (in memory) with the
+patterns found in the applicable .dockerignore files, in the following order:
+\`\`\`
+    **/.git
+    < user's patterns from the applicable '.dockerignore' file, if any >
+    !**/.balena
+    !**/.resin
+    !**/Dockerfile
+    !**/Dockerfile.*
+    !**/docker-compose.yml
+\`\`\`
+These patterns always apply, whether or not .dockerignore files exist in the
+project. If necessary, the effect of the \`**/.git\` pattern may be modified by
+adding exception patterns to the applicable .dockerignore file(s), for example
+\`!mysubmodule/.git\`. For documentation on pattern format, see:
+- https://docs.docker.com/engine/reference/builder/#dockerignore-file
+- https://www.npmjs.com/package/@balena/dockerignore`;
+
+export const dockerignoreHelp = isV13()
+	? dockerignoreHelpV13
+	: dockerignoreHelpV12;
 
 export const applicationIdInfo = `\
 Fleets may be specified by fleet name, slug, or numeric ID. Fleet slugs are

--- a/lib/utils/remote-build.ts
+++ b/lib/utils/remote-build.ts
@@ -50,7 +50,7 @@ export interface RemoteBuild {
 	source: string;
 	auth: string;
 	baseUrl: string;
-	nogitignore: boolean;
+	nogitignore: boolean; // v13: delete this line
 	opts: BuildOpts;
 	sdk: BalenaSDK;
 	// For internal use
@@ -321,7 +321,7 @@ async function getTarStream(build: RemoteBuild): Promise<Stream.Readable> {
 			preFinalizeCallback: preFinalizeCb,
 			convertEol: build.opts.convertEol,
 			multiDockerignore: build.opts.multiDockerignore,
-			nogitignore: build.nogitignore,
+			nogitignore: build.nogitignore, // v13: delete this line
 		});
 	} finally {
 		tarSpinner.stop();

--- a/tests/commands/deploy.spec.ts
+++ b/tests/commands/deploy.spec.ts
@@ -23,6 +23,7 @@ import * as nock from 'nock';
 import * as path from 'path';
 import * as sinon from 'sinon';
 
+import { isV13 } from '../../build/utils/version';
 import { BalenaAPIMock } from '../nock/balena-api-mock';
 import { expectStreamNoCRLF, testDockerBuildStream } from '../docker-build';
 import { DockerMock, dockerResponsePath } from '../nock/docker-mock';
@@ -65,9 +66,6 @@ const commonComposeQueryParams = {
 	},
 	labels: '',
 };
-
-const hr =
-	'----------------------------------------------------------------------';
 
 describe('balena deploy', function () {
 	let api: BalenaAPIMock;
@@ -143,7 +141,9 @@ describe('balena deploy', function () {
 		api.expectPostImageLabel();
 
 		await testDockerBuildStream({
-			commandLine: `deploy testApp --build --source ${projectPath} -G`,
+			commandLine: `deploy testApp --build --source ${projectPath} ${
+				isV13() ? '' : '-G'
+			}`,
 			dockerMock: docker,
 			expectedFilesByService: { main: expectedFiles },
 			expectedQueryParamsByService: { main: commonQueryParams },
@@ -304,7 +304,9 @@ describe('balena deploy', function () {
 			sinon.stub(process, 'exit');
 
 			await testDockerBuildStream({
-				commandLine: `deploy testApp --build --source ${projectPath} --noconvert-eol -G`,
+				commandLine: `deploy testApp --build --source ${projectPath} --noconvert-eol ${
+					isV13() ? '' : '-G'
+				}`,
 				dockerMock: docker,
 				expectedFilesByService: { main: expectedFiles },
 				expectedQueryParamsByService: { main: commonQueryParams },
@@ -385,11 +387,11 @@ describe('balena deploy', function () {
 				'[Build] service2 Step 1/4 : FROM busybox',
 			],
 			...[
-				`[Info] ${hr}`,
+				`[Info] ---------------------------------------------------------------------------`,
 				'[Info] The --multi-dockerignore option is being used, and a .dockerignore file was',
 				'[Info] found at the project source (root) directory. Note that this file will not',
 				'[Info] be used to filter service subdirectories. See "balena help deploy".',
-				`[Info] ${hr}`,
+				`[Info] ---------------------------------------------------------------------------`,
 			],
 		];
 		if (isWindows) {

--- a/tests/commands/device/devices.spec.ts
+++ b/tests/commands/device/devices.spec.ts
@@ -59,8 +59,9 @@ describe('balena devices', function () {
 		const lines = cleanOutput(out);
 
 		expect(lines[0].replace(/  +/g, ' ')).to.equal(
-			'ID UUID DEVICE NAME DEVICE TYPE APPLICATION NAME STATUS ' +
-				'IS ONLINE SUPERVISOR VERSION OS VERSION DASHBOARD URL',
+			isV13()
+				? 'ID UUID DEVICE NAME DEVICE TYPE FLEET STATUS IS ONLINE SUPERVISOR VERSION OS VERSION DASHBOARD URL'
+				: 'ID UUID DEVICE NAME DEVICE TYPE APPLICATION NAME STATUS IS ONLINE SUPERVISOR VERSION OS VERSION DASHBOARD URL',
 		);
 		expect(lines).to.have.lengthOf.at.least(2);
 

--- a/tests/commands/env/envs.spec.ts
+++ b/tests/commands/env/envs.spec.ts
@@ -21,11 +21,7 @@ import { stripIndent } from '../../../lib/utils/lazy';
 import { BalenaAPIMock } from '../../nock/balena-api-mock';
 import { runCommand } from '../../helpers';
 
-import {
-	appToFleetFlagMsg,
-	appToFleetOutputMsg,
-	warnify,
-} from '../../../build/utils/messages';
+import { appToFleetOutputMsg, warnify } from '../../../build/utils/messages';
 import { isV13 } from '../../../build/utils/version';
 
 describe('balena envs', function () {
@@ -48,13 +44,6 @@ describe('balena envs', function () {
 		api.done();
 	});
 
-	const appToFleetFlagWarn =
-		!isV13() &&
-		process.stderr.isTTY &&
-		process.env.BALENA_CLI_TEST_TYPE !== 'standalone'
-			? warnify(appToFleetFlagMsg) + '\n'
-			: '';
-
 	const appToFleetOutputWarn =
 		!isV13() &&
 		process.stderr.isTTY &&
@@ -67,18 +56,18 @@ describe('balena envs', function () {
 		api.expectGetAppEnvVars();
 		api.expectGetAppServiceVars();
 
-		const { out, err } = await runCommand(`envs -a ${appName}`);
+		const { out, err } = await runCommand(`envs -f ${appName}`);
 
 		expect(out.join('')).to.equal(
 			stripIndent`
-			ID     NAME  VALUE       APPLICATION SERVICE
-			120110 svar1 svar1-value test        service1
-			120111 svar2 svar2-value test        service2
-			120101 var1  var1-val    test        *
-			120102 var2  22          test        *
+			ID     NAME  VALUE       FLEET SERVICE
+			120110 svar1 svar1-value test  service1
+			120111 svar2 svar2-value test  service2
+			120101 var1  var1-val    test  *
+			120102 var2  22          test  *
 		` + '\n',
 		);
-		expect(err.join('')).to.equal(appToFleetFlagWarn);
+		expect(err.join('')).to.equal('');
 	});
 
 	it('should successfully list config vars for a test fleet', async () => {
@@ -101,11 +90,11 @@ describe('balena envs', function () {
 		api.expectGetApplication();
 		api.expectGetAppConfigVars();
 
-		const { out, err } = await runCommand(`envs -cja ${appName}`);
+		const { out, err } = await runCommand(`envs -cjf ${appName}`);
 
 		expect(JSON.parse(out.join(''))).to.deep.equal([
 			{
-				appName: 'test',
+				fleetName: 'test',
 				id: 120300,
 				name: 'RESIN_SUPERVISOR_NATIVE_LOGGER',
 				value: 'false',
@@ -122,18 +111,18 @@ describe('balena envs', function () {
 		api.expectGetAppServiceVars();
 
 		const { out, err } = await runCommand(
-			`envs -a ${appName} -s ${serviceName}`,
+			`envs -f ${appName} -s ${serviceName}`,
 		);
 
 		expect(out.join('')).to.equal(
 			stripIndent`
-		ID     NAME  VALUE       APPLICATION SERVICE
-		120111 svar2 svar2-value test        service2
-		120101 var1  var1-val    test        *
-		120102 var2  22          test        *
+		ID     NAME  VALUE       FLEET SERVICE
+		120111 svar2 svar2-value test  service2
+		120101 var1  var1-val    test  *
+		120102 var2  22          test  *
 		` + '\n',
 		);
-		expect(err.join('')).to.equal(appToFleetFlagWarn);
+		expect(err.join('')).to.equal('');
 	});
 
 	it('should successfully list env and service vars for a test fleet (-s flags)', async () => {
@@ -144,18 +133,18 @@ describe('balena envs', function () {
 		api.expectGetAppServiceVars();
 
 		const { out, err } = await runCommand(
-			`envs -a ${appName} -s ${serviceName}`,
+			`envs -f ${appName} -s ${serviceName}`,
 		);
 
 		expect(out.join('')).to.equal(
 			stripIndent`
-		ID     NAME  VALUE       APPLICATION SERVICE
-		120110 svar1 svar1-value test        ${serviceName}
-		120101 var1  var1-val    test        *
-		120102 var2  22          test        *
+		ID     NAME  VALUE       FLEET SERVICE
+		120110 svar1 svar1-value test  ${serviceName}
+		120101 var1  var1-val    test  *
+		120102 var2  22          test  *
 		` + '\n',
 		);
-		expect(err.join('')).to.equal(appToFleetFlagWarn);
+		expect(err.join('')).to.equal('');
 	});
 
 	it('should successfully list env variables for a test device', async () => {
@@ -167,22 +156,29 @@ describe('balena envs', function () {
 		api.expectGetDeviceServiceVars();
 
 		const uuid = shortUUID;
-		const { out, err } = await runCommand(`envs -d ${uuid}`);
-
-		expect(out.join('')).to.equal(
+		const result = await runCommand(`envs -d ${uuid}`);
+		const { err } = result;
+		let { out } = result;
+		let expected =
 			stripIndent`
-		ID     NAME  VALUE       APPLICATION DEVICE  SERVICE
-		120110 svar1 svar1-value test        *       service1
-		120111 svar2 svar2-value test        *       service2
-		120120 svar3 svar3-value test        ${uuid} service1
-		120121 svar4 svar4-value test        ${uuid} service2
-		120101 var1  var1-val    test        *       *
-		120102 var2  22          test        *       *
-		120203 var3  var3-val    test        ${uuid} *
-		120204 var4  44          test        ${uuid} *
-		` + '\n',
-		);
-
+			ID     NAME  VALUE       APPLICATION DEVICE  SERVICE
+			120110 svar1 svar1-value test        *       service1
+			120111 svar2 svar2-value test        *       service2
+			120120 svar3 svar3-value test        ${uuid} service1
+			120121 svar4 svar4-value test        ${uuid} service2
+			120101 var1  var1-val    test        *       *
+			120102 var2  22          test        *       *
+			120203 var3  var3-val    test        ${uuid} *
+			120204 var4  44          test        ${uuid} *
+			` + '\n';
+		if (isV13()) {
+			out = out.map((l) => l.replace(/ +/g, ' '));
+			expected = expected
+				.replace(/ +/g, ' ')
+				.replace(' APPLICATION ', ' FLEET ')
+				.replace(/ test /g, ' org/test ');
+		}
+		expect(out.join('')).to.equal(expected);
 		expect(err.join('')).to.equal(appToFleetOutputWarn);
 	});
 
@@ -195,9 +191,7 @@ describe('balena envs', function () {
 		api.expectGetDeviceServiceVars();
 
 		const { out, err } = await runCommand(`envs -jd ${shortUUID}`);
-
-		expect(JSON.parse(out.join(''))).to.deep.equal(
-			JSON.parse(`[
+		let expected = `[
 			{ "id": 120101, "appName": "test", "deviceUUID": "*", "name": "var1", "value": "var1-val", "serviceName": "*" },
 			{ "id": 120102, "appName": "test", "deviceUUID": "*", "name": "var2", "value": "22", "serviceName": "*" },
 			{ "id": 120110, "appName": "test", "deviceUUID": "*", "name": "svar1", "value": "svar1-value", "serviceName": "service1" },
@@ -206,9 +200,14 @@ describe('balena envs', function () {
 			{ "id": 120121, "appName": "test", "deviceUUID": "${fullUUID}", "name": "svar4", "value": "svar4-value", "serviceName": "service2" },
 			{ "id": 120203, "appName": "test", "deviceUUID": "${fullUUID}", "name": "var3", "value": "var3-val", "serviceName": "*" },
 			{ "id": 120204, "appName": "test", "deviceUUID": "${fullUUID}", "name": "var4", "value": "44", "serviceName": "*" }
-		]`),
-		);
-
+		]`;
+		if (isV13()) {
+			expected = expected.replace(
+				/"appName": "test"/g,
+				'"fleetName": "org/test"',
+			);
+		}
+		expect(JSON.parse(out.join(''))).to.deep.equal(JSON.parse(expected));
 		expect(err.join('')).to.equal('');
 	});
 
@@ -218,16 +217,23 @@ describe('balena envs', function () {
 		api.expectGetApplication();
 		api.expectGetAppConfigVars();
 
-		const { out, err } = await runCommand(`envs -d ${shortUUID} --config`);
-
-		expect(out.join('')).to.equal(
+		const result = await runCommand(`envs -d ${shortUUID} --config`);
+		const { err } = result;
+		let { out } = result;
+		let expected =
 			stripIndent`
-		ID     NAME                           VALUE  APPLICATION DEVICE
-		120300 RESIN_SUPERVISOR_NATIVE_LOGGER false  test        *
-		120400 RESIN_SUPERVISOR_POLL_INTERVAL 900900 test        ${shortUUID}
-		` + '\n',
-		);
-
+			ID     NAME                           VALUE  APPLICATION DEVICE
+			120300 RESIN_SUPERVISOR_NATIVE_LOGGER false  test        *
+			120400 RESIN_SUPERVISOR_POLL_INTERVAL 900900 test        ${shortUUID}
+		` + '\n';
+		if (isV13()) {
+			out = out.map((l) => l.replace(/ +/g, ' '));
+			expected = expected
+				.replace(/ +/g, ' ')
+				.replace(' APPLICATION ', ' FLEET ')
+				.replace(/ test /g, ' org/test ');
+		}
+		expect(out.join('')).to.equal(expected);
 		expect(err.join('')).to.equal(appToFleetOutputWarn);
 	});
 
@@ -242,20 +248,27 @@ describe('balena envs', function () {
 		api.expectGetDeviceEnvVars();
 
 		const uuid = shortUUID;
-		const { out, err } = await runCommand(`envs -d ${uuid} -s ${serviceName}`);
-
-		expect(out.join('')).to.equal(
+		const result = await runCommand(`envs -d ${uuid} -s ${serviceName}`);
+		const { err } = result;
+		let { out } = result;
+		let expected =
 			stripIndent`
-		ID     NAME  VALUE       APPLICATION DEVICE  SERVICE
-		120111 svar2 svar2-value test        *       service2
-		120121 svar4 svar4-value test        ${uuid} service2
-		120101 var1  var1-val    test        *       *
-		120102 var2  22          test        *       *
-		120203 var3  var3-val    test        ${uuid} *
-		120204 var4  44          test        ${uuid} *
-		` + '\n',
-		);
-
+			ID     NAME  VALUE       APPLICATION DEVICE  SERVICE
+			120111 svar2 svar2-value test        *       service2
+			120121 svar4 svar4-value test        ${uuid} service2
+			120101 var1  var1-val    test        *       *
+			120102 var2  22          test        *       *
+			120203 var3  var3-val    test        ${uuid} *
+			120204 var4  44          test        ${uuid} *
+		` + '\n';
+		if (isV13()) {
+			out = out.map((l) => l.replace(/ +/g, ' '));
+			expected = expected
+				.replace(/ +/g, ' ')
+				.replace(' APPLICATION ', ' FLEET ')
+				.replace(/ test /g, ' org/test ');
+		}
+		expect(out.join('')).to.equal(expected);
 		expect(err.join('')).to.equal(appToFleetOutputWarn);
 	});
 
@@ -265,18 +278,24 @@ describe('balena envs', function () {
 		api.expectGetDeviceServiceVars();
 
 		const uuid = shortUUID;
-
-		const { out, err } = await runCommand(`envs -d ${uuid}`);
-
-		expect(out.join('')).to.equal(
+		const result = await runCommand(`envs -d ${uuid}`);
+		const { err } = result;
+		let { out } = result;
+		let expected =
 			stripIndent`
 			ID     NAME  VALUE       APPLICATION DEVICE  SERVICE
 			120120 svar3 svar3-value N/A         ${uuid} service1
 			120121 svar4 svar4-value N/A         ${uuid} service2
 			120203 var3  var3-val    N/A         ${uuid} *
 			120204 var4  44          N/A         ${uuid} *
-			` + '\n',
-		);
+		` + '\n';
+		if (isV13()) {
+			out = out.map((l) => l.replace(/ +/g, ' '));
+			expected = expected
+				.replace(/ +/g, ' ')
+				.replace(' APPLICATION ', ' FLEET ');
+		}
+		expect(out.join('')).to.equal(expected);
 		expect(err.join('')).to.equal(appToFleetOutputWarn);
 	});
 
@@ -291,19 +310,27 @@ describe('balena envs', function () {
 		api.expectGetDeviceServiceVars();
 
 		const uuid = shortUUID;
-		const { out, err } = await runCommand(`envs -d ${uuid} -s ${serviceName}`);
-
-		expect(out.join('')).to.equal(
+		const result = await runCommand(`envs -d ${uuid} -s ${serviceName}`);
+		const { err } = result;
+		let { out } = result;
+		let expected =
 			stripIndent`
-		ID     NAME  VALUE       APPLICATION DEVICE  SERVICE
-		120110 svar1 svar1-value test        *       ${serviceName}
-		120120 svar3 svar3-value test        ${uuid} ${serviceName}
-		120101 var1  var1-val    test        *       *
-		120102 var2  22          test        *       *
-		120203 var3  var3-val    test        ${uuid} *
-		120204 var4  44          test        ${uuid} *
-		` + '\n',
-		);
+			ID     NAME  VALUE       APPLICATION DEVICE  SERVICE
+			120110 svar1 svar1-value test        *       ${serviceName}
+			120120 svar3 svar3-value test        ${uuid} ${serviceName}
+			120101 var1  var1-val    test        *       *
+			120102 var2  22          test        *       *
+			120203 var3  var3-val    test        ${uuid} *
+			120204 var4  44          test        ${uuid} *
+		` + '\n';
+		if (isV13()) {
+			out = out.map((l) => l.replace(/ +/g, ' '));
+			expected = expected
+				.replace(/ +/g, ' ')
+				.replace(' APPLICATION ', ' FLEET ')
+				.replace(/ test /g, ' org/test ');
+		}
+		expect(out.join('')).to.equal(expected);
 		expect(err.join('')).to.equal(appToFleetOutputWarn);
 	});
 
@@ -320,17 +347,21 @@ describe('balena envs', function () {
 		const { out, err } = await runCommand(
 			`envs -d ${shortUUID} -js ${serviceName}`,
 		);
-
-		expect(JSON.parse(out.join(''))).to.deep.equal(
-			JSON.parse(`[
-				{ "id": 120101, "appName": "test", "deviceUUID": "*", "name": "var1", "value": "var1-val", "serviceName": "*" },
-				{ "id": 120102, "appName": "test", "deviceUUID": "*", "name": "var2", "value": "22", "serviceName": "*" },
-				{ "id": 120110, "appName": "test", "deviceUUID": "*", "name": "svar1", "value": "svar1-value", "serviceName": "${serviceName}" },
-				{ "id": 120120, "appName": "test", "deviceUUID": "${fullUUID}", "name": "svar3", "value": "svar3-value", "serviceName": "${serviceName}" },
-				{ "id": 120203, "appName": "test", "deviceUUID": "${fullUUID}", "name": "var3", "value": "var3-val", "serviceName": "*" },
-				{ "id": 120204, "appName": "test", "deviceUUID": "${fullUUID}", "name": "var4", "value": "44", "serviceName": "*" }
-			]`),
-		);
+		let expected = `[
+			{ "id": 120101, "appName": "test", "deviceUUID": "*", "name": "var1", "value": "var1-val", "serviceName": "*" },
+			{ "id": 120102, "appName": "test", "deviceUUID": "*", "name": "var2", "value": "22", "serviceName": "*" },
+			{ "id": 120110, "appName": "test", "deviceUUID": "*", "name": "svar1", "value": "svar1-value", "serviceName": "${serviceName}" },
+			{ "id": 120120, "appName": "test", "deviceUUID": "${fullUUID}", "name": "svar3", "value": "svar3-value", "serviceName": "${serviceName}" },
+			{ "id": 120203, "appName": "test", "deviceUUID": "${fullUUID}", "name": "var3", "value": "var3-val", "serviceName": "*" },
+			{ "id": 120204, "appName": "test", "deviceUUID": "${fullUUID}", "name": "var4", "value": "44", "serviceName": "*" }
+		]`;
+		if (isV13()) {
+			expected = expected.replace(
+				/"appName": "test"/g,
+				'"fleetName": "org/test"',
+			);
+		}
+		expect(JSON.parse(out.join(''))).to.deep.equal(JSON.parse(expected));
 		expect(err.join('')).to.equal('');
 	});
 });

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -105,7 +105,7 @@ async function runCommandInProcess(cmd: string): Promise<TestOutput> {
 	const unhookIntercept = intercept(stdoutHook, stderrHook);
 
 	try {
-		await balenaCLI.run(preArgs.concat(cmd.split(' ')), {
+		await balenaCLI.run(preArgs.concat(cmd.split(' ').filter((c) => c)), {
 			noFlush: true,
 		});
 	} finally {
@@ -160,7 +160,7 @@ async function runCommandInSubprocess(
 	await new Promise<void>((resolve) => {
 		const child = execFile(
 			standalonePath,
-			cmd.split(' '),
+			cmd.split(' ').filter((c) => c),
 			{ env: { ...process.env, ...addedEnvs } },
 			($error, $stdout, $stderr) => {
 				stderr = $stderr || '';

--- a/tests/projects.ts
+++ b/tests/projects.ts
@@ -86,7 +86,6 @@ export async function addRegSecretsEntries(
 
 export function getDockerignoreWarn1(paths: string[], cmd: string) {
 	const lines = [
-		'[Warn] ----------------------------------------------------------------------',
 		'[Warn] The following .dockerignore file(s) will not be used:',
 	];
 	lines.push(...paths.map((p) => `[Warn] * ${p}`));
@@ -96,7 +95,6 @@ export function getDockerignoreWarn1(paths: string[], cmd: string) {
 			'[Warn] root) is used. Microservices (multicontainer) fleets may use a separate',
 			'[Warn] .dockerignore file for each service with the --multi-dockerignore (-m)',
 			`[Warn] option. See "balena help ${cmd}" for more details.`,
-			'[Warn] ----------------------------------------------------------------------',
 		],
 	);
 	return lines;
@@ -104,7 +102,6 @@ export function getDockerignoreWarn1(paths: string[], cmd: string) {
 
 export function getDockerignoreWarn2(paths: string[], cmd: string) {
 	const lines = [
-		'[Warn] ----------------------------------------------------------------------',
 		'[Warn] The following .dockerignore file(s) will not be used:',
 	];
 	lines.push(...paths.map((p) => `[Warn] * ${p}`));
@@ -114,7 +111,6 @@ export function getDockerignoreWarn2(paths: string[], cmd: string) {
 			"[Warn] root of each service's build context (in a microservices/multicontainer",
 			'[Warn] fleet), plus a .dockerignore file at the overall project root, are used.',
 			`[Warn] See "balena help ${cmd}" for more details.`,
-			'[Warn] ----------------------------------------------------------------------',
 		],
 	);
 	return lines;

--- a/tests/utils/ignore.spec.ts
+++ b/tests/utils/ignore.spec.ts
@@ -7,6 +7,9 @@ import { FileIgnorer, IgnoreFileType } from '../../build/utils/ignore';
 // of the FileIgnorer class to prevent a Typescript compilation error (this
 // behavior is by design: see
 // https://github.com/microsoft/TypeScript/issues/19335 )
+//
+// v13: delete this file
+//
 describe('File ignorer', function () {
 	it('should detect ignore files', function () {
 		const f = new FileIgnorer(`.${path.sep}`);


### PR DESCRIPTION
Preparations for the release of CLI v13. The changes take effect when the version field in `package.json` is eventually updated to v13.0.0 or later (feature switch: avoids the need for a separate release branch).

Change-type: patch
