### PR TITLE
v14 preparations: Fix TypeError produced by 'npx oclif manifest'

### DIFF
--- a/lib/commands/config/inject.ts
+++ b/lib/commands/config/inject.ts
@@ -57,7 +57,7 @@ export default class ConfigInjectCmd extends Command {
 	public static usage = 'config inject <file>';
 
 	public static flags: flags.Input<FlagsDef> = {
-		type: cf.deviceTypeIgnored,
+		...cf.deviceTypeIgnored,
 		drive: cf.driveOrImg,
 		help: cf.help,
 	};

--- a/lib/commands/config/read.ts
+++ b/lib/commands/config/read.ts
@@ -47,7 +47,7 @@ export default class ConfigReadCmd extends Command {
 	public static usage = 'config read';
 
 	public static flags: flags.Input<FlagsDef> = {
-		type: cf.deviceTypeIgnored,
+		...cf.deviceTypeIgnored,
 		drive: cf.driveOrImg,
 		help: cf.help,
 		json: cf.json,

--- a/lib/commands/config/reconfigure.ts
+++ b/lib/commands/config/reconfigure.ts
@@ -50,7 +50,7 @@ export default class ConfigReconfigureCmd extends Command {
 	public static usage = 'config reconfigure';
 
 	public static flags: flags.Input<FlagsDef> = {
-		type: cf.deviceTypeIgnored,
+		...cf.deviceTypeIgnored,
 		drive: cf.driveOrImg,
 		advanced: flags.boolean({
 			description: 'show advanced commands',

--- a/lib/commands/config/write.ts
+++ b/lib/commands/config/write.ts
@@ -64,7 +64,7 @@ export default class ConfigWriteCmd extends Command {
 	public static usage = 'config write <key> <value>';
 
 	public static flags: flags.Input<FlagsDef> = {
-		type: cf.deviceTypeIgnored,
+		...cf.deviceTypeIgnored,
 		drive: cf.driveOrImg,
 		help: cf.help,
 	};

--- a/lib/utils/common-flags.ts
+++ b/lib/utils/common-flags.ts
@@ -97,14 +97,18 @@ export const deviceType = flags.string({
 	required: true,
 });
 
-export const deviceTypeIgnored = isV14()
-	? undefined
-	: flags.string({
-			description: 'ignored - no longer required',
-			char: 't',
-			required: false,
-			hidden: true,
-	  });
+export const deviceTypeIgnored = {
+	...(isV14()
+		? {}
+		: {
+				type: flags.string({
+					description: 'ignored - no longer required',
+					char: 't',
+					required: false,
+					hidden: true,
+				}),
+		  }),
+};
 
 export const json: IBooleanFlag<boolean> = flags.boolean({
 	char: 'j',


### PR DESCRIPTION
Before this PR:
```
$ export BALENA_CLI_VERSION_OVERRIDE='14.0.0'
$ npx tsc && npx oclif manifest
    TypeError Plugin: balena-cli: Cannot read property 'type' of undefined
```

... which are part of `npm run build`. I.e., the build was broken when the next major (v14) feature switch was turned on.

Change-type: patch
