### PR TITLE
Drop support for the deprecated `balena device public-url <enable|disable|status> <uuid>` and related format

### DIFF
--- a/docs/balena-cli.md
+++ b/docs/balena-cli.md
@@ -941,9 +941,6 @@ This command will output the current public URL for the
 specified device.  It can also enable or disable the URL,
 or output the enabled status, using the respective options.
 
-The old command style 'balena device public-url enable <uuid>'
-is deprecated, but still supported.
-
 Examples:
 
 	$ balena device public-url 23c73a1
@@ -956,10 +953,6 @@ Examples:
 #### UUID
 
 the uuid of the device to manage
-
-#### LEGACYUUID
-
-
 
 ### Options
 

--- a/lib/commands/device/public-url.ts
+++ b/lib/commands/device/public-url.ts
@@ -32,8 +32,6 @@ interface FlagsDef {
 
 interface ArgsDef {
 	uuid: string;
-	// Optional hidden arg to support old command format
-	legacyUuid?: string;
 }
 
 export default class DevicePublicUrlCmd extends Command {
@@ -43,9 +41,6 @@ export default class DevicePublicUrlCmd extends Command {
 		This command will output the current public URL for the
 		specified device.  It can also enable or disable the URL,
 		or output the enabled status, using the respective options.
-
-		The old command style 'balena device public-url enable <uuid>'
-		is deprecated, but still supported.
 	`;
 
 	public static examples = [
@@ -61,12 +56,6 @@ export default class DevicePublicUrlCmd extends Command {
 			description: 'the uuid of the device to manage',
 			parse: (dev) => tryAsInteger(dev),
 			required: true,
-		},
-		{
-			// Optional hidden arg to support old command format
-			name: 'legacyUuid',
-			parse: (dev) => tryAsInteger(dev),
-			hidden: true,
 		},
 	];
 
@@ -94,25 +83,6 @@ export default class DevicePublicUrlCmd extends Command {
 		const { args: params, flags: options } = this.parse<FlagsDef, ArgsDef>(
 			DevicePublicUrlCmd,
 		);
-
-		// Legacy command format support.
-		// Previously this command used the following format
-		// (changed due to oclif technicalities):
-		//   `balena device public-url enable|disable|status <uuid>`
-		if (params.legacyUuid) {
-			const action = params.uuid;
-			if (!['enable', 'disable', 'status'].includes(action)) {
-				throw new ExpectedError(
-					`Unexpected arguments: ${params.uuid} ${params.legacyUuid}`,
-				);
-			}
-
-			options.enable = action === 'enable';
-			options.disable = action === 'disable';
-			options.status = action === 'status';
-			params.uuid = params.legacyUuid;
-			delete params.legacyUuid;
-		}
 
 		const balena = getBalenaSdk();
 


### PR DESCRIPTION
Drop support for the deprecated `balena device public-url <enable|disable|status> <uuid>` and related format

Resolves: #2501 
Change-type: major
Signed-off-by: Matthew Yarmolinsky <matthew-timothy@balena.io>

---
Please check the CONTRIBUTING.md file for relevant information and some
guidance. Keep in mind that the CLI is a cross-platform application that runs
on Windows, macOS and Linux. Tests will be automatically run by balena CI on
all three operating systems, but this will only help if you have added test
code that exercises the modified or added feature code.

Note that each commit message (currently only the first line) will be
automatically copied to the CHANGELOG.md file, so try writing it in a way
that describes the feature or fix for CLI users.

If there isn't a linked issue or if the linked issue doesn't quite match the
PR, please add a PR description to explain its purpose or the features that it
implements. Adding PR comments to blocks of code that aren't self explanatory
usually helps with the review process.

If the PR introduces security considerations or affects the development, build
or release process, please be sure to highlight this in the PR description.

Thank you very much for your contribution!
