### PR TITLE
Bump 'balena-lint' and fix 'no-floating-promises' warnings

### DIFF
--- a/automation/build-bin.ts
+++ b/automation/build-bin.ts
@@ -310,7 +310,7 @@ async function zipPkg() {
 		archive.on('warning', console.warn);
 
 		archive.pipe(outputStream);
-		archive.finalize();
+		archive.finalize().catch(reject);
 	});
 }
 

--- a/automation/capitanodoc/index.ts
+++ b/automation/capitanodoc/index.ts
@@ -105,4 +105,5 @@ async function printMarkdown() {
 	}
 }
 
+// tslint:disable-next-line:no-floating-promises
 printMarkdown();

--- a/automation/run.ts
+++ b/automation/run.ts
@@ -103,4 +103,5 @@ export async function run(args?: string[]) {
 	}
 }
 
+// tslint:disable-next-line:no-floating-promises
 run();

--- a/automation/update-module.ts
+++ b/automation/update-module.ts
@@ -136,4 +136,5 @@ async function main() {
 	}
 }
 
+// tslint:disable-next-line:no-floating-promises
 main();

--- a/lib/auth/index.ts
+++ b/lib/auth/index.ts
@@ -56,7 +56,7 @@ export async function login({ host = '127.0.0.1', port = 0 }) {
 
 	console.info(`Opening web browser for URL:\n${loginUrl}`);
 	const open = await import('open');
-	open(loginUrl, { wait: false });
+	await open(loginUrl, { wait: false });
 
 	const balena = getBalenaSdk();
 	const token = await loginServer.awaitForToken();

--- a/lib/commands/login.ts
+++ b/lib/commands/login.ts
@@ -187,7 +187,7 @@ ${messages.reachingOut}`);
 			if (loginType === 'register') {
 				const open = await import('open');
 				const signupUrl = `https://dashboard.${balenaUrl}/signup`;
-				open(signupUrl, { wait: false });
+				await open(signupUrl, { wait: false });
 				throw new ExpectedError(`Please sign up at ${signupUrl}`);
 			}
 

--- a/lib/commands/preload.ts
+++ b/lib/commands/preload.ts
@@ -282,10 +282,17 @@ Can be repeated to add multiple certificates.\
 			if (signal) {
 				gotSignal = true;
 				nodeCleanup.uninstall(); // don't call cleanup handler again
-				preloader.cleanup().then(() => {
-					// calling process.exit() won't inform parent process of signal
-					process.kill(process.pid, signal);
-				});
+				preloader
+					.cleanup()
+					.then(() => {
+						// calling process.exit() won't inform parent process of signal
+						process.kill(process.pid, signal);
+					})
+					.catch((e) => {
+						if (process.env.DEBUG) {
+							console.error(e);
+						}
+					});
 				return false;
 			}
 		});

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -915,12 +915,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.5.tgz",
-      "integrity": "sha512-y3rlP+/G25OIX3mYKKIOlQRcqj7YgrvHxOLbVmyLJ9bPmi5ttvUmpydVjcFjZphOktWuA7ovbx91ECloWTfjIA==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.0.tgz",
+      "integrity": "sha512-RR8hUCfRQn9j9RPKEVXo9LiwoxLPYn6hNZlvUOR8tSnaxlD0p0+la00ZP9/SnRt6HchKr+X0fO2r8vrETiJGew==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5",
+        "@babel/types": "^7.16.0",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       },
@@ -934,41 +934,41 @@
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
-      "integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.0.tgz",
+      "integrity": "sha512-BZh4mEk1xi2h4HFjWUXRQX5AEx4rvaZxHgax9gcjdLWdkjsY7MKt5p0otjsg5noXw+pB+clMCjw+aEVYADMjog==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.14.5",
-        "@babel/template": "^7.14.5",
-        "@babel/types": "^7.14.5"
+        "@babel/helper-get-function-arity": "^7.16.0",
+        "@babel/template": "^7.16.0",
+        "@babel/types": "^7.16.0"
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
-      "integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.0.tgz",
+      "integrity": "sha512-ASCquNcywC1NkYh/z7Cgp3w31YW8aojjYIlNg4VeJiHkqyP4AzIvr4qx7pYDb4/s8YcsZWqqOSxgkvjUz1kpDQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.16.0"
       }
     },
     "@babel/helper-hoist-variables": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz",
