### PR TITLE
chore: Bump multicast-dns to rebased commit

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -12252,7 +12252,7 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "multicast-dns": {
-      "version": "git+https://github.com/resin-io-modules/multicast-dns.git#a15c63464eb43e8925b187ed5cb9de6892e8aacc",
+      "version": "git+https://github.com/resin-io-modules/multicast-dns.git#db98d68b79bbefc936b6799de9de1038ba49f85d",
       "from": "git+https://github.com/resin-io-modules/multicast-dns.git#listen-on-all-interfaces",
       "requires": {
         "dns-packet": "^1.0.1",


### PR DESCRIPTION
Otherwise npm install fails due to the missing commit in npm-shrinkwrap.json

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>
See: https://github.com/balena-io-modules/multicast-dns/pull/1

I think this is the correct solution, and I've made identical PRs on a number of other projects as well. Let me know if there's a better way to approach this.