### PR TITLE
Deduplicate npm-shrinkwrap.json

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -10566,7 +10566,7 @@
     "macmount": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/macmount/-/macmount-1.0.0.tgz",
-      "integrity": "sha1-qsz7nv62fdbpRkm5HMErNtAtLPE=",
+      "integrity": "sha512-kaz5wkgk4lQSAZ+Ch+TJHJHQqjmqM9TOjoLMrOp1mdLlrQBPa2qC/5Hj6OEjklVpMZn6GC2EeBibmSVeyRpXuA==",
       "optional": true
     },
     "magic-string": {


### PR DESCRIPTION
Fixes the npm deduplication test that atm fails on master
See: https://github.com/balena-io/balena-cli/pull/2485
See: https://ci.product-os.io/builds/925501

Change-type: patch
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>

<!-- You can remove tags that do not apply. -->
Resolves: # <!-- Refer an issue of this repository that this PR fixes -->  
Change-type: major|minor|patch <!-- See https://semver.org/ -->  
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->  
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->  

---
Please check the CONTRIBUTING.md file for relevant information and some
guidance. Keep in mind that the CLI is a cross-platform application that runs
on Windows, macOS and Linux. Tests will be automatically run by balena CI on
all three operating systems, but this will only help if you have added test
code that exercises the modified or added feature code.

Note that each commit message (currently only the first line) will be
automatically copied to the CHANGELOG.md file, so try writing it in a way
that describes the feature or fix for CLI users.

If there isn't a linked issue or if the linked issue doesn't quite match the
PR, please add a PR description to explain its purpose or the features that it
implements. Adding PR comments to blocks of code that aren't self explanatory
usually helps with the review process.

If the PR introduces security considerations or affects the development, build
or release process, please be sure to highlight this in the PR description.

Thank you very much for your contribution!