-      "integrity": "sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.0.tgz",
+      "integrity": "sha512-1AZlpazjUR0EQZQv3sgRNfM9mEVWPK3M6vlalczA+EECcPz3XPh6VplbErL5UoMpChhSck5wAJHthlj1bYpcmg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.16.0"
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
-      "integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.0.tgz",
+      "integrity": "sha512-0YMMRpuDFNGTHNRiiqJX19GjNXA4H0E8jZ2ibccfSxaCogbm3am5WN/2nQNj0YnQwGWM1J06GOcQ2qnh3+0paw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.5"
+        "@babel/types": "^7.16.0"
       }
     },
     "@babel/helper-validator-identifier": {
@@ -1035,46 +1035,46 @@
       }
     },
     "@babel/template": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
-      "integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.0.tgz",
+      "integrity": "sha512-MnZdpFD/ZdYhXwiunMqqgyZyucaYsbL0IrjoGjaVhGilz+x8YB++kRfygSOIj1yOtWKPlx7NBp+9I1RQSgsd5A==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/parser": "^7.14.5",
-        "@babel/types": "^7.14.5"
+        "@babel/code-frame": "^7.16.0",
+        "@babel/parser": "^7.16.0",
+        "@babel/types": "^7.16.0"
       },
       "dependencies": {
         "@babel/code-frame": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
-          "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
+          "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
           "dev": true,
           "requires": {
-            "@babel/highlight": "^7.14.5"
+            "@babel/highlight": "^7.16.0"
           }
         },
         "@babel/helper-validator-identifier": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
-          "integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
+          "version": "7.15.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
+          "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
           "dev": true
         },
         "@babel/highlight": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
-          "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
+          "integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
           "dev": true,
           "requires": {
-            "@babel/helper-validator-identifier": "^7.14.5",
+            "@babel/helper-validator-identifier": "^7.15.7",
             "chalk": "^2.0.0",
             "js-tokens": "^4.0.0"
           }
         },
         "@babel/parser": {
-          "version": "7.14.7",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.7.tgz",
-          "integrity": "sha512-X67Z5y+VBJuHB/RjwECp8kSl5uYi0BvRbNeWqkaJCVh+LiTPl19WBUfG627psSgp9rSf6ojuXghQM3ha6qHHdA==",
+          "version": "7.16.4",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.4.tgz",
+          "integrity": "sha512-6V0qdPUaiVHH3RtZeLIsc+6pDhbYzHR8ogA8w+f+Wc77DuXto19g2QUwveINoS34Uw+W8/hQDGJCx+i4n7xcng==",
           "dev": true
         },
         "ansi-styles": {
@@ -1115,52 +1115,52 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.14.7",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.7.tgz",
-      "integrity": "sha512-9vDr5NzHu27wgwejuKL7kIOm4bwEtaPQ4Z6cpCmjSuaRqpH/7xc4qcGEscwMqlkwgcXl6MvqoAjZkQ24uSdIZQ==",
+      "version": "7.16.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.3.tgz",
+      "integrity": "sha512-eolumr1vVMjqevCpwVO99yN/LoGL0EyHiLO5I043aYQvwOJ9eR5UsZSClHVCzfhBduMAsSzgA/6AyqPjNayJag==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.14.5",
-        "@babel/helper-function-name": "^7.14.5",
-        "@babel/helper-hoist-variables": "^7.14.5",
-        "@babel/helper-split-export-declaration": "^7.14.5",
-        "@babel/parser": "^7.14.7",
-        "@babel/types": "^7.14.5",
+        "@babel/code-frame": "^7.16.0",
+        "@babel/generator": "^7.16.0",
+        "@babel/helper-function-name": "^7.16.0",
+        "@babel/helper-hoist-variables": "^7.16.0",
+        "@babel/helper-split-export-declaration": "^7.16.0",
+        "@babel/parser": "^7.16.3",
+        "@babel/types": "^7.16.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
       "dependencies": {
         "@babel/code-frame": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
-          "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
+          "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
           "dev": true,
           "requires": {
-            "@babel/highlight": "^7.14.5"
+            "@babel/highlight": "^7.16.0"
           }
         },
         "@babel/helper-validator-identifier": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
-          "integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
+          "version": "7.15.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
+          "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
           "dev": true
         },
         "@babel/highlight": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
