### PR TITLE
Drop deprecated `--logs` flag

### DIFF
--- a/docs/balena-cli.md
+++ b/docs/balena-cli.md
@@ -3042,10 +3042,6 @@ Use QEMU for ARM architecture emulation during the image build
 
 Alternative Dockerfile name/path, relative to the source folder
 
-#### --logs
-
-No-op and deprecated since balena CLI v12.0.0. Build logs are now shown by default.
-
 #### --nologs
 
 Hide the image build log output (produce less verbose output)
@@ -3270,10 +3266,6 @@ Use QEMU for ARM architecture emulation during the image build
 #### --dockerfile DOCKERFILE
 
 Alternative Dockerfile name/path, relative to the source folder
-
-#### --logs
-
-No-op and deprecated since balena CLI v12.0.0. Build logs are now shown by default.
 
 #### --nologs
 

--- a/lib/utils/compose-types.d.ts
+++ b/lib/utils/compose-types.d.ts
@@ -64,7 +64,6 @@ export interface ComposeOpts {
 export interface ComposeCliFlags {
 	emulated: boolean;
 	dockerfile?: string;
-	logs: boolean;
 	nologs: boolean;
 	'multi-dockerignore': boolean;
 	'noparent-check': boolean;

--- a/lib/utils/compose_ts.ts
+++ b/lib/utils/compose_ts.ts
@@ -1653,10 +1653,6 @@ export const composeCliFlags: flags.Input<ComposeCliFlags> = {
 		description:
 			'Alternative Dockerfile name/path, relative to the source folder',
 	}),
-	logs: flags.boolean({
-		description:
-			'No-op and deprecated since balena CLI v12.0.0. Build logs are now shown by default.',
-	}),
 	nologs: flags.boolean({
 		description:
 			'Hide the image build log output (produce less verbose output)',


### PR DESCRIPTION
Drop deprecated `--logs` flag

Resolves: #2499 
Change-type: major
Signed-off-by: Matthew Yarmolinsky <matthew-timothy@balena.io>

---
Please check the CONTRIBUTING.md file for relevant information and some
guidance. Keep in mind that the CLI is a cross-platform application that runs
on Windows, macOS and Linux. Tests will be automatically run by balena CI on
all three operating systems, but this will only help if you have added test
code that exercises the modified or added feature code.

Note that each commit message (currently only the first line) will be
automatically copied to the CHANGELOG.md file, so try writing it in a way
that describes the feature or fix for CLI users.

If there isn't a linked issue or if the linked issue doesn't quite match the
PR, please add a PR description to explain its purpose or the features that it
implements. Adding PR comments to blocks of code that aren't self explanatory
usually helps with the review process.

If the PR introduces security considerations or affects the development, build
or release process, please be sure to highlight this in the PR description.

Thank you very much for your contribution!
