### PR TITLE
os download: Future-proof unified dev/prod balenaOS versioning

### DIFF
--- a/docs/balena-cli.md
+++ b/docs/balena-cli.md
@@ -2309,7 +2309,7 @@ Examples:
 	$ balena os download raspberrypi3 -o ../foo/bar/raspberry-pi.img --version 2.60.1+rev1
 	$ balena os download raspberrypi3 -o ../foo/bar/raspberry-pi.img --version 2.60.1+rev1.dev
 	$ balena os download raspberrypi3 -o ../foo/bar/raspberry-pi.img --version ^2.60.0
-	$ balena os download raspberrypi3 -o ../foo/bar/raspberry-pi.img --version 2021.10.1
+	$ balena os download raspberrypi3 -o ../foo/bar/raspberry-pi.img --version 2021.10.2.prod
 	$ balena os download raspberrypi3 -o ../foo/bar/raspberry-pi.img --version latest
 	$ balena os download raspberrypi3 -o ../foo/bar/raspberry-pi.img --version default
 	$ balena os download raspberrypi3 -o ../foo/bar/raspberry-pi.img --version menu

--- a/lib/commands/os/download.ts
+++ b/lib/commands/os/download.ts
@@ -56,7 +56,7 @@ export default class OsDownloadCmd extends Command {
 		'$ balena os download raspberrypi3 -o ../foo/bar/raspberry-pi.img --version 2.60.1+rev1',
 		'$ balena os download raspberrypi3 -o ../foo/bar/raspberry-pi.img --version 2.60.1+rev1.dev',
 		'$ balena os download raspberrypi3 -o ../foo/bar/raspberry-pi.img --version ^2.60.0',
-		'$ balena os download raspberrypi3 -o ../foo/bar/raspberry-pi.img --version 2021.10.1',
+		'$ balena os download raspberrypi3 -o ../foo/bar/raspberry-pi.img --version 2021.10.2.prod',
 		'$ balena os download raspberrypi3 -o ../foo/bar/raspberry-pi.img --version latest',
 		'$ balena os download raspberrypi3 -o ../foo/bar/raspberry-pi.img --version default',
 		'$ balena os download raspberrypi3 -o ../foo/bar/raspberry-pi.img --version menu',
@@ -124,6 +124,22 @@ export default class OsDownloadCmd extends Command {
 			await downloadOSImage(params.type, options.output, options.version);
 		} catch (e) {
 			e.deviceTypeSlug = params.type;
+			e.message ||= '';
+			if (
+				e.code === 'BalenaRequestError' ||
+				e.message.toLowerCase().includes('no such version')
+			) {
+				const version = options.version || '';
+				if (
+					!version.endsWith('.dev') &&
+					!version.endsWith('.prod') &&
+					/^v?\d+\.\d+\.\d+/.test(version)
+				) {
+					e.message += `
+** Hint: some OS releases require specifying the full OS version including
+** the '.prod' or '.dev' suffix, e.g. '--version 2021.10.2.prod'`;
+				}
+			}
 			throw e;
 		}
 	}

--- a/lib/utils/cloud.ts
+++ b/lib/utils/cloud.ts
@@ -212,14 +212,10 @@ async function resolveOSVersion(
 	if (['menu', 'menu-esr'].includes(version)) {
 		return await selectOSVersionFromMenu(deviceType, version === 'menu-esr');
 	}
+	// Note that `version` may also be 'latest', 'recommended', 'default'
 	if (/^v?\d+\.\d+\.\d+/.test(version)) {
 		if (version[0] === 'v') {
 			version = version.slice(1);
-		}
-		// The version must end with either '.dev' or '.prod', as expected
-		// by `balena-image-manager` and the balena SDK.
-		if (!version.endsWith('.dev') && !version.endsWith('.prod')) {
-			version += '.prod';
 		}
 	}
 	return version;


### PR DESCRIPTION
Do not append the '.prod' suffix to semver versions and instead match user-provided versions against a list of available versions dynamically retrieved through the SDK/API.

Change-type: patch
See: https://www.flowdock.com/app/rulemotion/resin-devices/threads/bI-Uhq-pxSdxgN5lxAsYpd8GCpX
See: https://docs.google.com/document/d/1469SrFPKZnqZ_VYms3OYu7_a4YNm5rSBNrhHn0vCpgY/edit
