### PR TITLE
os download: Avoid incomplete os downloads appearing as successful

### DIFF
--- a/lib/utils/cloud.ts
+++ b/lib/utils/cloud.ts
@@ -139,6 +139,14 @@ export async function downloadOSImage(
 
 	const displayVersion = OSVersion === 'default' ? '' : ` ${OSVersion}`;
 
+	// Override the default zlib flush value as we've seen cases of
+	// incomplete files being identified as successful downloads when using Z_SYNC_FLUSH.
+	// Using Z_NO_FLUSH results in a Z_BUF_ERROR instead of a corrupt image file.
+	// https://github.com/nodejs/node/blob/master/doc/api/zlib.md#zlib-constants
+	// Hopefully this is a temporary workaround until we can resolve
+	// some ongoing issues with the os download stream.
+	process.env.ZLIB_FLUSH = 'Z_NO_FLUSH';
+
 	const manager = await import('balena-image-manager');
 	const stream = await manager.get(deviceType, OSVersion);
 


### PR DESCRIPTION
By forcing the zlib flush mode to Z_NO_FLUSH we are more likely to
see an error on image download pipelines vs silent failure and
incomplete files.

This is part of a larger investigation and may be removed in the
future when the root cause of the pipeline failures are identified.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>

Requires: https://github.com/balena-io-modules/balena-request/pull/158 (merged in `balena-request@11.4.2`)
Requires: https://github.com/balena-io/balena-sdk/pull/1126 (merged in `balena-sdk@15.51.1`)

See: https://github.com/balena-io/balena-cli/pull/2346#issuecomment-922856907
See: https://github.com/balena-io/balena-cli/issues/2152