-          "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
+          "integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
           "dev": true,
           "requires": {
-            "@babel/helper-validator-identifier": "^7.14.5",
+            "@babel/helper-validator-identifier": "^7.15.7",
             "chalk": "^2.0.0",
             "js-tokens": "^4.0.0"
           }
         },
         "@babel/parser": {
-          "version": "7.14.7",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.7.tgz",
-          "integrity": "sha512-X67Z5y+VBJuHB/RjwECp8kSl5uYi0BvRbNeWqkaJCVh+LiTPl19WBUfG627psSgp9rSf6ojuXghQM3ha6qHHdA==",
+          "version": "7.16.4",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.4.tgz",
+          "integrity": "sha512-6V0qdPUaiVHH3RtZeLIsc+6pDhbYzHR8ogA8w+f+Wc77DuXto19g2QUwveINoS34Uw+W8/hQDGJCx+i4n7xcng==",
           "dev": true
         },
         "ansi-styles": {
@@ -1201,19 +1201,19 @@
       }
     },
     "@babel/types": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.5.tgz",
-      "integrity": "sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+      "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.14.5",
+        "@babel/helper-validator-identifier": "^7.15.7",
         "to-fast-properties": "^2.0.0"
       },
       "dependencies": {
         "@babel/helper-validator-identifier": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
-          "integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
+          "version": "7.15.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
+          "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
           "dev": true
         }
       }
@@ -1246,9 +1246,9 @@
       "integrity": "sha512-o3/sRDyrXC75BUUziMAs+W5C02aVST0YqY5Ny31Ot3a+7CzK2XDRinMGywvK93tm2QVdL83HGkN483S62Xo9Dw=="
     },
     "@balena/lint": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@balena/lint/-/lint-6.1.1.tgz",
-      "integrity": "sha512-i7FbC+3RNyOO0iNELmwXEfLfumJ4p/c9a/GP54U7ARMgzYzkFhVguwDqMjG8PE46DyjJyb5AAsekBkgbFWNMDA==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@balena/lint/-/lint-6.2.0.tgz",
+      "integrity": "sha512-/17R2TAYIrjryiNUBVaDrFyeU5OQwTNybTo/gllJpR8DLa5+vnYGelCm+igHMU10u4wMgJVLz8SBNrEbaDW5iw==",
       "dev": true,
       "requires": {
         "@types/glob": "^7.1.3",
@@ -1265,9 +1265,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.20.16",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.16.tgz",
-          "integrity": "sha512-6CLxw83vQf6DKqXxMPwl8qpF8I7THFZuIwLt4TnNsumxkp1VsRZWT8txQxncT/Rl2UojTsFzWgDG4FRMwafrlA==",
+          "version": "12.20.37",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.37.tgz",
+          "integrity": "sha512-i1KGxqcvJaLQali+WuypQnXwcplhtNtjs66eNsZpp2P2FL/trJJxx/VWsM0YCL2iMoIJrbXje48lvIQAQ4p2ZA==",
           "dev": true
         }
       }
@@ -2473,12 +2473,6 @@
       "integrity": "sha512-AUxAGNIPr7wQmzdFMNhHy/RkR5kk8gSzAZIuCYY//6ZYJKHvnjezmoEYP34coPleUPnqrUWt03cCq7NzNaA/qg==",
       "dev": true
     },
-    "@types/estree": {
-      "version": "0.0.48",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.48.tgz",
-      "integrity": "sha512-LfZwXoGUDo0C3me81HXgkBg5CTQYb6xzEl+fNmbO4JdRiSKQ8A0GD1OBBvKAIsbCUgoyAty7m99GqqMQe784ew==",
-      "dev": true
-    },
     "@types/event-stream": {
       "version": "3.3.34",
       "resolved": "https://registry.npmjs.org/@types/event-stream/-/event-stream-3.3.34.tgz",
@@ -2754,9 +2748,9 @@
       "dev": true
     },
     "@types/prettier": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.3.2.tgz",
-      "integrity": "sha512-eI5Yrz3Qv4KPUa/nSIAi0h+qX0XyewOliug5F2QAtuRg6Kjg6jfmxe1GIwoIRhZspD1A0RP8ANrPwvEXXtRFog==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.4.2.tgz",
+      "integrity": "sha512-ekoj4qOQYp7CvjX8ZDBgN86w3MqQhLE1hczEJbEIjgFEumDy+na/4AJAbLXfgEWFNB2pKadM5rPFtuSGMWK7xA==",
       "dev": true
     },
     "@types/prettyjson": {
@@ -2954,92 +2948,96 @@
       "dev": true
     },
     "@vue/compiler-core": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.1.5.tgz",
