### PR TITLE
preload: Fix detection of supervisor version for balenaOS v2.93.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3812,9 +3812,9 @@
       }
     },
     "balena-preload": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/balena-preload/-/balena-preload-12.0.0.tgz",
-      "integrity": "sha512-BD4ayIqqopJB0KFFjjlz0rIpcbbHojG8El8qOBLJHvidatgtgVs5xFWBoF5B7fgdJdjRsclA/AbUMZwovN7t3w==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/balena-preload/-/balena-preload-12.0.1.tgz",
+      "integrity": "sha512-KnpJtIpL3cwmTRjwRQq3V4i4Y8VBPPESpRW8bM6WUHUc70OGPzcYmDIuDphAG+xqOM4zx0VdkERiZbEEfosw6Q==",
       "requires": {
         "archiver": "^3.1.1",
         "balena-sdk": "^16.0.0",

--- a/package.json
+++ b/package.json
@@ -207,7 +207,7 @@
     "balena-errors": "^4.7.1",
     "balena-image-fs": "^7.0.6",
     "balena-image-manager": "^7.1.1",
-    "balena-preload": "^12.0.0",
+    "balena-preload": "^12.0.1",
     "balena-release": "^3.2.0",
     "balena-sdk": "^16.9.0",
     "balena-semver": "^2.3.0",


### PR DESCRIPTION
Update balena-preload from 12.0.0 to 12.0.1

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>
See: https://github.com/balena-os/meta-balena/pull/2473
See: https://github.com/balena-io-modules/balena-preload/issues/271
