### PR TITLE
Update balena-sdk to use the native OS release phase & variant fields

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3981,9 +3981,9 @@
       }
     },
     "balena-sdk": {
-      "version": "16.20.4",
-      "resolved": "https://registry.npmjs.org/balena-sdk/-/balena-sdk-16.20.4.tgz",
-      "integrity": "sha512-e6uho8v9S7TO0V1RMCBWNLViY0+PH39snQuHKGy5jZ1YfwTMk/e/Po/99SUBylcAyqqXGN9QjV5Id2X4fiPQow==",
+      "version": "16.22.0",
+      "resolved": "https://registry.npmjs.org/balena-sdk/-/balena-sdk-16.22.0.tgz",
+      "integrity": "sha512-HTEC8fYD0SZDlqgn0gcQ7EWliL9XIiGQ/P3f6xxvs4Nj0mG5wYtFrqK8dC6NAR0VQQxzWJtvM6iDFhshLIes7A==",
       "requires": {
         "@balena/es-version": "^1.0.0",
         "@types/json-schema": "^7.0.9",
@@ -4005,9 +4005,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.20.52",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.52.tgz",
-          "integrity": "sha512-cfkwWw72849SNYp3Zx0IcIs25vABmFh73xicxhCkTcvtZQeIez15PpwQN8fY3RD7gv1Wrxlc9MEtfMORZDEsGw=="
+          "version": "12.20.55",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+          "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="
         },
         "balena-hup-action-utils": {
           "version": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -209,7 +209,7 @@
     "balena-image-manager": "^7.1.1",
     "balena-preload": "^12.1.0",
     "balena-release": "^3.2.0",
-    "balena-sdk": "^16.20.4",
+    "balena-sdk": "^16.22.0",
     "balena-semver": "^2.3.0",
     "balena-settings-client": "^4.0.7",
     "balena-settings-storage": "^7.0.0",


### PR DESCRIPTION
Update balena-sdk from 16.20.4 to 16.22.0

Change-type: patch

<!-- You can remove tags that do not apply. -->
Resolves: # <!-- Refer an issue of this repository that this PR fixes -->  
Change-type: major|minor|patch <!-- See https://semver.org/ -->  
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->  
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->  

---
Please check the CONTRIBUTING.md file for relevant information and some
guidance. Keep in mind that the CLI is a cross-platform application that runs
on Windows, macOS and Linux. Tests will be automatically run by balena CI on
all three operating systems, but this will only help if you have added test
code that exercises the modified or added feature code.

Note that each commit message (currently only the first line) will be
automatically copied to the CHANGELOG.md file, so try writing it in a way
that describes the feature or fix for CLI users.

If there isn't a linked issue or if the linked issue doesn't quite match the
PR, please add a PR description to explain its purpose or the features that it
implements. Adding PR comments to blocks of code that aren't self explanatory
usually helps with the review process.

If the PR introduces security considerations or affects the development, build
or release process, please be sure to highlight this in the PR description.

Thank you very much for your contribution!