-      "integrity": "sha512-TXBhFinoBaXKDykJzY26UEuQU1K07FOp/0Ie+OXySqqk0bS0ZO7Xvl7UmiTUPYcLrWbxWBR7Bs/y55AI0MNc2Q==",
+      "version": "3.2.23",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.23.tgz",
+      "integrity": "sha512-4ZhiI/orx+7EJ1B+0zjgvXMV2uRN+XBfG06UN2sJfND9rH5gtEQT3QmO4erum1o6Irl7y754W8/KSaDJh4EUQg==",
       "dev": true,
       "requires": {
-        "@babel/parser": "^7.12.0",
-        "@babel/types": "^7.12.0",
-        "@vue/shared": "3.1.5",
-        "estree-walker": "^2.0.1",
+        "@babel/parser": "^7.15.0",
+        "@vue/shared": "3.2.23",
+        "estree-walker": "^2.0.2",
         "source-map": "^0.6.1"
       },
       "dependencies": {
         "@babel/parser": {
-          "version": "7.14.7",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.7.tgz",
-          "integrity": "sha512-X67Z5y+VBJuHB/RjwECp8kSl5uYi0BvRbNeWqkaJCVh+LiTPl19WBUfG627psSgp9rSf6ojuXghQM3ha6qHHdA==",
+          "version": "7.16.4",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.4.tgz",
+          "integrity": "sha512-6V0qdPUaiVHH3RtZeLIsc+6pDhbYzHR8ogA8w+f+Wc77DuXto19g2QUwveINoS34Uw+W8/hQDGJCx+i4n7xcng==",
           "dev": true
         }
       }
     },
     "@vue/compiler-dom": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.1.5.tgz",
-      "integrity": "sha512-ZsL3jqJ52OjGU/YiT/9XiuZAmWClKInZM2aFJh9gnsAPqOrj2JIELMbkIFpVKR/CrVO/f2VxfPiiQdQTr65jcQ==",
+      "version": "3.2.23",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.23.tgz",
+      "integrity": "sha512-X2Nw8QFc5lgoK3kio5ktM95nqmLUH+q+N/PbV4kCHzF1avqv/EGLnAhaaF0Iu4bewNvHJAAhhwPZFeoV/22nbw==",
       "dev": true,
       "requires": {
-        "@vue/compiler-core": "3.1.5",
-        "@vue/shared": "3.1.5"
+        "@vue/compiler-core": "3.2.23",
+        "@vue/shared": "3.2.23"
       }
     },
     "@vue/compiler-sfc": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.1.5.tgz",
-      "integrity": "sha512-mtMY6xMvZeSRx9MTa1+NgJWndrkzVTdJ1pQAmAKQuxyb5LsHVvrgP7kcQFvxPHVpLVTORbTJWHaiqoKrJvi1iA==",
+      "version": "3.2.23",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.23.tgz",
+      "integrity": "sha512-Aw+pb50Q5zTjyvWod8mNKmYZDRGHJBptmNNWE+84ZxrzEztPgMz8cNYIzWGbwcFVkmJlhvioAMvKnB+LM/sjSA==",
       "dev": true,
       "requires": {
-        "@babel/parser": "^7.13.9",
-        "@babel/types": "^7.13.0",
-        "@types/estree": "^0.0.48",
-        "@vue/compiler-core": "3.1.5",
-        "@vue/compiler-dom": "3.1.5",
-        "@vue/compiler-ssr": "3.1.5",
-        "@vue/shared": "3.1.5",
-        "consolidate": "^0.16.0",
-        "estree-walker": "^2.0.1",
-        "hash-sum": "^2.0.0",
-        "lru-cache": "^5.1.1",
+        "@babel/parser": "^7.15.0",
+        "@vue/compiler-core": "3.2.23",
+        "@vue/compiler-dom": "3.2.23",
+        "@vue/compiler-ssr": "3.2.23",
+        "@vue/ref-transform": "3.2.23",
+        "@vue/shared": "3.2.23",
+        "estree-walker": "^2.0.2",
         "magic-string": "^0.25.7",
-        "merge-source-map": "^1.1.0",
         "postcss": "^8.1.10",
-        "postcss-modules": "^4.0.0",
-        "postcss-selector-parser": "^6.0.4",
         "source-map": "^0.6.1"
       },
       "dependencies": {
         "@babel/parser": {
-          "version": "7.14.7",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.7.tgz",
-          "integrity": "sha512-X67Z5y+VBJuHB/RjwECp8kSl5uYi0BvRbNeWqkaJCVh+LiTPl19WBUfG627psSgp9rSf6ojuXghQM3ha6qHHdA==",
+          "version": "7.16.4",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.4.tgz",
+          "integrity": "sha512-6V0qdPUaiVHH3RtZeLIsc+6pDhbYzHR8ogA8w+f+Wc77DuXto19g2QUwveINoS34Uw+W8/hQDGJCx+i4n7xcng==",
           "dev": true
-        },
-        "lru-cache": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-          "dev": true,
-          "requires": {
-            "yallist": "^3.0.2"
-          }
         }
       }
     },
     "@vue/compiler-ssr": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.1.5.tgz",
