### PR TITLE
Update balena CI configuration (remove Node v10 from npm pipeline list)

### DIFF
--- a/.resinci.yml
+++ b/.resinci.yml
@@ -5,13 +5,11 @@ npm:
       os: ubuntu
       architecture: x86_64
       node_versions:
-        - "10"
         - "12"
         - "14"
     - name: linux
       os: alpine
       architecture: x86_64
       node_versions:
-        - "10"
         - "12"
         - "14"


### PR DESCRIPTION
Remove Node.js v10 from `.resinci.yml` because balena CI no longer runs those tests in the npm pipeline. (The `node-cli` pipeline still runs Node.js v10 though.)

See: https://www.flowdock.com/app/rulemotion/d-build-pipelines/threads/y7ey6vgBxuY9fboeIeI4RlEZAGG
Connects-to: product-os/balena-concourse/pull/622
Change-type: patch
