### PR TITLE
os download: Assume '.prod' suffix by default for all balenaOS versions

### DIFF
--- a/docs/balena-cli.md
+++ b/docs/balena-cli.md
@@ -2309,9 +2309,11 @@ Examples:
 	$ balena os download raspberrypi3 -o ../foo/bar/raspberry-pi.img --version 2.60.1+rev1
 	$ balena os download raspberrypi3 -o ../foo/bar/raspberry-pi.img --version 2.60.1+rev1.dev
 	$ balena os download raspberrypi3 -o ../foo/bar/raspberry-pi.img --version ^2.60.0
+	$ balena os download raspberrypi3 -o ../foo/bar/raspberry-pi.img --version 2021.10.1
 	$ balena os download raspberrypi3 -o ../foo/bar/raspberry-pi.img --version latest
 	$ balena os download raspberrypi3 -o ../foo/bar/raspberry-pi.img --version default
 	$ balena os download raspberrypi3 -o ../foo/bar/raspberry-pi.img --version menu
+	$ balena os download raspberrypi3 -o ../foo/bar/raspberry-pi.img --version menu-esr
 
 ### Arguments
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3783,9 +3783,9 @@
       }
     },
     "balena-image-manager": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/balena-image-manager/-/balena-image-manager-7.1.0.tgz",
-      "integrity": "sha512-W8Etn0PBQJUlTJ1m1rCuQQ8TTLdkBoNP2SRHQqez2HANQp+T38wFjQXVx9PhQ6J7eqOYuW87SkJiKLpnmlz79Q==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/balena-image-manager/-/balena-image-manager-7.1.1.tgz",
+      "integrity": "sha512-ny0BrjdK23RFKG0VDk6PceYMtiekyqJEoh91Q/JxjWwayoV+CUajQJYN9YE95i2Qp/iqI97Hlm1V5N4E1YHLEg==",
       "requires": {
         "balena-sdk": "^15.2.1",
         "mime": "^2.4.6",

--- a/package.json
+++ b/package.json
@@ -207,7 +207,7 @@
     "balena-device-init": "^6.0.0",
     "balena-errors": "^4.7.1",
     "balena-image-fs": "^7.0.6",
-    "balena-image-manager": "^7.1.0",
+    "balena-image-manager": "^7.1.1",
     "balena-preload": "^11.0.0",
     "balena-release": "^3.2.0",
     "balena-sdk": "^15.51.1",

--- a/typings/balena-image-manager/index.d.ts
+++ b/typings/balena-image-manager/index.d.ts
@@ -22,4 +22,6 @@ declare module 'balena-image-manager' {
 		deviceType: string,
 		versionOrRange: string,
 	): Promise<NodeJS.ReadableStream & { mime: string }>;
+
+	export function isESR(version: string): boolean;
 }


### PR DESCRIPTION
Also add a better error message when the user is not logged in and attempts to download a balenaOS ESR version.

See also: (restricted access) https://www.flowdock.com/app/rulemotion/resin-devices/threads/bI-Uhq-pxSdxgN5lxAsYpd8GCpX

Resolves: #2387
Change-type: patch
