### PR TITLE
os download: Prevent image cache from closing the stream early

### DIFF
--- a/lib/utils/cloud.ts
+++ b/lib/utils/cloud.ts
@@ -181,7 +181,7 @@ export async function downloadOSImage(
 	}
 
 	const streamToPromise = await import('stream-to-promise');
-	await streamToPromise(stream.pipe(output));
+	await streamToPromise(stream.pipe(output, { end: false }));
 
 	console.info('The image was downloaded successfully');
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3785,9 +3785,9 @@
       }
     },
     "balena-image-manager": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/balena-image-manager/-/balena-image-manager-7.0.3.tgz",
-      "integrity": "sha512-KLb/5JksYxCR7JClq+MAuCMYPNMAXB9MgqubUvzj4mI/Yec3XD4xZ2BMITwINrl4sMKui/G7t/R5tBNFZsFe9w==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/balena-image-manager/-/balena-image-manager-7.0.4.tgz",
+      "integrity": "sha512-R6BJGpFmS5SwejbJk0ZYNud+/Y/T+D2ebnLm5BD9eslWAxdonNUSEojuQGC5tapkMUSBvdnfVV1ysnzDaiY4Bg==",
       "requires": {
         "balena-sdk": "^15.2.1",
         "mime": "^2.4.6",

--- a/package.json
+++ b/package.json
@@ -205,7 +205,7 @@
     "balena-device-init": "^6.0.0",
     "balena-errors": "^4.7.1",
     "balena-image-fs": "^7.0.6",
-    "balena-image-manager": "^7.0.3",
+    "balena-image-manager": "^7.0.4",
     "balena-preload": "^11.0.0",
     "balena-release": "^3.2.0",
     "balena-sdk": "^15.51.1",


### PR DESCRIPTION
Update balena-image-manager from 7.0.3 to 7.0.4

Currently the os download function will create two file streams,
one to write to the provided path, and one to write to the local image cache.

This change prevents the target stream from closing early if the image
cache completes first.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>
See: https://github.com/balena-io-modules/balena-image-manager/pull/55
Resolves: https://github.com/balena-io/balena-cli/issues/2152
