### PR TITLE
Use cli-ux spinner instead of resin-cli-visuals spinner

### DIFF
--- a/docs/balena-cli.md
+++ b/docs/balena-cli.md
@@ -2557,9 +2557,9 @@ fleet name, slug (preferred), or numeric ID (deprecated)
 
 The commit hash of the release to preload. Use "current" to specify the current
 release (ignored if no appId is given). The current release is usually also the
-latest, but can be pinned to a specific release. See:  
-https://www.balena.io/docs/learn/deploy/release-strategy/release-policy/  
-https://www.balena.io/docs/learn/more/masterclasses/fleet-management/#63-pin-using-the-api  
+latest, but can be pinned to a specific release. See:
+https://www.balena.io/docs/learn/deploy/release-strategy/release-policy/
+https://www.balena.io/docs/learn/more/masterclasses/fleet-management/#63-pin-using-the-api
 https://github.com/balena-io-examples/staged-releases
 
 #### -s, --splash-image SPLASH-IMAGE

--- a/lib/commands/preload.ts
+++ b/lib/commands/preload.ts
@@ -33,6 +33,7 @@ import { flags } from '@oclif/command';
 import * as _ from 'lodash';
 import type { Application, BalenaSDK, PineExpand, Release } from 'balena-sdk';
 import type { Preloader } from 'balena-preload';
+import { cli } from 'cli-ux';
 
 interface FlagsDef extends DockerConnectionCliFlags {
 	fleet?: string;
@@ -98,9 +99,9 @@ export default class PreloadCmd extends Command {
 			description: `\
 The commit hash of the release to preload. Use "current" to specify the current
 release (ignored if no appId is given). The current release is usually also the
-latest, but can be pinned to a specific release. See:  
-https://www.balena.io/docs/learn/deploy/release-strategy/release-policy/  
-https://www.balena.io/docs/learn/more/masterclasses/fleet-management/#63-pin-using-the-api  
+latest, but can be pinned to a specific release. See:
+https://www.balena.io/docs/learn/deploy/release-strategy/release-policy/
+https://www.balena.io/docs/learn/more/masterclasses/fleet-management/#63-pin-using-the-api
 https://github.com/balena-io-examples/staged-releases\
 `,
 			char: 'c',
@@ -200,19 +201,11 @@ Can be repeated to add multiple certificates.\
 			return progressBar.update({ percentage: event.percentage });
 		};
 
-		const spinners: {
-			[key: string]: ReturnType<typeof getVisuals>['Spinner'];
-		} = {};
-
 		const spinnerHandler = function (event: { name: string; action: string }) {
-			const spinner = (spinners[event.name] ??= new visuals.Spinner(
-				event.name,
-			));
 			if (event.action === 'start') {
-				return spinner.start();
+				return cli.action.start(event.name);
 			} else {
-				console.log();
-				return spinner.stop();
+				return cli.action.stop();
 			}
 		};
 
@@ -396,17 +389,12 @@ Can be repeated to add multiple certificates.\
 	}
 
 	async selectApplication(deviceTypeSlug: string) {
-		const visuals = getVisuals();
-
-		const applicationInfoSpinner = new visuals.Spinner(
-			'Downloading list of applications and releases.',
-		);
-		applicationInfoSpinner.start();
+		cli.action.start('Downloading list of applications and releases.');
 
 		const applications = await this.getApplicationsWithSuccessfulBuilds(
 			deviceTypeSlug,
 		);
-		applicationInfoSpinner.stop();
+		cli.action.stop();
 		if (applications.length === 0) {
 			throw new ExpectedError(
 				`No fleets found with successful releases for device type '${deviceTypeSlug}'`,

--- a/lib/utils/cloud.ts
+++ b/lib/utils/cloud.ts
@@ -138,6 +138,7 @@ export async function downloadOSImage(
 	OSVersion?: string,
 ) {
 	console.info(`Getting device operating system for ${deviceType}`);
+	const { cli } = await import('cli-ux');
 
 	if (!OSVersion) {
 		console.warn('OS version not specified: using latest released version');
@@ -167,20 +168,20 @@ export async function downloadOSImage(
 	const bar = new visuals.Progress(
 		`Downloading balenaOS version ${displayVersion}`,
 	);
-	const spinner = new visuals.Spinner(
-		`Downloading balenaOS version ${displayVersion} (size unknown)`,
-	);
-
 	stream.on('progress', (state: any) => {
 		if (state != null) {
 			return bar.update(state);
 		} else {
-			return spinner.start();
+			return cli.action.start(
+				`Downloading balenaOS version ${displayVersion} (size unknown)`,
+				'',
+				{ stdout: true },
+			);
 		}
 	});
 
 	stream.on('end', () => {
-		spinner.stop();
+		cli.action.stop();
 	});
 
 	// We completely rely on the `mime` custom property

--- a/lib/utils/patterns.ts
+++ b/lib/utils/patterns.ts
@@ -207,35 +207,6 @@ export async function selectOrganization(organizations?: Organization[]) {
 	});
 }
 
-export async function awaitDevice(uuid: string) {
-	const balena = getBalenaSdk();
-	const deviceName = await balena.models.device.getName(uuid);
-	const visuals = getVisuals();
-	const spinner = new visuals.Spinner(
-		`Waiting for ${deviceName} to come online`,
-	);
-
-	const poll = async (): Promise<void> => {
-		const isOnline = await balena.models.device.isOnline(uuid);
-		if (isOnline) {
-			spinner.stop();
-			console.info(`The device **${deviceName}** is online!`);
-			return;
-		} else {
-			// Spinner implementation is smart enough to
-			// not start again if it was already started
-			spinner.start();
-
-			await delay(3000);
-			await poll();
-		}
-	};
-
-	console.info(`Waiting for ${deviceName} to connect to balena...`);
-	await poll();
-	return uuid;
-}
-
 export async function awaitDeviceOsUpdate(
 	uuid: string,
 	targetOsVersion: string,

--- a/lib/utils/promote.ts
+++ b/lib/utils/promote.ts
@@ -17,7 +17,7 @@
 import type * as BalenaSdk from 'balena-sdk';
 
 import { ExpectedError, printErrorMessage } from '../errors';
-import { getVisuals, stripIndent, getCliForm } from './lazy';
+import { stripIndent, getCliForm } from './lazy';
 import Logger = require('./logger');
 import { confirm } from './patterns';
 import { exec, execBuffered, getDeviceOsRelease } from './ssh';
@@ -89,19 +89,17 @@ async function execCommand(
 	msg: string,
 ): Promise<void> {
 	const through = await import('through2');
-	const visuals = getVisuals();
+	const { cli } = await import('cli-ux');
 
-	const spinner = new visuals.Spinner(`[${deviceIp}] Connecting...`);
-	const innerSpinner = spinner.spinner;
+	cli.action.start(`[${deviceIp}] Connecting...`);
 
 	const stream = through(function (data, _enc, cb) {
-		innerSpinner.setSpinnerTitle(`%s [${deviceIp}] ${msg}`);
+		cli.action.task!.action = `[${deviceIp}] ${msg}`;
 		cb(null, data);
 	});
 
-	spinner.start();
 	await exec(deviceIp, cmd, stream);
-	spinner.stop();
+	cli.action.stop();
 }
 
 async function configure(deviceIp: string, config: any): Promise<void> {


### PR DESCRIPTION
This change switches to using the spinner widget from `cli-ux` instead
of `resin-cli-visuals` as part of the process of deprecating the
`resin-cli-visuals` library.
    
Depends-on: https://github.com/balena-io/balena-cli/pull/2455
    
Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>