### PR TITLE
local push: Fix "invalid character '/' looking for beginning of value"

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -6149,9 +6149,9 @@
       "integrity": "sha512-djh3R7KXkEPm80PXK9xbz8bCfEFuU11Tmf5l9IXKdjBPx91/cOqhwOwtOq6s35B8TqrwY6L4xLphmyYmJT0ZXw=="
     },
     "docker-modem": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-3.0.2.tgz",
-      "integrity": "sha512-K6ahu0IaJXqRqiAUZYo01n/6MkHir1c5mVJx1//JpyRmePYoIOC7oPR2vSx8rCaxIt7qRc77v9ewxljl6Qatdg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-3.0.0.tgz",
+      "integrity": "sha512-WwFajJ8I5geZ/dDZ5FDMDA6TBkWa76xWwGIGw8uzUjNUGCN0to83wJ8Oi1AxrJTC0JBn+7fvIxUctnawtlwXeg==",
       "requires": {
         "debug": "^4.1.1",
         "readable-stream": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -223,7 +223,7 @@
     "columnify": "^1.5.2",
     "common-tags": "^1.7.2",
     "denymount": "^2.3.0",
-    "docker-modem": "^3.0.2",
+    "docker-modem": "3.0.0",
     "docker-progress": "^5.0.1",
     "docker-qemu-transpose": "^1.1.1",
     "dockerode": "^3.3.1",


### PR DESCRIPTION
Resolves: #2440
Change-type: patch

Although this PR actually resolves #2440, it does so by downgrading and pinning `docker-modem`, which is a sort of workaround. The root cause was traced to `docker-modem` PR https://github.com/apocas/docker-modem/pull/133#issuecomment-1009464228. When `docker-modem` is fixed, we can unpin it in the balena CLI, and that would be the proper fix.