### PR TITLE
os versions, os download: Add support for balenaOS ESR versions

### DIFF
--- a/doc/cli.markdown
+++ b/doc/cli.markdown
@@ -2240,6 +2240,9 @@ device UUID
 Show the available balenaOS versions for the given device type.
 Check available types with `balena devices supported`.
 
+balenaOS ESR versions can be listed with the '--esr' option. See also:
+https://www.balena.io/docs/reference/OS/extended-support-release/
+
 Examples:
 
 	$ balena os versions raspberrypi3
@@ -2252,23 +2255,28 @@ device type
 
 ### Options
 
+#### --esr
+
+select balenaOS ESR versions
+
 ## os download &#60;type&#62;
 
-Download an unconfigured OS image for a certain device type.
-Check available types with `balena devices supported`
+Download an unconfigured OS image for the specified device type.
+Check available device types with 'balena devices supported'.
 
 Note: Currently this command only works with balenaCloud, not openBalena.
 If using openBalena, please download the OS from: https://www.balena.io/os/
 
-If version is not specified the newest stable (non-pre-release) version of OS
-is downloaded (if available), otherwise the newest version (if all existing
-versions for the given device type are pre-release).
+The '--version' option is used to select the balenaOS version. If omitted,
+the latest released version is downloaded (and if only pre-release versions
+exist, the latest pre-release version is downloaded).
 
-You can pass `--version menu` to pick the OS version from the interactive menu
-of all available versions.
+Use '--version menu' or '--version menu-esr' to interactively select the
+OS version. The latter lists ESR versions which are only available for
+download on Production and Enterprise plans. See also:
+https://www.balena.io/docs/reference/OS/extended-support-release/
 
-To download a development image append `.dev` to the version or select from
-the interactive menu.
+Development images can be selected by appending `.dev` to the version.
 
 Examples:
 
@@ -2294,11 +2302,13 @@ output path
 
 #### --version VERSION
 
-exact version number, or a valid semver range,
+version number (ESR or non-ESR versions),
+or semver range (non-ESR versions only),
 or 'latest' (includes pre-releases),
-or 'default' (excludes pre-releases if at least one stable version is available),
+or 'default' (excludes pre-releases if at least one released version is available),
 or 'recommended' (excludes pre-releases, will fail if only pre-release versions are available),
-or 'menu' (will show the interactive menu)
+or 'menu' (interactive menu, non-ESR versions),
+or 'menu-esr' (interactive menu, ESR versions)
 
 ## os build-config &#60;image&#62; &#60;device-type&#62;
 

--- a/lib/commands/os/download.ts
+++ b/lib/commands/os/download.ts
@@ -34,21 +34,22 @@ export default class OsDownloadCmd extends Command {
 	public static description = stripIndent`
 		Download an unconfigured OS image.
 
-		Download an unconfigured OS image for a certain device type.
-		Check available types with \`balena devices supported\`
+		Download an unconfigured OS image for the specified device type.
+		Check available device types with 'balena devices supported'.
 
 		Note: Currently this command only works with balenaCloud, not openBalena.
 		If using openBalena, please download the OS from: https://www.balena.io/os/
 
-		If version is not specified the newest stable (non-pre-release) version of OS
-		is downloaded (if available), otherwise the newest version (if all existing
-		versions for the given device type are pre-release).
+		The '--version' option is used to select the balenaOS version. If omitted,
+		the latest released version is downloaded (and if only pre-release versions
+		exist, the latest pre-release version is downloaded).
 
-		You can pass \`--version menu\` to pick the OS version from the interactive menu
-		of all available versions.
+		Use '--version menu' or '--version menu-esr' to interactively select the
+		OS version. The latter lists ESR versions which are only available for
+		download on Production and Enterprise plans. See also:
+		https://www.balena.io/docs/reference/OS/extended-support-release/
 
-		To download a development image append \`.dev\` to the version or select from
-		the interactive menu.
+		Development images can be selected by appending \`.dev\` to the version.
 `;
 	public static examples = [
 		'$ balena os download raspberrypi3 -o ../foo/bar/raspberry-pi.img',
@@ -78,11 +79,13 @@ export default class OsDownloadCmd extends Command {
 		}),
 		version: flags.string({
 			description: stripIndent`
-				exact version number, or a valid semver range,
+				version number (ESR or non-ESR versions),
+				or semver range (non-ESR versions only),
 				or 'latest' (includes pre-releases),
-				or 'default' (excludes pre-releases if at least one stable version is available),
+				or 'default' (excludes pre-releases if at least one released version is available),
 				or 'recommended' (excludes pre-releases, will fail if only pre-release versions are available),
-				or 'menu' (will show the interactive menu)
+				or 'menu' (interactive menu, non-ESR versions),
+				or 'menu-esr' (interactive menu, ESR versions)
 				`,
 		}),
 		help: cf.help,

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3785,9 +3785,9 @@
       }
     },
     "balena-image-manager": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/balena-image-manager/-/balena-image-manager-7.0.3.tgz",
-      "integrity": "sha512-KLb/5JksYxCR7JClq+MAuCMYPNMAXB9MgqubUvzj4mI/Yec3XD4xZ2BMITwINrl4sMKui/G7t/R5tBNFZsFe9w==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/balena-image-manager/-/balena-image-manager-7.1.0.tgz",
+      "integrity": "sha512-W8Etn0PBQJUlTJ1m1rCuQQ8TTLdkBoNP2SRHQqez2HANQp+T38wFjQXVx9PhQ6J7eqOYuW87SkJiKLpnmlz79Q==",
       "requires": {
         "balena-sdk": "^15.2.1",
         "mime": "^2.4.6",

--- a/package.json
+++ b/package.json
@@ -205,7 +205,7 @@
     "balena-device-init": "^6.0.0",
     "balena-errors": "^4.7.1",
     "balena-image-fs": "^7.0.6",
-    "balena-image-manager": "^7.0.3",
+    "balena-image-manager": "^7.1.0",
     "balena-preload": "^11.0.0",
     "balena-release": "^3.2.0",
     "balena-sdk": "^15.51.1",


### PR DESCRIPTION
Resolves: #2005
Depends-on: balena-io-modules/balena-image-manager/pull/54
See: https://www.flowdock.com/app/rulemotion/resin-devices/threads/BtGUlpKl9fyhDGpI1OJ4W32EfAD
Change-type: minor
