### PR TITLE
Add debug logs when registry secrets are being used

### DIFF
--- a/lib/utils/compose_ts.ts
+++ b/lib/utils/compose_ts.ts
@@ -910,6 +910,7 @@ export async function getRegistrySecrets(
 	sdk: BalenaSDK,
 	inputFilename?: string,
 ): Promise<MultiBuild.RegistrySecrets> {
+	const logger = await Logger.getLogger();
 	if (inputFilename != null) {
 		return await parseRegistrySecrets(inputFilename);
 	}
@@ -923,6 +924,7 @@ export async function getRegistrySecrets(
 
 	for (const potentialPath of potentialPaths) {
 		if (await exists(potentialPath)) {
+			logger.logDebug(`Found registry secrets file: ${potentialPath}`);
 			return await parseRegistrySecrets(potentialPath);
 		}
 	}

--- a/lib/utils/device/deploy.ts
+++ b/lib/utils/device/deploy.ts
@@ -530,6 +530,13 @@ async function assignDockerBuildOpts(
 
 	globalLogger.logDebug(`Using ${images.length} on-device images for cache...`);
 
+	if (opts.registrySecrets && Object.keys(opts.registrySecrets).length > 0) {
+		globalLogger.logDebug('Using secrets for the following registries:');
+		for (const registry of Object.keys(opts.registrySecrets)) {
+			globalLogger.logDebug(`    ${registry}`);
+		}
+	}
+
 	await Promise.all(
 		buildTasks.map(async (task: BuildTask) => {
 			task.dockerOpts = {


### PR DESCRIPTION
If you unknowingly have a `secrets.json` file that has incorrect
credentials, it can be really hard to debug why you're builds will start
failing with the error:
```
unauthorized: incorrect username or password
```

This change adds extra logging that will make it more obvious what's
going on when you use `--debug`.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>

<!-- You can remove tags that do not apply. -->
Resolves: # <!-- Refer an issue of this repository that this PR fixes -->  
Change-type: major|minor|patch <!-- See https://semver.org/ -->  
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->  
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->  

---
Please check the CONTRIBUTING.md file for relevant information and some
guidance. Keep in mind that the CLI is a cross-platform application that runs
on Windows, macOS and Linux. Tests will be automatically run by balena CI on
all three operating systems, but this will only help if you have added test
code that exercises the modified or added feature code.

Note that each commit message (currently only the first line) will be
automatically copied to the CHANGELOG.md file, so try writing it in a way
that describes the feature or fix for CLI users.

If there isn't a linked issue or if the linked issue doesn't quite match the
PR, please add a PR description to explain its purpose or the features that it
implements. Adding PR comments to blocks of code that aren't self explanatory
usually helps with the review process.

If the PR introduces security considerations or affects the development, build
or release process, please be sure to highlight this in the PR description.

Thank you very much for your contribution!
