### PR TITLE
Improve directory scan speed prior to tarballing

### DIFF
--- a/lib/utils/device/deploy.ts
+++ b/lib/utils/device/deploy.ts
@@ -199,14 +199,17 @@ export async function deployToDevice(opts: DeviceDeployOptions): Promise<void> {
 
 	await checkBuildSecretsRequirements(docker, opts.source);
 	globalLogger.logDebug('Tarring all non-ignored files...');
+	const tarStartTime = Date.now();
 	const tarStream = await tarDirectory(opts.source, {
 		composition: project.composition,
 		convertEol: opts.convertEol,
 		multiDockerignore: opts.multiDockerignore,
 		nogitignore: opts.nogitignore, // v13: delete this line
 	});
+	globalLogger.logDebug(`Tarring complete in ${Date.now() - tarStartTime} ms`);
 
 	// Try to detect the device information
+	globalLogger.logDebug('Fetching device information...');
 	const deviceInfo = await api.getDeviceInformation();
 
 	let buildLogs: Dictionary<string> | undefined;

--- a/lib/utils/remote-build.ts
+++ b/lib/utils/remote-build.ts
@@ -317,12 +317,18 @@ async function getTarStream(build: RemoteBuild): Promise<Stream.Readable> {
 			Object.keys(build.opts.registrySecrets).length > 0
 				? preFinalizeCallback
 				: undefined;
-		return await tarDirectory(path.resolve(build.source), {
+		globalLogger.logDebug('Tarring all non-ignored files...');
+		const tarStartTime = Date.now();
+		const tarStream = await tarDirectory(path.resolve(build.source), {
 			preFinalizeCallback: preFinalizeCb,
 			convertEol: build.opts.convertEol,
 			multiDockerignore: build.opts.multiDockerignore,
 			nogitignore: build.nogitignore, // v13: delete this line
 		});
+		globalLogger.logDebug(
+			`Tarring complete in ${Date.now() - tarStartTime} ms`,
+		);
+		return tarStream;
 	} finally {
 		tarSpinner.stop();
 	}


### PR DESCRIPTION
This changes improves the speed that the project is tarballed by switching from
`klaw` to `fdir` and not running `lstat` on files that are ignored.
Whilst testing with the Jellyfish repository, which contains a number of
sub directories, each with their own node_modules folder, I was able to
reduce the time taken to scan and tarball the project from 70s to 11s,
which is a massive improvement.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