-      "integrity": "sha512-CU5N7Di/a4lyJ18LGJxJYZS2a8PlLdWpWHX9p/XcsjT2TngMpj3QvHVRkuik2u8QrIDZ8OpYmTyj1WDNsOV+Dg==",
+      "version": "3.2.23",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.23.tgz",
+      "integrity": "sha512-Bqzn4jFyXPK1Ehqiq7e/czS8n62gtYF1Zfeu0DrR5uv+SBllh7LIvZjZU6+c8qbocAd3/T3I3gn2cZGmnDb6zg==",
       "dev": true,
       "requires": {
-        "@vue/compiler-dom": "3.1.5",
-        "@vue/shared": "3.1.5"
+        "@vue/compiler-dom": "3.2.23",
+        "@vue/shared": "3.2.23"
+      }
+    },
+    "@vue/ref-transform": {
+      "version": "3.2.23",
+      "resolved": "https://registry.npmjs.org/@vue/ref-transform/-/ref-transform-3.2.23.tgz",
+      "integrity": "sha512-gW0GD2PSAs/th7mC7tPB/UwpIQxclbApVtsDtscDmOJXb2+cdu60ny+SuHNgfrlUT/JqWKQHq7jFKO4woxLNaA==",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "^7.15.0",
+        "@vue/compiler-core": "3.2.23",
+        "@vue/shared": "3.2.23",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.25.7"
+      },
+      "dependencies": {
+        "@babel/parser": {
+          "version": "7.16.4",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.4.tgz",
+          "integrity": "sha512-6V0qdPUaiVHH3RtZeLIsc+6pDhbYzHR8ogA8w+f+Wc77DuXto19g2QUwveINoS34Uw+W8/hQDGJCx+i4n7xcng==",
+          "dev": true
+        }
       }
     },
     "@vue/shared": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.1.5.tgz",
-      "integrity": "sha512-oJ4F3TnvpXaQwZJNF3ZK+kLPHKarDmJjJ6jyzVNDKH9md1dptjC7lWR//jrGuLdek/U6iltWxqAnYOu8gCiOvA==",
+      "version": "3.2.23",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.23.tgz",
+      "integrity": "sha512-U+/Jefa0QfXUF2qVy9Dqlrb6HKJSr9/wJcM66wXmWcTOoqg7hOWzF4qruDle51pyF4x3wMn6TSH54UdjKjCKMA==",
       "dev": true
     },
     "@yarnpkg/lockfile": {
@@ -4230,12 +4228,6 @@
       "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.50.tgz",
       "integrity": "sha512-+O2uoQWFRo8ysZNo/rjtri2jIwjr3XfeAgRjAUADRqGG+ZITvyn8J1kvXLTaKVr3hhGXk+f23tKfdzmklVM9vQ=="
     },
-    "big.js": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
-      "dev": true
-    },
     "binary": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
@@ -5191,12 +5183,6 @@
       "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
       "dev": true
     },
-    "colorette": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
-      "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
-      "dev": true
-    },
     "colors": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
@@ -5410,15 +5396,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
-    },
-    "consolidate": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/consolidate/-/consolidate-0.16.0.tgz",
-      "integrity": "sha512-Nhl1wzCslqXYTJVDyJCu3ODohy9OfBMB5uD2BiBTzd7w+QY0lBzafkR8y8755yMYHAaMD4NuzbAw03/xzfw+eQ==",
-      "dev": true,
-      "requires": {
-        "bluebird": "^3.7.2"
-      }
     },
     "content-disposition": {
       "version": "0.5.3",
@@ -5768,12 +5745,6 @@
       "integrity": "sha512-ACUm3L0/jiZTqfzRM3Hi9Q8eZqd6IK37mMWPLz9PJxkLWllYeRf+EHUSHYEtFop2Eqytaq1FizFVh7XfBnXCDQ==",
       "dev": true
     },
