### PR TITLE
Update balena-preload to v12

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3815,12 +3815,12 @@
       }
     },
     "balena-preload": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/balena-preload/-/balena-preload-11.0.0.tgz",
-      "integrity": "sha512-2LuPTw6LoVxuasGhn+cLyA5n7kjvwBtQmBsg08KNhcbEpWLkzrV5jhpNxlMPUuoC2xcMv5Rcg6FWbY87QV5zYQ==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/balena-preload/-/balena-preload-12.0.0.tgz",
+      "integrity": "sha512-BD4ayIqqopJB0KFFjjlz0rIpcbbHojG8El8qOBLJHvidatgtgVs5xFWBoF5B7fgdJdjRsclA/AbUMZwovN7t3w==",
       "requires": {
         "archiver": "^3.1.1",
-        "balena-sdk": "^15.44.0",
+        "balena-sdk": "^16.0.0",
         "bluebird": "^3.7.2",
         "compare-versions": "^3.6.0",
         "docker-progress": "^5.0.0",
@@ -3837,11 +3837,6 @@
         "unzipper": "^0.8.14"
       },
       "dependencies": {
-        "@types/node": {
-          "version": "10.17.60",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-          "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
-        },
         "archiver": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/archiver/-/archiver-3.1.1.tgz",
@@ -3854,32 +3849,6 @@
             "readable-stream": "^3.4.0",
             "tar-stream": "^2.1.0",
             "zip-stream": "^2.1.2"
-          }
-        },
-        "balena-sdk": {
-          "version": "15.59.2",
-          "resolved": "https://registry.npmjs.org/balena-sdk/-/balena-sdk-15.59.2.tgz",
-          "integrity": "sha512-pMNwqqnqtets6PoYxRQhOHBnk7Say4gNhInAvS69UlEhraCR0Xau8rJk9G2IthWDA4tpR2In3u4SQJMIHYj84w==",
-          "requires": {
-            "@balena/es-version": "^1.0.0",
-            "@types/lodash": "^4.14.168",
-            "@types/memoizee": "^0.4.5",
-            "@types/node": "^10.17.55",
-            "abortcontroller-polyfill": "^1.7.1",
-            "balena-auth": "^4.1.0",
-            "balena-errors": "^4.7.1",
-            "balena-hup-action-utils": "~4.0.2",
-            "balena-pine": "^12.4.0",
-            "balena-register-device": "^7.1.0",
-            "balena-request": "^11.5.0",
-            "balena-semver": "^2.3.0",
-            "balena-settings-client": "^4.0.6",
-            "lodash": "^4.17.21",
-            "memoizee": "^0.4.15",
-            "moment": "^2.29.1",
-            "ndjson": "^2.0.0",
-            "semver": "^7.3.4",
-            "tslib": "^2.1.0"
           }
         },
         "compress-commons": {
@@ -3952,11 +3921,6 @@
               }
             }
           }
-        },
-        "tslib": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
         },
         "zip-stream": {
           "version": "2.1.3",
@@ -4309,9 +4273,9 @@
       "dev": true
     },
     "big-integer": {
-      "version": "1.6.50",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.50.tgz",
-      "integrity": "sha512-+O2uoQWFRo8ysZNo/rjtri2jIwjr3XfeAgRjAUADRqGG+ZITvyn8J1kvXLTaKVr3hhGXk+f23tKfdzmklVM9vQ=="
+      "version": "1.6.51",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
+      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg=="
     },
     "binary": {
       "version": "0.3.0",
@@ -16906,9 +16870,9 @@
       }
     },
     "tmp-promise": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.2.tgz",
-      "integrity": "sha512-OyCLAKU1HzBjL6Ev3gxUeraJNlbNingmi8IrHHEsYH8LTmEuhvYfqvhn2F/je+mjf4N58UmZ96OMEy1JanSCpA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
+      "integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
       "requires": {
         "tmp": "^0.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -206,7 +206,7 @@
     "balena-errors": "^4.7.1",
     "balena-image-fs": "^7.0.6",
     "balena-image-manager": "^7.1.1",
-    "balena-preload": "^11.0.0",
+    "balena-preload": "^12.0.0",
     "balena-release": "^3.2.0",
     "balena-sdk": "^16.9.0",
     "balena-semver": "^2.3.0",


### PR DESCRIPTION
Update balena-preload from 11.0.0 to 12.0.0

Change-type: patch
Changelog-entry: preload: Stop using the deprecated /device-types/v1 API endpoints
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

<!-- You can remove tags that do not apply. -->
Resolves: # <!-- Refer an issue of this repository that this PR fixes -->  
Change-type: major|minor|patch <!-- See https://semver.org/ -->  
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->  
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->  

---
Please check the CONTRIBUTING.md file for relevant information and some
guidance. Keep in mind that the CLI is a cross-platform application that runs
on Windows, macOS and Linux. Tests will be automatically run by balena CI on
all three operating systems, but this will only help if you have added test
code that exercises the modified or added feature code.

Note that each commit message (currently only the first line) will be
automatically copied to the CHANGELOG.md file, so try writing it in a way
that describes the feature or fix for CLI users.

If there isn't a linked issue or if the linked issue doesn't quite match the
PR, please add a PR description to explain its purpose or the features that it
implements. Adding PR comments to blocks of code that aren't self explanatory
usually helps with the review process.

If the PR introduces security considerations or affects the development, build
or release process, please be sure to highlight this in the PR description.

Thank you very much for your contribution!
