### PR TITLE
os versions, os download: Replace deprecated version fields 

### DIFF
--- a/lib/commands/os/versions.ts
+++ b/lib/commands/os/versions.ts
@@ -65,9 +65,11 @@ export default class OsVersionsCmd extends Command {
 			OsVersionsCmd,
 		);
 
-		const { getFormattedOsVersions } = await import('../../utils/cloud');
-		const vs = await getFormattedOsVersions(params.type, !!options.esr);
+		const { formatOsVersion, getOsVersions } = await import(
+			'../../utils/cloud'
+		);
+		const vs = await getOsVersions(params.type, !!options.esr);
 
-		console.log(vs.map((v) => v.formattedVersion).join('\n'));
+		console.log(vs.map((v) => formatOsVersion(v)).join('\n'));
 	}
 }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3955,9 +3955,9 @@
       }
     },
     "balena-sdk": {
-      "version": "16.8.0",
-      "resolved": "https://registry.npmjs.org/balena-sdk/-/balena-sdk-16.8.0.tgz",
-      "integrity": "sha512-kch7hhB9PksFsyVOAFyylsQMlv976V11DOwhb41w2JykVKjR9KSNFBfy1wYwYY1Wcp8PWXvj9WxtB0Sd/SW9bQ==",
+      "version": "16.8.1",
+      "resolved": "https://registry.npmjs.org/balena-sdk/-/balena-sdk-16.8.1.tgz",
+      "integrity": "sha512-fSYo/aOGVRj0PhIRla8GRuLhyIecvri8kFFbDu0faUgDDUHfidyfIIUzuTggOc7XKr20WazvjfI4M2uVAqMKww==",
       "requires": {
         "@balena/es-version": "^1.0.0",
         "@types/json-schema": "^7.0.9",

--- a/package.json
+++ b/package.json
@@ -208,7 +208,7 @@
     "balena-image-manager": "^7.1.1",
     "balena-preload": "^11.0.0",
     "balena-release": "^3.2.0",
-    "balena-sdk": "^16.8.0",
+    "balena-sdk": "^16.8.1",
     "balena-semver": "^2.3.0",
     "balena-settings-client": "^4.0.7",
     "balena-settings-storage": "^7.0.0",


### PR DESCRIPTION
Replace deprecated `rawVersion` and `formattedVersion` fields and use alternative overload of `getAvailableOsVersions`. As a result, the word 'recommended' is no longer printed next to any OS versions. The SDK was simply always labelling  the `'latest'` version `'recommended'`. Using the latest OS version is just common sense anyway, except for very conservative users who might prefer using a slightly older version (?) and who might question the recommendation.

See: https://www.flowdock.com/app/rulemotion/r-architecture/threads/YN4RClMOz6v6W-VCfoqBaNoliFZ
Change-type: patch