-    "cssesc": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
-      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-      "dev": true
-    },
     "csso": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/csso/-/csso-3.5.1.tgz",
@@ -6025,9 +5996,9 @@
       },
       "dependencies": {
         "@babel/parser": {
-          "version": "7.14.7",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.7.tgz",
-          "integrity": "sha512-X67Z5y+VBJuHB/RjwECp8kSl5uYi0BvRbNeWqkaJCVh+LiTPl19WBUfG627psSgp9rSf6ojuXghQM3ha6qHHdA==",
+          "version": "7.16.4",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.4.tgz",
+          "integrity": "sha512-6V0qdPUaiVHH3RtZeLIsc+6pDhbYzHR8ogA8w+f+Wc77DuXto19g2QUwveINoS34Uw+W8/hQDGJCx+i4n7xcng==",
           "dev": true
         },
         "arrify": {
@@ -6037,9 +6008,9 @@
           "dev": true
         },
         "camelcase": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
-          "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.1.tgz",
+          "integrity": "sha512-tVI4q5jjFV5CavAU8DXfza/TJcZutVKo/5Foskmsqcm0MsL91moHvwiGNnqaa2o6PF/7yT5ikDRcVcl8Rj6LCA==",
           "dev": true
         },
         "debug": {
@@ -6052,9 +6023,9 @@
           }
         },
         "is-core-module": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.5.0.tgz",
-          "integrity": "sha512-TXCMSDsEHMEEZ6eCA8rwRDbLu55MRGmrctljsBX/2v1d9/GzqHOxW5c5oPSgrUt2vBFXebu9rGqckXGPWOlYpg==",
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.0.tgz",
+          "integrity": "sha512-vd15qHsaqrRL7dtH6QNuy0ndJmRDrS9HAM1CAiSifNUFv4x1a0CCVsj18hJ1mShxIG6T2i1sO78MkP56r0nYRw==",
           "dev": true,
           "requires": {
             "has": "^1.0.3"
@@ -6759,12 +6730,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-    },
-    "emojis-list": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
-      "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
-      "dev": true
     },
     "encodeurl": {
       "version": "1.0.2",
@@ -8349,15 +8314,6 @@
         }
       }
     },
-    "generic-names": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/generic-names/-/generic-names-2.0.1.tgz",
-      "integrity": "sha512-kPCHWa1m9wGG/OwQpeweTwM/PYiQLrUIxXbt/P4Nic3LbGjCP0YwrALHW1uNLKZ0LIMg+RF+XRlj2ekT9ZlZAQ==",
-      "dev": true,
-      "requires": {
-        "loader-utils": "^1.1.0"
-      }
-    },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -9376,12 +9332,6 @@
       "resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-2.1.0.tgz",
       "integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw=="
     },
-    "hash-sum": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-2.0.0.tgz",
-      "integrity": "sha512-WdZTbAByD+pHfl/g9QSsBIIwy8IT+EsPiKDs0KNX+zSHhdDLFKdZu0BQHljvO+0QI/BasbMSUa8wYNCZTvhslg==",
-      "dev": true
-    },
     "he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
@@ -9725,18 +9675,6 @@
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
-    },
-    "icss-replace-symbols": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
-      "integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0=",
-      "dev": true
-    },
-    "icss-utils": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
-      "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-      "dev": true
     },
     "ieee754": {
       "version": "1.1.13",
@@ -10929,28 +10867,6 @@
         "strip-bom": "^3.0.0"
       }
     },
-    "loader-utils": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-      "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
-      "dev": true,
-      "requires": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^3.0.0",
-        "json5": "^1.0.1"
-      },
-      "dependencies": {
-        "json5": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.0"
-          }
-        }
-      }
-    },
     "locate-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
@@ -11012,12 +10928,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
       "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI="
-    },
-    "lodash.camelcase": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
-      "dev": true
     },
     "lodash.defaults": {
       "version": "4.2.0",
@@ -11852,15 +11762,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
-    },
-    "merge-source-map": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.1.0.tgz",
-      "integrity": "sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==",
-      "dev": true,
-      "requires": {
-        "source-map": "^0.6.1"
-      }
     },
     "merge-stream": {
       "version": "2.0.0",
@@ -13851,6 +13752,12 @@
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
+    "picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
+    },
     "picomatch": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
