### PR TITLE
Error message when renaming a fleet now mentions the target name.

### DIFF
--- a/lib/commands/app/rename.ts
+++ b/lib/commands/app/rename.ts
@@ -120,7 +120,7 @@ export class FleetRenameCmd extends Command {
 		} catch (e) {
 			// BalenaRequestError: Request error: "organization" and "app_name" must be unique.
 			if ((e.message || '').toLowerCase().includes('unique')) {
-				throw new ExpectedError(`Error: fleet ${params.fleet} already exists.`);
+				throw new ExpectedError(`Error: fleet ${newName} already exists.`);
 			}
 			throw e;
 		}


### PR DESCRIPTION
The source name is shown in the error message instead of the target name.
This patch fixes the error message.

Change-type: patch
Signed-off-by: Carlo Miguel F. Cruz <carloc@balena.io>


---
Please check the CONTRIBUTING.md file for relevant information and some
guidance. Keep in mind that the CLI is a cross-platform application that runs
on Windows, macOS and Linux. Tests will be automatically run by balena CI on
all three operating systems, but this will only help if you have added test
code that exercises the modified or added feature code.

Note that each commit message (currently only the first line) will be
automatically copied to the CHANGELOG.md file, so try writing it in a way
that describes the feature or fix for CLI users.

If there isn't a linked issue or if the linked issue doesn't quite match the
PR, please add a PR description to explain its purpose or the features that it
implements. Adding PR comments to blocks of code that aren't self explanatory
usually helps with the review process.

If the PR introduces security considerations or affects the development, build
or release process, please be sure to highlight this in the PR description.

Thank you very much for your contribution!
