### PR TITLE
deploy: Ensure the release fails if an image's digest (hash) is missing

### DIFF
--- a/.mocharc.js
+++ b/.mocharc.js
@@ -3,5 +3,8 @@ module.exports = {
 	require: 'ts-node/register/transpile-only',
 	file: './tests/config-tests',
 	timeout: 12000,
+	// To test only, say, 'push.spec.ts', do it as follows so that
+	// requests are authenticated:
+	// spec: ['tests/auth/*.spec.ts', 'tests/**/deploy.spec.ts'],
 	spec: 'tests/**/*.spec.ts',
 };

--- a/lib/utils/compose.js
+++ b/lib/utils/compose.js
@@ -354,76 +354,6 @@ export const authorizePush = function (
 		.catch(() => '');
 };
 
-/**
- * @param {import('dockerode')} docker
- * @param {string} token
- * @param {Array<import('./compose-types').TaggedImage>} images
- * @param {(serviceImage: import('balena-release/build/models').ImageModel, props: object) => void} afterEach
- */
-export const pushAndUpdateServiceImages = function (
-	docker,
-	token,
-	images,
-	afterEach,
-) {
-	const { DockerProgress } = require('docker-progress');
-	const { retry } = require('./helpers');
-	const tty = require('./tty')(process.stdout);
-	const Bluebird = require('bluebird');
-
-	const opts = { authconfig: { registrytoken: token } };
-
-	const progress = new DockerProgress({ docker });
-	const renderer = pushProgressRenderer(
-		tty,
-		getChalk().blue('[Push]') + '    ',
-	);
-	const reporters = progress.aggregateProgress(images.length, renderer);
-
-	return Bluebird.using(tty.cursorHidden(), () =>
-		Promise.all(
-			images.map(({ serviceImage, localImage, props, logs }, index) =>
-				Promise.all([
-					localImage.inspect().then((img) => img.Size),
-					retry({
-						// @ts-ignore
-						func: () => progress.push(localImage.name, reporters[index], opts),
-						maxAttempts: 3, // try calling func 3 times (max)
-						// @ts-ignore
-						label: localImage.name, // label for retry log messages
-						initialDelayMs: 2000, // wait 2 seconds before the 1st retry
-						backoffScaler: 1.4, // wait multiplier for each retry
-					}).finally(renderer.end),
-				])
-					.then(
-						/** @type {([number, string]) => void} */
-						function ([size, digest]) {
-							serviceImage.image_size = size;
-							serviceImage.content_hash = digest;
-							serviceImage.build_log = logs;
-							serviceImage.dockerfile = props.dockerfile;
-							serviceImage.project_type = props.projectType;
-							if (props.startTime) {
-								serviceImage.start_timestamp = props.startTime;
-							}
-							if (props.endTime) {
-								serviceImage.end_timestamp = props.endTime;
-							}
-							serviceImage.push_timestamp = new Date();
-							serviceImage.status = 'success';
-						},
-					)
-					.catch(function (e) {
-						serviceImage.error_message = '' + e;
-						serviceImage.status = 'failed';
-						throw e;
-					})
-					.finally(() => afterEach?.(serviceImage, props)),
-			),
-		),
-	);
-};
-
 // utilities
 
 const renderProgressBar = function (percentage, stepCount) {
@@ -435,7 +365,7 @@ const renderProgressBar = function (percentage, stepCount) {
 	return `${bar} ${_.padStart(percentage, 3)}%`;
 };
 
-var pushProgressRenderer = function (tty, prefix) {
+export const pushProgressRenderer = function (tty, prefix) {
 	const fn = function (e) {
 		const { error, percentage } = e;
 		if (error != null) {

--- a/lib/utils/tty.ts
+++ b/lib/utils/tty.ts
@@ -1,3 +1,20 @@
+/**
+ * @license
+ * Copyright 2018-2021 Balena Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 const windowSize: { width?: number; height?: number } = {};
 
 const updateWindowSize = () => {
@@ -29,13 +46,6 @@ export = (stream: NodeJS.WriteStream = process.stdout) => {
 
 	const cursorDown = (rows: number = 0) => stream.write(`\u001B[${rows}B`);
 
-	const cursorHidden = () => {
-		const Bluebird = require('bluebird') as typeof import('bluebird');
-		return Bluebird.try(hideCursor).disposer(() => {
-			showCursor();
-		});
-	};
-
 	const write = (str: string) => stream.write(str);
 
 	const writeLine = (str: string) => stream.write(`${str}\n`);
@@ -54,7 +64,6 @@ export = (stream: NodeJS.WriteStream = process.stdout) => {
 		currentWindowSize,
 		hideCursor,
 		showCursor,
-		cursorHidden,
 		cursorUp,
 		cursorDown,
 		write,


### PR DESCRIPTION
This PR improves error handling for `balena deploy`, ensuring the release status is 'failed' and error message is printed for the user in the event that an image digest (content hash) cannot be extracted from the image push stream by `docker-progress`.

The issue was reported in the support thread linked below. We don't know exactly what the root cause was for a blank digest (so far we could not reproduce it), and therefore this PR does NOT fix the root cause as such, however this PR at least detects the situation, print an error message and marks the release as 'failed'. Before this PR, the release would be marked 'successful' despite the missing image hash, causing the supervisor to get in bad state on devices.

See: https://jel.ly.fish/support-thread-supervisor-running-may-unhealthy-bf05575
Change-type: patch
