### PR TITLE
Update resin-compose-parse from 2.1.3 to 2.3.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -15440,9 +15440,9 @@
       }
     },
     "resin-compose-parse": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/resin-compose-parse/-/resin-compose-parse-2.1.3.tgz",
-      "integrity": "sha512-X5WQo+OHoPe+FV8JliGzSIL4glLX0PPFvtnopppYef1UqKcJm+GHaiEZBOj3C7vIEDqQrsNrKXY/BpadlOFiWA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/resin-compose-parse/-/resin-compose-parse-2.3.0.tgz",
+      "integrity": "sha512-9vE+ascGEXuyTYjLmhwmVOYNkws99Cq7/RtUrgT8VCYJRuhqZMpGMOJPrjEIF6PvsBY7B6+u32x1HPCR4gWHBQ==",
       "requires": {
         "@types/lodash": "^4.14.86",
         "@types/node": "^8.0.55",

--- a/package.json
+++ b/package.json
@@ -265,7 +265,7 @@
     "request": "^2.88.2",
     "resin-cli-form": "^2.0.2",
     "resin-cli-visuals": "^1.8.0",
-    "resin-compose-parse": "^2.1.3",
+    "resin-compose-parse": "^2.3.0",
     "resin-doodles": "^0.1.1",
     "resin-multibuild": "^4.12.2",
     "resin-stream-logger": "^0.1.2",


### PR DESCRIPTION
This adds support for Docker compose v2.4

Closes: #2364
Change-type: patch
Signed-off-by: Tomás Migone <tomas@balena.io>