### PR TITLE
Add `--view` flag to `fleet` command for opening a fleet's dashboard page

### DIFF
--- a/docs/balena-cli.md
+++ b/docs/balena-cli.md
@@ -353,6 +353,7 @@ Examples:
 
 	$ balena fleet MyFleet
 	$ balena fleet myorg/myfleet
+	$ balena fleet myorg/myfleet --view
 
 ### Arguments
 
@@ -361,6 +362,10 @@ Examples:
 fleet name, slug (preferred), or numeric ID (deprecated)
 
 ### Options
+
+#### --view
+
+open fleet dashboard page
 
 ## fleet create &#60;name&#62;
 


### PR DESCRIPTION
Add `--view` flag to `fleet` command for opening a fleet's dashboard page

Connects-to: #1440
Change-type: minor
Signed-off-by: Matthew Yarmolinsky <matthew-timothy@balena.io>

---
Please check the CONTRIBUTING.md file for relevant information and some
guidance. Keep in mind that the CLI is a cross-platform application that runs
on Windows, macOS and Linux. Tests will be automatically run by balena CI on
all three operating systems, but this will only help if you have added test
code that exercises the modified or added feature code.

Note that each commit message (currently only the first line) will be
automatically copied to the CHANGELOG.md file, so try writing it in a way
that describes the feature or fix for CLI users.

If there isn't a linked issue or if the linked issue doesn't quite match the
PR, please add a PR description to explain its purpose or the features that it
implements. Adding PR comments to blocks of code that aren't self explanatory
usually helps with the review process.

If the PR introduces security considerations or affects the development, build
or release process, please be sure to highlight this in the PR description.

Thank you very much for your contribution!
