### PR TITLE
Don't recursively scan ignored directories

### DIFF
--- a/lib/utils/device/deploy.ts
+++ b/lib/utils/device/deploy.ts
@@ -197,14 +197,17 @@ export async function deployToDevice(opts: DeviceDeployOptions): Promise<void> {
 
 	await checkBuildSecretsRequirements(docker, opts.source);
 	globalLogger.logDebug('Tarring all non-ignored files...');
+	const tarStartTime = Date.now();
 	const tarStream = await tarDirectory(opts.source, {
 		composition: project.composition,
 		convertEol: opts.convertEol,
 		multiDockerignore: opts.multiDockerignore,
 		nogitignore: opts.nogitignore, // v13: delete this line
 	});
+	globalLogger.logDebug(`Tarring complete in ${Date.now() - tarStartTime} ms`);
 
 	// Try to detect the device information
+	globalLogger.logDebug('Fetching device information...');
 	const deviceInfo = await api.getDeviceInformation();
 
 	let buildLogs: Dictionary<string> | undefined;


### PR DESCRIPTION
This changes improves the speed that the project is tarballed by filtering out
ignored directories *during* the file scanning process instead of
afterwards, preventing the CLI from needlessly scanning potentially
large directories (e.g. node_modules).
Whilst testing with the Jellyfish repository, which contains a number of
sub directories, each with their own node_modules folder, I was able to
reduce the time taken to scan and tarball the project from 70s to 2s,
which is a massive improvement.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>


