### PR TITLE
Add provisioning key expiry date option to config generate options

### DIFF
--- a/docs/balena-cli.md
+++ b/docs/balena-cli.md
@@ -811,6 +811,10 @@ path to the config JSON file, see `balena os build-config`
 
 custom key name assigned to generated provisioning api key
 
+#### --provisioning-key-expiry-date PROVISIONING-KEY-EXPIRY-DATE
+
+expiry date assigned to generated provisioning api key (format: YYYY-MM-DD)
+
 ## device local-mode &#60;uuid&#62;
 
 Output current local mode status, or enable/disable local mode
@@ -2236,6 +2240,10 @@ paths to local files to place into the 'system-connections' directory
 
 custom key name assigned to generated provisioning api key
 
+#### --provisioning-key-expiry-date PROVISIONING-KEY-EXPIRY-DATE
+
+expiry date assigned to generated provisioning api key (format: YYYY-MM-DD)
+
 ## os initialize &#60;image&#62;
 
 Initialize an os image for a device with a previously
@@ -2372,6 +2380,10 @@ supervisor cloud polling interval in minutes (e.g. for device variables)
 #### --provisioning-key-name PROVISIONING-KEY-NAME
 
 custom key name assigned to generated provisioning api key
+
+#### --provisioning-key-expiry-date PROVISIONING-KEY-EXPIRY-DATE
+
+expiry date assigned to generated provisioning api key (format: YYYY-MM-DD)
 
 ## config inject &#60;file&#62;
 

--- a/lib/commands/config/generate.ts
+++ b/lib/commands/config/generate.ts
@@ -37,6 +37,7 @@ interface FlagsDef {
 	wifiKey?: string;
 	appUpdatePollInterval?: string;
 	'provisioning-key-name'?: string;
+	'provisioning-key-expiry-date'?: string;
 	help: void;
 }
 