@@ -14072,90 +13979,23 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
     },
     "postcss": {
-      "version": "8.3.5",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.5.tgz",
-      "integrity": "sha512-NxTuJocUhYGsMiMFHDUkmjSKT3EdH4/WbGF6GCi1NDGk+vbcUTun4fpbOqaPtD8IIsztA2ilZm2DhYCuyN58gA==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.1.tgz",
+      "integrity": "sha512-WqLs/TTzXdG+/A4ZOOK9WDZiikrRaiA+eoEb/jz2DT9KUhMNHgP7yKPO8vwi62ZCsb703Gwb7BMZwDzI54Y2Ag==",
       "dev": true,
       "requires": {
-        "colorette": "^1.2.2",
-        "nanoid": "^3.1.23",
-        "source-map-js": "^0.6.2"
+        "nanoid": "^3.1.30",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.1"
       },
       "dependencies": {
         "nanoid": {
-          "version": "3.1.23",
-          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
-          "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
+          "version": "3.1.30",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.30.tgz",
+          "integrity": "sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ==",
           "dev": true
         }
       }
-    },
-    "postcss-modules": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/postcss-modules/-/postcss-modules-4.1.3.tgz",
-      "integrity": "sha512-dBT39hrXe4OAVYJe/2ZuIZ9BzYhOe7t+IhedYeQ2OxKwDpAGlkEN/fR0fGnrbx4BvgbMReRX4hCubYK9cE/pJQ==",
-      "dev": true,
-      "requires": {
-        "generic-names": "^2.0.1",
-        "icss-replace-symbols": "^1.1.0",
-        "lodash.camelcase": "^4.3.0",
-        "postcss-modules-extract-imports": "^3.0.0",
-        "postcss-modules-local-by-default": "^4.0.0",
-        "postcss-modules-scope": "^3.0.0",
-        "postcss-modules-values": "^4.0.0",
-        "string-hash": "^1.1.1"
-      }
-    },
-    "postcss-modules-extract-imports": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
-      "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-      "dev": true
-    },
-    "postcss-modules-local-by-default": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.0.tgz",
-      "integrity": "sha512-sT7ihtmGSF9yhm6ggikHdV0hlziDTX7oFoXtuVWeDd3hHObNkcHRo9V3yg7vCAY7cONyxJC/XXCmmiHHcvX7bQ==",
-      "dev": true,
-      "requires": {
-        "icss-utils": "^5.0.0",
-        "postcss-selector-parser": "^6.0.2",
-        "postcss-value-parser": "^4.1.0"
-      }
-    },
-    "postcss-modules-scope": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.0.0.tgz",
-      "integrity": "sha512-hncihwFA2yPath8oZ15PZqvWGkWf+XUfQgUGamS4LqoP1anQLOsOJw0vr7J7IwLpoY9fatA2qiGUGmuZL0Iqlg==",
-      "dev": true,
-      "requires": {
-        "postcss-selector-parser": "^6.0.4"
-      }
-    },
-    "postcss-modules-values": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-4.0.0.tgz",
-      "integrity": "sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==",
-      "dev": true,
-      "requires": {
-        "icss-utils": "^5.0.0"
-      }
-    },
-    "postcss-selector-parser": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.6.tgz",
-      "integrity": "sha512-9LXrvaaX3+mcv5xkg5kFwqSzSH1JIObIx51PrndZwlmznwXRfxMddDvo9gve3gVR8ZTKgoFDdWkbRFmEhT4PMg==",
-      "dev": true,
-      "requires": {
-        "cssesc": "^3.0.0",
-        "util-deprecate": "^1.0.2"
-      }
-    },
-    "postcss-value-parser": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
-      "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==",
-      "dev": true
     },
     "prebuild-install": {
       "version": "5.3.6",
@@ -14191,9 +14031,9 @@
       "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
     },
     "prettier": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
