### PR TITLE
Correctly use the device uuid when logging the tunnel target

### DIFF
--- a/lib/commands/tunnel.ts
+++ b/lib/commands/tunnel.ts
@@ -136,8 +136,7 @@ export default class TunnelCmd extends Command {
 		// Ascertain device uuid
 		const { getOnlineTargetDeviceUuid } = await import('../utils/patterns');
 		const uuid = await getOnlineTargetDeviceUuid(sdk, params.deviceOrFleet);
-		const device = await sdk.models.device.get(uuid);
-		logger.logInfo(`Opening a tunnel to ${device.uuid}...`);
+		logger.logInfo(`Opening a tunnel to ${uuid}...`);
 
 		const _ = await import('lodash');
 		const localListeners = _.chain(options.port)
@@ -147,11 +146,7 @@ export default class TunnelCmd extends Command {
 			.map(async ({ localPort, localAddress, remotePort }) => {
 				try {
 					const { tunnelConnectionToDevice } = await import('../utils/tunnel');
-					const handler = await tunnelConnectionToDevice(
-						device.uuid,
-						remotePort,
-						sdk,
-					);
+					const handler = await tunnelConnectionToDevice(uuid, remotePort, sdk);
 
 					const { createServer } = await import('net');
 					const server = createServer(async (client: Socket) => {
@@ -162,7 +157,7 @@ export default class TunnelCmd extends Command {
 								client.remotePort || 0,
 								client.localAddress,
 								client.localPort,
-								device.uuid,
+								uuid,
 								remotePort,
 							);
 						} catch (err) {
@@ -171,7 +166,7 @@ export default class TunnelCmd extends Command {
 								client.remotePort || 0,
 								client.localAddress,
 								client.localPort,
-								device.uuid,
+								uuid,
 								remotePort,
 								err,
 							);
@@ -186,15 +181,15 @@ export default class TunnelCmd extends Command {
 					});
 
 					logger.logInfo(
-						` - tunnelling ${localAddress}:${localPort} to ${device.uuid}:${remotePort}`,
+						` - tunnelling ${localAddress}:${localPort} to ${uuid}:${remotePort}`,
 					);
 
 					return true;
 				} catch (err) {
 					logger.logWarn(
-						` - not tunnelling ${localAddress}:${localPort} to ${
-							device.uuid
-						}:${remotePort}, failed ${JSON.stringify(err.message)}`,
+						` - not tunnelling ${localAddress}:${localPort} to ${uuid}:${remotePort}, failed ${JSON.stringify(
+							err.message,
+						)}`,
 					);
 
 					return false;

--- a/lib/commands/tunnel.ts
+++ b/lib/commands/tunnel.ts
@@ -162,7 +162,7 @@ export default class TunnelCmd extends Command {
 								client.remotePort || 0,
 								client.localAddress,
 								client.localPort,
-								device.vpn_address || '',
+								device.uuid,
 								remotePort,
 							);
 						} catch (err) {
@@ -171,7 +171,7 @@ export default class TunnelCmd extends Command {
 								client.remotePort || 0,
 								client.localAddress,
 								client.localPort,
-								device.vpn_address || '',
+								device.uuid,
 								remotePort,
 								err,
 							);


### PR DESCRIPTION
The "vpn address" is only relevant on the device/vpn server themselves
and makes no sense from a CLI context as it uses the uuid to specify
the target

Change-type: patch

<!-- You can remove tags that do not apply. -->
Resolves: # <!-- Refer an issue of this repository that this PR fixes -->  
Change-type: major|minor|patch <!-- See https://semver.org/ -->  
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->  
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->  

---
Please check the CONTRIBUTING.md file for relevant information and some
guidance. Keep in mind that the CLI is a cross-platform application that runs
on Windows, macOS and Linux. Tests will be automatically run by balena CI on
all three operating systems, but this will only help if you have added test
code that exercises the modified or added feature code.

Note that each commit message (currently only the first line) will be
automatically copied to the CHANGELOG.md file, so try writing it in a way
that describes the feature or fix for CLI users.

If there isn't a linked issue or if the linked issue doesn't quite match the
PR, please add a PR description to explain its purpose or the features that it
implements. Adding PR comments to blocks of code that aren't self explanatory
usually helps with the review process.

If the PR introduces security considerations or affects the development, build
or release process, please be sure to highlight this in the PR description.

Thank you very much for your contribution!