@@ -81,7 +82,11 @@ export default class ConfigGenerateCmd extends Command {
 		dev: cf.dev,
 		device: {
 			...cf.device,
-			exclusive: ['fleet', 'provisioning-key-name'],
+			exclusive: [
+				'fleet',
+				'provisioning-key-name',
+				'provisioning-key-expiry-date',
+			],
 		},
 		deviceApiKey: flags.string({
 			description:
@@ -118,6 +123,11 @@ export default class ConfigGenerateCmd extends Command {
 		}),
 		'provisioning-key-name': flags.string({
 			description: 'custom key name assigned to generated provisioning api key',
+			exclusive: ['device'],
+		}),
+		'provisioning-key-expiry-date': flags.string({
+			description:
+				'expiry date assigned to generated provisioning api key (format: YYYY-MM-DD)',
 			exclusive: ['device'],
 		}),
 		help: cf.help,
@@ -196,6 +206,7 @@ export default class ConfigGenerateCmd extends Command {
 		answers.version = options.version;
 		answers.developmentMode = options.dev;
 		answers.provisioningKeyName = options['provisioning-key-name'];
+		answers.provisioningKeyExpiryDate = options['provisioning-key-expiry-date'];
 
 		// Generate config
 		const { generateDeviceConfig, generateApplicationConfig } = await import(

--- a/lib/commands/device/init.ts
+++ b/lib/commands/device/init.ts
@@ -31,6 +31,7 @@ interface FlagsDef {
 	config?: string;
 	help: void;
 	'provisioning-key-name'?: string;
+	'provisioning-key-expiry-date'?: string;
 }
 
 export default class DeviceInitCmd extends Command {
@@ -96,6 +97,10 @@ export default class DeviceInitCmd extends Command {
 		}),
 		'provisioning-key-name': flags.string({
 			description: 'custom key name assigned to generated provisioning api key',
+		}),
+		'provisioning-key-expiry-date': flags.string({
+			description:
+				'expiry date assigned to generated provisioning api key (format: YYYY-MM-DD)',
 		}),
 		help: cf.help,
 	};
@@ -185,6 +190,14 @@ export default class DeviceInitCmd extends Command {
 				options['provisioning-key-name'],
 			);
 		}
+
+		if (options['provisioning-key-expiry-date']) {
+			configureCommand.push(
+				'--provisioning-key-expiry-date',
+				options['provisioning-key-expiry-date'],
+			);
+		}
+
 		await runCommand(configureCommand);
 	}
 

--- a/lib/commands/os/configure.ts
+++ b/lib/commands/os/configure.ts
@@ -43,6 +43,7 @@ interface FlagsDef {
 	'system-connection': string[];
 	'initial-device-name'?: string;
 	'provisioning-key-name'?: string;
+	'provisioning-key-expiry-date'?: string;
 }
 
 interface ArgsDef {
@@ -58,6 +59,7 @@ interface Answers {
 	wifiSsid?: string;
 	wifiKey?: string;
 	provisioningKeyName?: string;
+	provisioningKeyExpiryDate?: string;
 }
 
 export default class OsConfigureCmd extends Command {
@@ -121,7 +123,7 @@ export default class OsConfigureCmd extends Command {
 		config: flags.string({
 			description:
 				'path to a pre-generated config.json file to be injected in the OS image',
-			exclusive: ['provisioning-key-name'],
+			exclusive: ['provisioning-key-name', 'provisioning-key-expiry-date'],
 		}),
 		'config-app-update-poll-interval': flags.integer({
 			description:
@@ -138,7 +140,14 @@ export default class OsConfigureCmd extends Command {
 			description: 'WiFi SSID (network name) (non-interactive configuration)',
 		}),
 		dev: cf.dev,
-		device: { ...cf.device, exclusive: ['fleet', 'provisioning-key-name'] },
+		device: {
+			...cf.device,
+			exclusive: [
+				'fleet',
+				'provisioning-key-name',
+				'provisioning-key-expiry-date',
+			],
+		},
 		'device-type': flags.string({
 			description:
 				'device type slug (e.g. "raspberrypi3") to override the fleet device type',
@@ -159,6 +168,11 @@ export default class OsConfigureCmd extends Command {
 		}),
 		'provisioning-key-name': flags.string({
 			description: 'custom key name assigned to generated provisioning api key',
+			exclusive: ['config', 'device'],
+		}),
+		'provisioning-key-expiry-date': flags.string({
+			description:
+				'expiry date assigned to generated provisioning api key (format: YYYY-MM-DD)',
 			exclusive: ['config', 'device'],
 		}),
 		help: cf.help,
@@ -235,6 +249,7 @@ export default class OsConfigureCmd extends Command {
 		answers.version = osVersion;
 		answers.developmentMode = options.dev;
 		answers.provisioningKeyName = options['provisioning-key-name'];
+		answers.provisioningKeyExpiryDate = options['provisioning-key-expiry-date'];
 
 		if (_.isEmpty(configJson)) {
 			if (device) {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2694,9 +2694,9 @@
       "integrity": "sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw=="
     },
     "@types/json-schema": {
-      "version": "7.0.9",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
-      "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ=="
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
+      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
     },
     "@types/jsonstream": {
       "version": "0.8.30",
@@ -3981,49 +3981,61 @@
       }
     },
     "balena-sdk": {
-      "version": "16.9.0",
-      "resolved": "https://registry.npmjs.org/balena-sdk/-/balena-sdk-16.9.0.tgz",
-      "integrity": "sha512-iuIiXAEkDXoEtUJzFG5RO+rvudqMsoBppdgQLOrnIdWc14T+mvwWUFKAHHAkvxnA0GLmbxqGp7qo3uVMgS2Ojw==",
+      "version": "16.20.4",
+      "resolved": "https://registry.npmjs.org/balena-sdk/-/balena-sdk-16.20.4.tgz",
+      "integrity": "sha512-e6uho8v9S7TO0V1RMCBWNLViY0+PH39snQuHKGy5jZ1YfwTMk/e/Po/99SUBylcAyqqXGN9QjV5Id2X4fiPQow==",
       "requires": {
         "@balena/es-version": "^1.0.0",
         "@types/json-schema": "^7.0.9",
-        "@types/lodash": "^4.14.168",
-        "@types/memoizee": "^0.4.5",
-        "@types/node": "^10.17.55",
+        "@types/node": "^12.20.50",
         "abortcontroller-polyfill": "^1.7.1",
         "balena-auth": "^4.1.0",
         "balena-errors": "^4.7.1",
         "balena-hup-action-utils": "~4.1.0",
-        "balena-pine": "^12.4.0",
         "balena-register-device": "^7.1.0",
-        "balena-request": "^11.5.0",
+        "balena-request": "^11.5.5",
         "balena-semver": "^2.3.0",
         "balena-settings-client": "^4.0.6",
         "lodash": "^4.17.21",
         "memoizee": "^0.4.15",
         "moment": "^2.29.1",
         "ndjson": "^2.0.0",
+        "pinejs-client-core": "^6.9.6",
         "tslib": "^2.1.0"
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.17.60",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-          "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
+          "version": "12.20.52",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.52.tgz",
+          "integrity": "sha512-cfkwWw72849SNYp3Zx0IcIs25vABmFh73xicxhCkTcvtZQeIez15PpwQN8fY3RD7gv1Wrxlc9MEtfMORZDEsGw=="
         },
         "balena-hup-action-utils": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/balena-hup-action-utils/-/balena-hup-action-utils-4.1.0.tgz",
-          "integrity": "sha512-aLVlbdXhJi1rHpTmF9/YbheWtgAmwDUBPk3eKXhJuOZWg4XDnhbP4DUOdPBIM+U+rvXcPeBKOYqsswO0ymd96w==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/balena-hup-action-utils/-/balena-hup-action-utils-4.1.1.tgz",
+          "integrity": "sha512-VpyH3py5NPMBJe1fwj5NFUeq58i2V5VaXU1EMa0ja/kUCUwTM1HL5nfNNOU3bd66V+VGqCw49iO7Wppccg3pPg==",
           "requires": {
             "balena-semver": "^2.0.0",
             "tslib": "^2.0.0"
           }
         },
+        "balena-request": {
+          "version": "11.5.5",
+          "resolved": "https://registry.npmjs.org/balena-request/-/balena-request-11.5.5.tgz",
+          "integrity": "sha512-sQG+OBAUKOW4KENPRGqit/34l3kWZqoT+aUdpitIG8QdKUrRjKQkjkCmDzprDEDJuXfWoCToKdleN9tYwRCXEw==",
+          "requires": {
+            "@balena/node-web-streams": "^0.2.3",
+            "balena-errors": "^4.7.1",
+            "fetch-ponyfill": "^7.1.0",
+            "fetch-readablestream": "^0.2.0",
+            "progress-stream": "^2.0.0",
+            "qs": "^6.9.4",
+            "tslib": "^2.0.0"
+          }
+        },
         "tslib": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -209,7 +209,7 @@
     "balena-image-manager": "^7.1.1",
     "balena-preload": "^12.0.1",
     "balena-release": "^3.2.0",
-    "balena-sdk": "^16.9.0",
+    "balena-sdk": "^16.20.4",
     "balena-semver": "^2.3.0",
     "balena-settings-client": "^4.0.7",
     "balena-settings-storage": "^7.0.0",

--- a/tests/commands/os/configure.spec.ts
+++ b/tests/commands/os/configure.spec.ts
@@ -59,6 +59,7 @@ if (process.platform !== 'win32') {
 				'--config-network ethernet',
 				'--initial-device-name testDeviceName',
 				'--provisioning-key-name testKey',
+				'--provisioning-key-expiry-date 2050-12-12',
 			];
 
 			const { err } = await runCommand(command.join(' '));


### PR DESCRIPTION
Change-Type: minor
Signed-off-by: Nitish Agarwal <1592163+nitishagar@users.noreply.github.com>

Depends-on: https://github.com/balena-io/open-balena-api/pull/814
See: https://jel.ly.fish/product-improvement-provisioning-api-key-management-4c86a2c3-8899-4764-9019-8c9b932e57f5