### PR TITLE
Stop creating an extra provisioning API key in each config generation

### DIFF
--- a/tests/commands/os/configure.spec.ts
+++ b/tests/commands/os/configure.spec.ts
@@ -49,7 +49,6 @@ if (process.platform !== 'win32') {
 			api.expectGetApplication();
 			api.expectGetConfigDeviceTypes();
 			api.expectDownloadConfig();
-			api.expectApplicationProvisioning();
 
 			const command: string[] = [
 				`os configure ${tmpPath}`,


### PR DESCRIPTION
Change-type: patch
Changelog-entry: Avoid creating an extra provisioning API key in os configure & config generate
See: https://github.com/balena-io/balena-cli/pull/2294#discussion_r756499196
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

---
Please check the CONTRIBUTING.md file for relevant information and some
guidance. Keep in mind that the CLI is a cross-platform application that runs
on Windows, macOS and Linux. Tests will be automatically run by balena CI on
all three operating systems, but this will only help if you have added test
code that exercises the modified or added feature code.

Note that each commit message (currently only the first line) will be
automatically copied to the CHANGELOG.md file, so try writing it in a way
that describes the feature or fix for CLI users.

If there isn't a linked issue or if the linked issue doesn't quite match the
PR, please add a PR description to explain its purpose or the features that it
implements. Adding PR comments to blocks of code that aren't self explanatory
usually helps with the review process.

If the PR introduces security considerations or affects the development, build
or release process, please be sure to highlight this in the PR description.

Thank you very much for your contribution!
