### PR TITLE
Add ability to push to remote device UUID

### DIFF
--- a/doc/cli.markdown
+++ b/doc/cli.markdown
@@ -2913,12 +2913,14 @@ Examples:
 	
 	$ balena push 23c73a1.local --system
 	$ balena push 23c73a1.local --system --service my-service
+	
+	$ balena push 9f0cc5e4-0707-487c-ba84-edd0c36ff1c9
 
 ### Arguments
 
 #### FLEETORDEVICE
 
-fleet name or slug, or local device IP address or ".local" hostname
+fleet name or slug, device UUID, or local device IP address or ".local" hostname
 
 ### Options
 

--- a/doc/cli.markdown
+++ b/doc/cli.markdown
@@ -2914,7 +2914,7 @@ Examples:
 	$ balena push 23c73a1.local --system
 	$ balena push 23c73a1.local --system --service my-service
 	
-	$ balena push 9f0cc5e4-0707-487c-ba84-edd0c36ff1c9
+	$ balena push 8dd2c780aad4dbd3455b5a9412e6e902
 
 ### Arguments
 

--- a/lib/commands/logs.ts
+++ b/lib/commands/logs.ts
@@ -153,7 +153,7 @@ export default class LogsCmd extends Command {
 				const uuid = await getOnlineTargetDeviceUuid(balena, deviceAddress);
 				const device = await balena.models.device.get(uuid);
 				logger.logInfo(`Opening tunnels to ${deviceAddress}`);
-				await openTunnel(logger, device, balena, 48484, 'localhost', 48484);
+				await openTunnel(logger, device, balena, 48484, 'localhost', '48484');
 				// await openTunnel(logger, device, balena, 2375, 'localhost', 2375);
 				logger.logInfo(`Opened tunnels to ${deviceAddress}...`);
 				deviceAddress = '127.0.0.1';

--- a/lib/commands/push.ts
+++ b/lib/commands/push.ts
@@ -113,7 +113,7 @@ export default class PushCmd extends Command {
 		'$ balena push 23c73a1.local --system',
 		'$ balena push 23c73a1.local --system --service my-service',
 		'',
-		'$ balena push 9f0cc5e4-0707-487c-ba84-edd0c36ff1c9',
+		'$ balena push 8dd2c780aad4dbd3455b5a9412e6e902',
 	];
 
 	public static args = [

--- a/lib/commands/push.ts
+++ b/lib/commands/push.ts
@@ -112,13 +112,15 @@ export default class PushCmd extends Command {
 		'',
 		'$ balena push 23c73a1.local --system',
 		'$ balena push 23c73a1.local --system --service my-service',
+		'',
+		'$ balena push 9f0cc5e4-0707-487c-ba84-edd0c36ff1c9',
 	];
 
 	public static args = [
 		{
 			name: 'fleetOrDevice',
 			description:
-				'fleet name or slug, or local device IP address or ".local" hostname',
+				'fleet name or slug, device UUID, or local device IP address or ".local" hostname',
 			required: true,
 			parse: lowercaseIfSlug,
 		},
@@ -315,7 +317,7 @@ export default class PushCmd extends Command {
 				break;
 
 			case BuildTarget.Device:
-				logger.logDebug(`Pushing to local device: ${params.fleetOrDevice}`);
+				logger.logDebug(`Pushing to device: ${params.fleetOrDevice}`);
 				await this.pushToDevice(
 					params.fleetOrDevice,
 					options,
@@ -442,9 +444,9 @@ export default class PushCmd extends Command {
 	}
 
 	protected async getBuildTarget(appOrDevice: string): Promise<BuildTarget> {
-		const { validateLocalHostnameOrIp } = await import('../utils/validation');
+		const { validateDeviceAddress } = await import('../utils/validation');
 
-		return validateLocalHostnameOrIp(appOrDevice)
+		return validateDeviceAddress(appOrDevice)
 			? BuildTarget.Device
 			: BuildTarget.Cloud;
 	}

--- a/lib/commands/tunnel.ts
+++ b/lib/commands/tunnel.ts
@@ -157,8 +157,8 @@ export default class TunnelCmd extends Command {
 		let localAddress = 'localhost';
 
 		// First element is always remotePort
-		const remotePort = parseInt(mappingElements[0], undefined);
-		let localPort = remotePort;
+		const remotePort = mappingElements[0];
+		let localPort = parseInt(remotePort, undefined);
 
 		if (mappingElements.length === 2) {
 			// [1] could be localAddress or localPort
@@ -176,7 +176,7 @@ export default class TunnelCmd extends Command {
 		}
 
 		// Validate results
-		if (!this.isValidPort(remotePort) || !this.isValidPort(localPort)) {
+		if (!this.isValidPort(localPort)) {
 			throw new InvalidPortMappingError(portMapping);
 		}
 

--- a/lib/utils/device/deploy.ts
+++ b/lib/utils/device/deploy.ts
@@ -135,8 +135,8 @@ export async function deployToDevice(opts: DeviceDeployOptions): Promise<void> {
 		const device = await sdk.models.device.get(uuid);
 		logger.logInfo(`Opening tunnels to ${device.uuid}...`);
 
-		await openTunnel(logger, device, sdk, 48484, 'localhost', 48484);
-		await openTunnel(logger, device, sdk, 2375, 'localhost', 2375);
+		await openTunnel(logger, device, sdk, 48484, 'localhost', '48484');
+		await openTunnel(logger, device, sdk, 2375, 'localhost', '2375');
 		logger.logInfo(`Opened tunnels to ${device.uuid}...`);
 
 		opts.deviceHost = 'localhost';

--- a/lib/utils/device/deploy.ts
+++ b/lib/utils/device/deploy.ts
@@ -40,7 +40,10 @@ import { DeviceAPI, DeviceInfo } from './api';
 import * as LocalPushErrors from './errors';
 import LivepushManager from './live';
 import { displayBuildLog } from './logs';
-import { stripIndent } from '../lazy';
+import { getBalenaSdk, stripIndent } from '../lazy';
+import { validateIPAddress } from '../validation';
+import { Server, Socket } from 'net';
+import { BalenaSDK, Device } from 'balena-sdk';
 
 const LOCAL_APPNAME = 'localapp';
 const LOCAL_RELEASEHASH = 'localrelease';
@@ -121,7 +124,110 @@ async function environmentFromInput(
 	return ret;
 }
 
+const logConnection = (
+	logger: Logger,
+	fromHost: string,
+	fromPort: number,
+	localAddress: string,
+	localPort: number,
+	deviceAddress: string,
+	devicePort: number,
+	err?: Error,
+) => {
+	const logMessage = `${fromHost}:${fromPort} => ${localAddress}:${localPort} ===> ${deviceAddress}:${devicePort}`;
+
+	if (err) {
+		logger.logError(`${logMessage} :: ${err.message}`);
+	} else {
+		logger.logLogs(logMessage);
+	}
+};
+
+async function openTunnel(
+	logger: Logger,
+	device: Device,
+	sdk: BalenaSDK,
+	port: number,
+): Promise<any> {
+	const localhost = 'localhost';
+	try {
+		const { tunnelConnectionToDevice } = await import('../tunnel');
+		const handler = await tunnelConnectionToDevice(device.uuid, port, sdk);
+
+		const { createServer } = await import('net');
+		const server = createServer(async (client: Socket) => {
+			try {
+				await handler(client);
+				logConnection(
+					logger,
+					client.remoteAddress || '',
+					client.remotePort || 0,
+					client.localAddress,
+					client.localPort,
+					device.vpn_address || '',
+					port,
+				);
+			} catch (err: any) {
+				logConnection(
+					logger,
+					client.remoteAddress || '',
+					client.remotePort || 0,
+					client.localAddress,
+					client.localPort,
+					device.vpn_address || '',
+					port,
+					err,
+				);
+			}
+		});
+
+		await new Promise<Server>((resolve, reject) => {
+			server.on('error', reject);
+			server.listen(port, localhost, () => {
+				resolve(server);
+			});
+		});
+
+		logger.logInfo(
+			` - tunnelling ${localhost}:${port} to ${device.uuid}:${port}`,
+		);
+
+		// opts.deviceHost = localhost;
+	} catch (err: any) {
+		logger.logWarn(
+			` - tunnel failed ${localhost}:${port} to ${
+				device.uuid
+			}:${port}, failed ${JSON.stringify(err.message)}`,
+		);
+	}
+}
+
 export async function deployToDevice(opts: DeviceDeployOptions): Promise<void> {
+	// Can only communicate with device using IP if local
+	const isLocal =
+		opts.deviceHost.includes('.local') || validateIPAddress(opts.deviceHost)
+			? true
+			: false;
+	if (!isLocal) {
+		// 1. Open tunnel from remote device to localhost
+		// 2. Deploy to localhost
+		const logger = Logger.getLogger();
+		const sdk = getBalenaSdk();
+
+		// Ascertain device uuid
+		const { getOnlineTargetDeviceUuid } = await import('../patterns');
+		const uuid = await getOnlineTargetDeviceUuid(sdk, opts.deviceHost);
+		const device = await sdk.models.device.get(uuid);
+		logger.logInfo(`Opening a tunnel to ${device.uuid}...`);
+
+		await openTunnel(logger, device, sdk, 48484);
+		await openTunnel(logger, device, sdk, 2375);
+
+		logger.logInfo('Opened tunnels to supervisor and docker...');
+
+		opts.deviceHost = 'localhost';
+	}
+
 	// Resolve .local addresses to IP to avoid
 	// issue with Windows and rapid repeat lookups.
 	// see: https://github.com/balena-io/balena-cli/issues/1518
@@ -145,7 +251,7 @@ export async function deployToDevice(opts: DeviceDeployOptions): Promise<void> {
 		throw new ExpectedError(stripIndent`
 			Could not communicate with device supervisor at address ${opts.deviceHost}:${port}.
 			Device may not have local mode enabled. Check with:
-			  balena device local-mode <device-uuid>
+			balena device local-mode <device-uuid>
 		`);
 	}
 

--- a/lib/utils/tunnel.ts
+++ b/lib/utils/tunnel.ts
@@ -35,8 +35,8 @@ class UnableToConnectError extends TypedError {
 }
 
 class RemoteSocketNotListening extends TypedError {
-	public port: number;
-	constructor(port: number) {
+	public port: string;
+	constructor(port: string) {
 		super(`Device is not listening on port ${port}`);
 	}
 }
@@ -48,7 +48,7 @@ export const logConnection = (
 	localAddress: string,
 	localPort: number,
 	deviceAddress: string,
-	devicePort: number,
+	devicePort: string,
 	err?: Error,
 ) => {
 	const logMessage = `${fromHost}:${fromPort} => ${localAddress}:${localPort} ===> ${deviceAddress}:${devicePort}`;
@@ -66,7 +66,7 @@ export const openTunnel = async (
 	sdk: BalenaSDK,
 	localPort: number,
 	localAddress: string,
-	remotePort: number,
+	remotePort: string,
 ) => {
 	try {
 		const handler = await tunnelConnectionToDevice(
@@ -127,7 +127,7 @@ export const openTunnel = async (
 
 export const tunnelConnectionToDevice = (
 	uuid: string,
-	port: number,
+	port: string,
 	sdk: BalenaSDK,
 ) => {
 	return Promise.all([
@@ -172,7 +172,7 @@ const openPortThroughProxy = (
 	proxyPort: number,
 	proxyAuth: { user: string; password: string } | null,
 	deviceUuid: string,
-	devicePort: number,
+	devicePort: string,
 ) => {
 	const httpHeaders = [`CONNECT ${deviceUuid}.balena:${devicePort} HTTP/1.0`];
 

--- a/lib/utils/validation.ts
+++ b/lib/utils/validation.ts
@@ -57,6 +57,10 @@ export function validateDotLocalUrl(input: string): boolean {
 	return DOTLOCAL_REGEX.test(input);
 }
 
+export function validateDeviceAddress(input: string): boolean {
+	return validateLocalHostnameOrIp(input) || validateUuid(input);
+}
+
 export function validateLocalHostnameOrIp(input: string): boolean {
 	return validateIPAddress(input) || validateDotLocalUrl(input);
 }


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Josh Bowling <josh@balena.io>

---

Add ability to push to a device using its UUID. This works for both local and remote devices by first tunneling the device's supervisor API (port `48484`) and the docker service (port `2375`) to `localhost` and then running build as normal but with the target device host being set as `localhost`. The device must be in local mode in order for this to work (otherwise the necessary ports won't be available for tunneling).