### PR TITLE
Add support for YAML anchors and aliases in 'docker-compose.yml'

### DIFF
--- a/lib/utils/compose.js
+++ b/lib/utils/compose.js
@@ -63,9 +63,7 @@ export function createProject(
 	const compose = require('resin-compose-parse');
 
 	// both methods below may throw.
-	const rawComposition = yml.load(composeStr, {
-		schema: yml.FAILSAFE_SCHEMA,
-	});
+	const rawComposition = yml.load(composeStr);
 	const composition = compose.normalize(rawComposition);
 
 	projectName ||= path.basename(composePath);


### PR DESCRIPTION
This allows project files to define services from generic fragments by leveraging YAML's anchors and aliases. See here for an example: https://github.com/compose-spec/compose-spec/blob/43f6537b2c8f01b6d3f0e184d13a0f3cb93d38d7/spec.md#fragments

Removing the FAILSAFE_SCHEMA flag is not expected to break existing project files, since the default behaviour is more liberal, or cause problems down the road given we perform validation immediately after. Docs for the flag: https://github.com/nodeca/js-yaml#load-string---options-

Change-type: minor