-      "integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.0.tgz",
+      "integrity": "sha512-FM/zAKgWTxj40rH03VxzIPdXmj39SwSjwG0heUcNFwI+EMZJnY93yAiKXM3dObIKAM5TA88werc8T/EwhB45eg==",
       "dev": true
     },
     "pretty-bytes": {
@@ -16139,9 +15979,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sass": {
-      "version": "1.35.2",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.35.2.tgz",
-      "integrity": "sha512-jhO5KAR+AMxCEwIH3v+4zbB2WB0z67V1X0jbapfVwQQdjHZUGUyukpnoM6+iCMfsIUC016w9OPKQ5jrNOS9uXw==",
+      "version": "1.43.5",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.43.5.tgz",
+      "integrity": "sha512-WuNm+eAryMgQluL7Mbq9M4EruyGGMyal7Lu58FfnRMVWxgUzIvI7aSn60iNt3kn5yZBMR7G84fAGDcwqOF5JOg==",
       "dev": true,
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0"
@@ -16721,9 +16561,9 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "source-map-js": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
-      "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.1.tgz",
+      "integrity": "sha512-4+TN2b3tqOCd/kaGRJ/sTYA0tR0mdXx26ipdolxcwtJVqEnqNYvlCAt1q3ypy4QMlYus+Zh34RNtYLoq2oQ4IA==",
       "dev": true
     },
     "source-map-resolve": {
@@ -17030,12 +16870,6 @@
       "requires": {
         "editor": "^1.0.0"
       }
-    },
-    "string-hash": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
-      "integrity": "sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs=",
-      "dev": true
     },
     "string-template": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,9 @@
     "catch-uncommitted": "ts-node --transpile-only automation/run.ts catch-uncommitted",
     "ci": "npm run test && npm run catch-uncommitted",
     "watch": "gulp watch",
-    "lint": "balena-lint -e ts -e js --fix automation/ completion/ lib/ typings/ tests/ bin/balena bin/balena-dev gulpfile.js .mocharc.js .mocharc-standalone.js",
+    "lint": "npm run lint-tsconfig && npm run lint-other",
+    "lint-tsconfig": "balena-lint -e ts -e js -t tsconfig.dev.json --fix automation/ lib/ tests/ typings/",
+    "lint-other": "balena-lint -e ts -e js --fix bin/balena bin/balena-dev completion/ gulpfile.js .mocharc.js .mocharc-standalone.js",
     "update": "ts-node --transpile-only ./automation/update-module.ts",
     "prepare": "echo {} > bin/.fast-boot.json",
     "prepublishOnly": "npm run build"
@@ -113,7 +115,7 @@
     ]
   },
   "devDependencies": {
-    "@balena/lint": "^6.1.1",
+    "@balena/lint": "^6.2.0",
     "@oclif/config": "^1.17.0",
     "@oclif/dev-cli": "^1.26.0",
     "@oclif/parser": "^3.8.5",


### PR DESCRIPTION
Motivated by a "missing await clause" error caught by @srlowe: https://github.com/balena-io/balena-cli/pull/2378#discussion_r753178880

The `'no-floating-promises'` tslint rule was actually added to `balena-lint` in the linked depends-on PR. That rule caught the following issues in the CLI repo:

```
$ npx balena-lint -e ts -e js -t tsconfig.dev.json --fix automation/ lib/ typings/
/Users/paulo/balena/balena-io/balena-cli/lib/app.ts:84:2
ERROR: 84:2    no-floating-promises  Promises must be handled appropriately

/Users/paulo/balena/balena-io/balena-cli/lib/auth/index.ts:59:2
ERROR: 59:2    no-floating-promises  Promises must be handled appropriately

/Users/paulo/balena/balena-io/balena-cli/lib/commands/login.ts:190:5
ERROR: 190:5   no-floating-promises  Promises must be handled appropriately

/Users/paulo/balena/balena-io/balena-cli/lib/commands/preload.ts:285:5
ERROR: 285:5   no-floating-promises  Promises must be handled appropriately

/Users/paulo/balena/balena-io/balena-cli/lib/utils/compose_ts.ts:1103:3
ERROR: 1103:3  no-floating-promises  Promises must be handled appropriately

/Users/paulo/balena/balena-io/balena-cli/automation/build-bin.ts:313:3
ERROR: 313:3  no-floating-promises  Promises must be handled appropriately

/Users/paulo/balena/balena-io/balena-cli/automation/capitanodoc/index.ts:108:1
ERROR: 108:1  no-floating-promises  Promises must be handled appropriately

/Users/paulo/balena/balena-io/balena-cli/automation/run.ts:106:1
ERROR: 106:1  no-floating-promises  Promises must be handled appropriately

/Users/paulo/balena/balena-io/balena-cli/automation/update-module.ts:139:1
ERROR: 139:1  no-floating-promises  Promises must be handled appropriately
```

They are fixed in this PR.

Depends-on: balena-io-modules/node-balena-lint/pull/81
Change-type: patch
