### PR TITLE
Drop support for numeric fleet id parameters from all commands

### DIFF
--- a/docs/balena-cli.md
+++ b/docs/balena-cli.md
@@ -361,7 +361,7 @@ field to sort by (prepend '-' for descending order)
 
 Display detailed information about a single fleet.
 
-Fleets may be specified by fleet name, slug, or numeric ID. Fleet slugs are
+Fleets may be specified by fleet name or slug. Fleet slugs are
 the recommended option, as they are unique and unambiguous. Slugs can be
 listed with the `balena fleets` command. Note that slugs may change if the
 fleet is renamed. Fleet names are not unique and may result in  "Fleet is
@@ -369,9 +369,7 @@ ambiguous" errors at any time (even if it "used to work in the past"), for
 example if the name clashes with a newly created public fleet, or with fleets
 from other balena accounts that you may be invited to join under any role.
 For this reason, fleet names are especially discouraged in scripts (e.g. CI
-environments). Numeric fleet IDs are deprecated because they consist of an
-implementation detail of the balena backend. We intend to remove support for
-numeric IDs at some point in the future.
+environments).
 
 Examples:
 
@@ -383,7 +381,7 @@ Examples:
 
 #### FLEET
 
-fleet name, slug (preferred), or numeric ID (deprecated)
+fleet name or slug (preferred)
 
 ### Options
 
@@ -445,7 +443,7 @@ fleet device type (Check available types with `balena devices supported`)
 Purge data from all devices belonging to a fleet.
 This will clear the fleet's '/data' directory.
 
-Fleets may be specified by fleet name, slug, or numeric ID. Fleet slugs are
+Fleets may be specified by fleet name or slug. Fleet slugs are
 the recommended option, as they are unique and unambiguous. Slugs can be
 listed with the `balena fleets` command. Note that slugs may change if the
 fleet is renamed. Fleet names are not unique and may result in  "Fleet is
@@ -453,9 +451,7 @@ ambiguous" errors at any time (even if it "used to work in the past"), for
 example if the name clashes with a newly created public fleet, or with fleets
 from other balena accounts that you may be invited to join under any role.
 For this reason, fleet names are especially discouraged in scripts (e.g. CI
-environments). Numeric fleet IDs are deprecated because they consist of an
-implementation detail of the balena backend. We intend to remove support for
-numeric IDs at some point in the future.
+environments).
 
 Examples:
 
@@ -466,7 +462,7 @@ Examples:
 
 #### FLEET
 
-fleet name, slug (preferred), or numeric ID (deprecated)
+fleet name or slug (preferred)
 
 ### Options
 
@@ -477,7 +473,7 @@ Rename a fleet.
 Note, if the `newName` parameter is omitted, it will be
 prompted for interactively.
 
-Fleets may be specified by fleet name, slug, or numeric ID. Fleet slugs are
+Fleets may be specified by fleet name or slug. Fleet slugs are
 the recommended option, as they are unique and unambiguous. Slugs can be
 listed with the `balena fleets` command. Note that slugs may change if the
 fleet is renamed. Fleet names are not unique and may result in  "Fleet is
@@ -485,9 +481,7 @@ ambiguous" errors at any time (even if it "used to work in the past"), for
 example if the name clashes with a newly created public fleet, or with fleets
 from other balena accounts that you may be invited to join under any role.
 For this reason, fleet names are especially discouraged in scripts (e.g. CI
-environments). Numeric fleet IDs are deprecated because they consist of an
-implementation detail of the balena backend. We intend to remove support for
-numeric IDs at some point in the future.
+environments).
 
 Examples:
 
@@ -499,7 +493,7 @@ Examples:
 
 #### FLEET
 
-fleet name, slug (preferred), or numeric ID (deprecated)
+fleet name or slug (preferred)
 
 #### NEWNAME
 
@@ -511,7 +505,7 @@ the new name for the fleet
 
 Restart all devices belonging to a fleet.
 
-Fleets may be specified by fleet name, slug, or numeric ID. Fleet slugs are
+Fleets may be specified by fleet name or slug. Fleet slugs are
 the recommended option, as they are unique and unambiguous. Slugs can be
 listed with the `balena fleets` command. Note that slugs may change if the
 fleet is renamed. Fleet names are not unique and may result in  "Fleet is
@@ -519,9 +513,7 @@ ambiguous" errors at any time (even if it "used to work in the past"), for
 example if the name clashes with a newly created public fleet, or with fleets
 from other balena accounts that you may be invited to join under any role.
 For this reason, fleet names are especially discouraged in scripts (e.g. CI
-environments). Numeric fleet IDs are deprecated because they consist of an
-implementation detail of the balena backend. We intend to remove support for
-numeric IDs at some point in the future.
+environments).
 
 Examples:
 
@@ -532,7 +524,7 @@ Examples:
 
 #### FLEET
 
-fleet name, slug (preferred), or numeric ID (deprecated)
+fleet name or slug (preferred)
 
 ### Options
 
@@ -542,7 +534,7 @@ Permanently remove a fleet.
 
 The --yes option may be used to avoid interactive confirmation.
 
-Fleets may be specified by fleet name, slug, or numeric ID. Fleet slugs are
+Fleets may be specified by fleet name or slug. Fleet slugs are
 the recommended option, as they are unique and unambiguous. Slugs can be
 listed with the `balena fleets` command. Note that slugs may change if the
 fleet is renamed. Fleet names are not unique and may result in  "Fleet is
@@ -550,9 +542,7 @@ ambiguous" errors at any time (even if it "used to work in the past"), for
 example if the name clashes with a newly created public fleet, or with fleets
 from other balena accounts that you may be invited to join under any role.
 For this reason, fleet names are especially discouraged in scripts (e.g. CI
-environments). Numeric fleet IDs are deprecated because they consist of an
-implementation detail of the balena backend. We intend to remove support for
-numeric IDs at some point in the future.
+environments).
 
 Examples:
 
@@ -564,7 +554,7 @@ Examples:
 
 #### FLEET
 
-fleet name, slug (preferred), or numeric ID (deprecated)
+fleet name or slug (preferred)
 
 ### Options
 
@@ -655,7 +645,7 @@ List all of your devices.
 
 Devices can be filtered by fleet with the `--fleet` option.
 
-Fleets may be specified by fleet name, slug, or numeric ID. Fleet slugs are
+Fleets may be specified by fleet name or slug. Fleet slugs are
 the recommended option, as they are unique and unambiguous. Slugs can be
 listed with the `balena fleets` command. Note that slugs may change if the
 fleet is renamed. Fleet names are not unique and may result in  "Fleet is
@@ -663,9 +653,7 @@ ambiguous" errors at any time (even if it "used to work in the past"), for
 example if the name clashes with a newly created public fleet, or with fleets
 from other balena accounts that you may be invited to join under any role.
 For this reason, fleet names are especially discouraged in scripts (e.g. CI
-environments). Numeric fleet IDs are deprecated because they consist of an
-implementation detail of the balena backend. We intend to remove support for
-numeric IDs at some point in the future.
+environments).
 
 The --json option is recommended when scripting the output of this command,
 because field names are less likely to change in JSON format and because it
@@ -683,7 +671,7 @@ Examples:
 
 #### -f, --fleet FLEET
 
-fleet name, slug (preferred), or numeric ID (deprecated)
+fleet name or slug (preferred)
 
 #### -j, --json
 
@@ -790,7 +778,7 @@ If the '--fleet' or '--drive' options are omitted, interactive menus will be
 presented with values to choose from. If the '--os-version' option is omitted,
 the latest released OS version for the fleet's default device type will be used.
 
-Fleets may be specified by fleet name, slug, or numeric ID. Fleet slugs are
+Fleets may be specified by fleet name or slug. Fleet slugs are
 the recommended option, as they are unique and unambiguous. Slugs can be
 listed with the `balena fleets` command. Note that slugs may change if the
 fleet is renamed. Fleet names are not unique and may result in  "Fleet is
@@ -798,9 +786,7 @@ ambiguous" errors at any time (even if it "used to work in the past"), for
 example if the name clashes with a newly created public fleet, or with fleets
 from other balena accounts that you may be invited to join under any role.
 For this reason, fleet names are especially discouraged in scripts (e.g. CI
-environments). Numeric fleet IDs are deprecated because they consist of an
-implementation detail of the balena backend. We intend to remove support for
-numeric IDs at some point in the future.
+environments).
 
 Image configuration questions will be asked interactively unless a pre-configured
 'config.json' file is provided with the '--config' option.  The file can be
@@ -816,7 +802,7 @@ Examples:
 
 #### -f, --fleet FLEET
 
-fleet name, slug (preferred), or numeric ID (deprecated)
+fleet name or slug (preferred)
 
 #### -y, --yes
 
@@ -890,7 +876,7 @@ Move one or more devices to another fleet.
 
 If --fleet is omitted, the fleet will be prompted for interactively.
 
-Fleets may be specified by fleet name, slug, or numeric ID. Fleet slugs are
+Fleets may be specified by fleet name or slug. Fleet slugs are
 the recommended option, as they are unique and unambiguous. Slugs can be
 listed with the `balena fleets` command. Note that slugs may change if the
 fleet is renamed. Fleet names are not unique and may result in  "Fleet is
@@ -898,9 +884,7 @@ ambiguous" errors at any time (even if it "used to work in the past"), for
 example if the name clashes with a newly created public fleet, or with fleets
 from other balena accounts that you may be invited to join under any role.
 For this reason, fleet names are especially discouraged in scripts (e.g. CI
-environments). Numeric fleet IDs are deprecated because they consist of an
-implementation detail of the balena backend. We intend to remove support for
-numeric IDs at some point in the future.
+environments).
 
 Examples:
 
@@ -919,7 +903,7 @@ comma-separated list (no blank spaces) of device UUIDs to be moved
 
 #### -f, --fleet FLEET
 
-fleet name, slug (preferred), or numeric ID (deprecated)
+fleet name or slug (preferred)
 
 ## device os-update &#60;uuid&#62;
 
@@ -1038,7 +1022,7 @@ Register a new device with a balena fleet.
 
 If --uuid is not provided, a new UUID will be automatically assigned.
 
-Fleets may be specified by fleet name, slug, or numeric ID. Fleet slugs are
+Fleets may be specified by fleet name or slug. Fleet slugs are
 the recommended option, as they are unique and unambiguous. Slugs can be
 listed with the `balena fleets` command. Note that slugs may change if the
 fleet is renamed. Fleet names are not unique and may result in  "Fleet is
@@ -1046,9 +1030,7 @@ ambiguous" errors at any time (even if it "used to work in the past"), for
 example if the name clashes with a newly created public fleet, or with fleets
 from other balena accounts that you may be invited to join under any role.
 For this reason, fleet names are especially discouraged in scripts (e.g. CI
-environments). Numeric fleet IDs are deprecated because they consist of an
-implementation detail of the balena backend. We intend to remove support for
-numeric IDs at some point in the future.
+environments).
 
 Examples:
 
@@ -1060,7 +1042,7 @@ Examples:
 
 #### FLEET
 
-fleet name, slug (preferred), or numeric ID (deprecated)
+fleet name or slug (preferred)
 
 ### Options
 
@@ -1274,7 +1256,7 @@ name may be null in JSON output (or 'N/A' in tabular output) if the fleet that
 the device belonged to is no longer accessible by the current user (for example,
 in case the current user was removed from the fleet by the fleet's owner).
 
-Fleets may be specified by fleet name, slug, or numeric ID. Fleet slugs are
+Fleets may be specified by fleet name or slug. Fleet slugs are
 the recommended option, as they are unique and unambiguous. Slugs can be
 listed with the `balena fleets` command. Note that slugs may change if the
 fleet is renamed. Fleet names are not unique and may result in  "Fleet is
@@ -1282,9 +1264,7 @@ ambiguous" errors at any time (even if it "used to work in the past"), for
 example if the name clashes with a newly created public fleet, or with fleets
 from other balena accounts that you may be invited to join under any role.
 For this reason, fleet names are especially discouraged in scripts (e.g. CI
-environments). Numeric fleet IDs are deprecated because they consist of an
-implementation detail of the balena backend. We intend to remove support for
-numeric IDs at some point in the future.
+environments).
 
 Examples:
 
@@ -1302,7 +1282,7 @@ Examples:
 
 #### -f, --fleet FLEET
 
-fleet name, slug (preferred), or numeric ID (deprecated)
+fleet name or slug (preferred)
 
 #### -c, --config
 
@@ -1412,7 +1392,7 @@ therefore the --service option cannot be used when the variable name starts
 with a reserved prefix. When defining custom fleet variables, please avoid
 these reserved prefixes.
 
-Fleets may be specified by fleet name, slug, or numeric ID. Fleet slugs are
+Fleets may be specified by fleet name or slug. Fleet slugs are
 the recommended option, as they are unique and unambiguous. Slugs can be
 listed with the `balena fleets` command. Note that slugs may change if the
 fleet is renamed. Fleet names are not unique and may result in  "Fleet is
@@ -1420,9 +1400,7 @@ ambiguous" errors at any time (even if it "used to work in the past"), for
 example if the name clashes with a newly created public fleet, or with fleets
 from other balena accounts that you may be invited to join under any role.
 For this reason, fleet names are especially discouraged in scripts (e.g. CI
-environments). Numeric fleet IDs are deprecated because they consist of an
-implementation detail of the balena backend. We intend to remove support for
-numeric IDs at some point in the future.
+environments).
 
 Examples:
 
@@ -1450,7 +1428,7 @@ variable value; if omitted, use value from this process' environment
 
 #### -f, --fleet FLEET
 
-fleet name, slug (preferred), or numeric ID (deprecated)
+fleet name or slug (preferred)
 
 #### -d, --device DEVICE
 
@@ -1533,7 +1511,7 @@ select a service variable (may be used together with the --device option)
 
 List all tags and their values for the specified fleet, device or release.
 
-Fleets may be specified by fleet name, slug, or numeric ID. Fleet slugs are
+Fleets may be specified by fleet name or slug. Fleet slugs are
 the recommended option, as they are unique and unambiguous. Slugs can be
 listed with the `balena fleets` command. Note that slugs may change if the
 fleet is renamed. Fleet names are not unique and may result in  "Fleet is
@@ -1541,9 +1519,7 @@ ambiguous" errors at any time (even if it "used to work in the past"), for
 example if the name clashes with a newly created public fleet, or with fleets
 from other balena accounts that you may be invited to join under any role.
 For this reason, fleet names are especially discouraged in scripts (e.g. CI
-environments). Numeric fleet IDs are deprecated because they consist of an
-implementation detail of the balena backend. We intend to remove support for
-numeric IDs at some point in the future.
+environments).
 
 Examples:
 
@@ -1557,7 +1533,7 @@ Examples:
 
 #### -f, --fleet FLEET
 
-fleet name, slug (preferred), or numeric ID (deprecated)
+fleet name or slug (preferred)
 
 #### -d, --device DEVICE
 
@@ -1571,7 +1547,7 @@ release id
 
 Remove a tag from a fleet, device or release.
 
-Fleets may be specified by fleet name, slug, or numeric ID. Fleet slugs are
+Fleets may be specified by fleet name or slug. Fleet slugs are
 the recommended option, as they are unique and unambiguous. Slugs can be
 listed with the `balena fleets` command. Note that slugs may change if the
 fleet is renamed. Fleet names are not unique and may result in  "Fleet is
@@ -1579,9 +1555,7 @@ ambiguous" errors at any time (even if it "used to work in the past"), for
 example if the name clashes with a newly created public fleet, or with fleets
 from other balena accounts that you may be invited to join under any role.
 For this reason, fleet names are especially discouraged in scripts (e.g. CI
-environments). Numeric fleet IDs are deprecated because they consist of an
-implementation detail of the balena backend. We intend to remove support for
-numeric IDs at some point in the future.
+environments).
 
 Examples:
 
@@ -1601,7 +1575,7 @@ the key string of the tag
 
 #### -f, --fleet FLEET
 
-fleet name, slug (preferred), or numeric ID (deprecated)
+fleet name or slug (preferred)
 
 #### -d, --device DEVICE
 
@@ -1619,7 +1593,7 @@ You can optionally provide a value to be associated with the created
 tag, as an extra argument after the tag key. If a value isn't
 provided, a tag with an empty value is created.
 
-Fleets may be specified by fleet name, slug, or numeric ID. Fleet slugs are
+Fleets may be specified by fleet name or slug. Fleet slugs are
 the recommended option, as they are unique and unambiguous. Slugs can be
 listed with the `balena fleets` command. Note that slugs may change if the
 fleet is renamed. Fleet names are not unique and may result in  "Fleet is
@@ -1627,9 +1601,7 @@ ambiguous" errors at any time (even if it "used to work in the past"), for
 example if the name clashes with a newly created public fleet, or with fleets
 from other balena accounts that you may be invited to join under any role.
 For this reason, fleet names are especially discouraged in scripts (e.g. CI
-environments). Numeric fleet IDs are deprecated because they consist of an
-implementation detail of the balena backend. We intend to remove support for
-numeric IDs at some point in the future.
+environments).
 
 Examples:
 
@@ -1656,7 +1628,7 @@ the optional value associated with the tag
 
 #### -f, --fleet FLEET
 
-fleet name, slug (preferred), or numeric ID (deprecated)
+fleet name or slug (preferred)
 
 #### -d, --device DEVICE
 
@@ -1941,7 +1913,7 @@ Examples:
 
 #### FLEETORDEVICE
 
-fleet name/slug/id, device uuid, or address of local device
+fleet name/slug, device uuid, or address of local device
 
 #### SERVICE
 
@@ -2009,7 +1981,7 @@ Examples:
 
 #### DEVICEORFLEET
 
-device UUID or fleet name/slug/ID
+device UUID or fleet name/slug
 
 ### Options
 
@@ -2188,7 +2160,7 @@ are multiple files to inject. See connection profile examples and reference at:
 https://www.balena.io/docs/reference/OS/network/2.x/
 https://developer.gnome.org/NetworkManager/stable/ref-settings.html
 
-Fleets may be specified by fleet name, slug, or numeric ID. Fleet slugs are
+Fleets may be specified by fleet name or slug. Fleet slugs are
 the recommended option, as they are unique and unambiguous. Slugs can be
 listed with the `balena fleets` command. Note that slugs may change if the
 fleet is renamed. Fleet names are not unique and may result in  "Fleet is
@@ -2196,9 +2168,7 @@ ambiguous" errors at any time (even if it "used to work in the past"), for
 example if the name clashes with a newly created public fleet, or with fleets
 from other balena accounts that you may be invited to join under any role.
 For this reason, fleet names are especially discouraged in scripts (e.g. CI
-environments). Numeric fleet IDs are deprecated because they consist of an
-implementation detail of the balena backend. We intend to remove support for
-numeric IDs at some point in the future.
+environments).
 
 Note: This command is currently not supported on Windows natively. Windows users
 are advised to install the Windows Subsystem for Linux (WSL) with Ubuntu, and use
@@ -2227,7 +2197,7 @@ ask advanced configuration questions (when in interactive mode)
 
 #### -f, --fleet FLEET
 
-fleet name, slug (preferred), or numeric ID (deprecated)
+fleet name or slug (preferred)
 
 #### --config CONFIG
 
@@ -2341,7 +2311,7 @@ alongside the --deviceType option to specify the target device type.
 To avoid interactive questions, specify a command line option for each question that
 would otherwise be asked.
 
-Fleets may be specified by fleet name, slug, or numeric ID. Fleet slugs are
+Fleets may be specified by fleet name or slug. Fleet slugs are
 the recommended option, as they are unique and unambiguous. Slugs can be
 listed with the `balena fleets` command. Note that slugs may change if the
 fleet is renamed. Fleet names are not unique and may result in  "Fleet is
@@ -2349,9 +2319,7 @@ ambiguous" errors at any time (even if it "used to work in the past"), for
 example if the name clashes with a newly created public fleet, or with fleets
 from other balena accounts that you may be invited to join under any role.
 For this reason, fleet names are especially discouraged in scripts (e.g. CI
-environments). Numeric fleet IDs are deprecated because they consist of an
-implementation detail of the balena backend. We intend to remove support for
-numeric IDs at some point in the future.
+environments).
 
 Examples:
 
@@ -2372,7 +2340,7 @@ a balenaOS version
 
 #### -f, --fleet FLEET
 
-fleet name, slug (preferred), or numeric ID (deprecated)
+fleet name or slug (preferred)
 
 #### --dev
 
@@ -2548,7 +2516,7 @@ Check also the Preloading and Preregistering section of the balena CLI's advance
 masterclass document:
 https://www.balena.io/docs/learn/more/masterclasses/advanced-cli/#5-preloading-and-preregistering
 
-Fleets may be specified by fleet name, slug, or numeric ID. Fleet slugs are
+Fleets may be specified by fleet name or slug. Fleet slugs are
 the recommended option, as they are unique and unambiguous. Slugs can be
 listed with the `balena fleets` command. Note that slugs may change if the
 fleet is renamed. Fleet names are not unique and may result in  "Fleet is
@@ -2556,9 +2524,7 @@ ambiguous" errors at any time (even if it "used to work in the past"), for
 example if the name clashes with a newly created public fleet, or with fleets
 from other balena accounts that you may be invited to join under any role.
 For this reason, fleet names are especially discouraged in scripts (e.g. CI
-environments). Numeric fleet IDs are deprecated because they consist of an
-implementation detail of the balena backend. We intend to remove support for
-numeric IDs at some point in the future.
+environments).
 
 Note that the this command requires Docker to be installed, as further detailed
 in the balena CLI's installation instructions:
@@ -2584,7 +2550,7 @@ the image file path
 
 #### -f, --fleet FLEET
 
-fleet name, slug (preferred), or numeric ID (deprecated)
+fleet name or slug (preferred)
 
 #### -c, --commit COMMIT
 
@@ -3048,7 +3014,7 @@ the type of device this build is for
 
 #### -f, --fleet FLEET
 
-fleet name, slug (preferred), or numeric ID (deprecated)
+fleet name or slug (preferred)
 
 #### -e, --emulated
 
@@ -3238,7 +3204,7 @@ Examples:
 
 #### FLEET
 
-fleet name, slug (preferred), or numeric ID (deprecated)
+fleet name or slug (preferred)
 
 #### IMAGE
 
@@ -3376,7 +3342,7 @@ scan the local network for balenaOS devices and prompt you to select one
 from an interactive picker. This may require administrator/root privileges.
 Likewise, if the fleet option is not provided then a picker will be shown.
 
-Fleets may be specified by fleet name, slug, or numeric ID. Fleet slugs are
+Fleets may be specified by fleet name or slug. Fleet slugs are
 the recommended option, as they are unique and unambiguous. Slugs can be
 listed with the `balena fleets` command. Note that slugs may change if the
 fleet is renamed. Fleet names are not unique and may result in  "Fleet is
@@ -3384,9 +3350,7 @@ ambiguous" errors at any time (even if it "used to work in the past"), for
 example if the name clashes with a newly created public fleet, or with fleets
 from other balena accounts that you may be invited to join under any role.
 For this reason, fleet names are especially discouraged in scripts (e.g. CI
-environments). Numeric fleet IDs are deprecated because they consist of an
-implementation detail of the balena backend. We intend to remove support for
-numeric IDs at some point in the future.
+environments).
 
 Examples:
 
@@ -3407,7 +3371,7 @@ the IP or hostname of device
 
 #### -f, --fleet FLEET
 
-fleet name, slug (preferred), or numeric ID (deprecated)
+fleet name or slug (preferred)
 
 #### -i, --pollInterval POLLINTERVAL
 
@@ -3463,7 +3427,7 @@ or hours, e.g. '12h', '2d'.
 Both --device and --fleet flags accept multiple values, specified as
 a comma-separated list (with no spaces).
 
-Fleets may be specified by fleet name, slug, or numeric ID. Fleet slugs are
+Fleets may be specified by fleet name or slug. Fleet slugs are
 the recommended option, as they are unique and unambiguous. Slugs can be
 listed with the `balena fleets` command. Note that slugs may change if the
 fleet is renamed. Fleet names are not unique and may result in  "Fleet is
@@ -3471,9 +3435,7 @@ ambiguous" errors at any time (even if it "used to work in the past"), for
 example if the name clashes with a newly created public fleet, or with fleets
 from other balena accounts that you may be invited to join under any role.
 For this reason, fleet names are especially discouraged in scripts (e.g. CI
-environments). Numeric fleet IDs are deprecated because they consist of an
-implementation detail of the balena backend. We intend to remove support for
-numeric IDs at some point in the future.
+environments).
 
 Examples:
 

--- a/lib/commands/device/init.ts
+++ b/lib/commands/device/init.ts
@@ -128,7 +128,7 @@ export default class DeviceInitCmd extends Command {
 			options.fleet ||
 				(
 					await (await import('../../utils/patterns')).selectApplication()
-				).id,
+				).slug,
 			{
 				$expand: {
 					is_for__device_type: {

--- a/lib/commands/device/move.ts
+++ b/lib/commands/device/move.ts
@@ -115,7 +115,7 @@ export default class DeviceMoveCmd extends Command {
 				: 'N/a';
 		}
 
-		// Disambiguate application (if is a number, it could either be an ID or a numerical name)
+		// Disambiguate application
 		const { getApplication } = await import('../../utils/sdk');
 
 		// Get destination application

--- a/lib/commands/fleet/restart.ts
+++ b/lib/commands/fleet/restart.ts
@@ -62,9 +62,9 @@ export default class FleetRestartCmd extends Command {
 
 		const balena = getBalenaSdk();
 
-		// Disambiguate application (if is a number, it could either be an ID or a numerical name)
+		// Disambiguate application
 		const application = await getApplication(balena, params.fleet);
 
-		await balena.models.application.restart(application.id);
+		await balena.models.application.restart(application.slug);
 	}
 }

--- a/lib/commands/fleet/rm.ts
+++ b/lib/commands/fleet/rm.ts
@@ -79,6 +79,6 @@ export default class FleetRmCmd extends Command {
 		const application = await getApplication(balena, params.fleet);
 
 		// Remove
-		await balena.models.application.remove(application.id);
+		await balena.models.application.remove(application.slug);
 	}
 }

--- a/lib/commands/preload.ts
+++ b/lib/commands/preload.ts
@@ -288,7 +288,7 @@ Can be repeated to add multiple certificates.\
 				preloader.on('error', reject);
 				resolve(
 					this.prepareAndPreload(preloader, balena, {
-						appId: fleetSlug,
+						slug: fleetSlug,
 						commit,
 						pinDevice,
 					}),
@@ -503,15 +503,15 @@ Would you like to disable automatic updates for this fleet now?\
 		preloader: Preloader,
 		balenaSdk: BalenaSDK,
 		options: {
-			appId?: string;
+			slug?: string;
 			commit?: string;
 			pinDevice: boolean;
 		},
 	) {
 		await preloader.prepare();
 
-		const application = options.appId
-			? await this.getAppWithReleases(balenaSdk, options.appId)
+		const application = options.slug
+			? await this.getAppWithReleases(balenaSdk, options.slug)
 			: await this.selectApplication(preloader.config.deviceType);
 
 		let commit: string; // commit hash or the strings 'latest' or 'current'
@@ -523,7 +523,7 @@ Would you like to disable automatic updates for this fleet now?\
 			if (this.isCurrentCommit(options.commit)) {
 				if (!appCommit) {
 					throw new Error(
-						`Unexpected empty commit hash for fleet ID "${application.id}"`,
+						`Unexpected empty commit hash for fleet slug "${application.slug}"`,
 					);
 				}
 				// handle `--commit current` (and its `--commit latest` synonym)

--- a/lib/commands/ssh.ts
+++ b/lib/commands/ssh.ts
@@ -76,8 +76,7 @@ export default class SshCmd extends Command {
 	public static args = [
 		{
 			name: 'fleetOrDevice',
-			description:
-				'fleet name/slug/id, device uuid, or address of local device',
+			description: 'fleet name/slug, device uuid, or address of local device',
 			required: true,
 		},
 		{

--- a/lib/commands/tunnel.ts
+++ b/lib/commands/tunnel.ts
@@ -82,7 +82,7 @@ export default class TunnelCmd extends Command {
 	public static args = [
 		{
 			name: 'deviceOrFleet',
-			description: 'device UUID or fleet name/slug/ID',
+			description: 'device UUID or fleet name/slug',
 			required: true,
 			parse: lowercaseIfSlug,
 		},

--- a/lib/events.ts
+++ b/lib/events.ts
@@ -24,7 +24,7 @@ import { stripIndent } from './utils/lazy';
  * @param commandSignature A string like, for example:
  *      "push <fleetOrDevice>"
  * That's literally so: "fleetOrDevice" is NOT replaced with the actual
- * fleet ID or device ID. The purpose is to find out the most / least
+ * fleet slug or device uui. The purpose is to find out the most / least
  * used command verbs, so we can focus our development effort where it is most
  * beneficial to end users.
  *

--- a/lib/utils/common-args.ts
+++ b/lib/utils/common-args.ts
@@ -18,7 +18,7 @@ import { lowercaseIfSlug } from './normalization';
 
 export const fleetRequired = {
 	name: 'fleet',
-	description: 'fleet name, slug (preferred), or numeric ID (deprecated)',
+	description: 'fleet name or slug (preferred)',
 	required: true,
 	parse: lowercaseIfSlug,
 };

--- a/lib/utils/common-flags.ts
+++ b/lib/utils/common-flags.ts
@@ -24,7 +24,7 @@ import type { DataOutputOptions, DataSetOutputOptions } from '../framework';
 
 export const fleet = flags.string({
 	char: 'f',
-	description: 'fleet name, slug (preferred), or numeric ID (deprecated)',
+	description: 'fleet name or slug (preferred)',
 	parse: lowercaseIfSlug,
 });
 

--- a/lib/utils/messages.ts
+++ b/lib/utils/messages.ts
@@ -137,7 +137,7 @@ adding exception patterns to the applicable .dockerignore file(s), for example
 - https://www.npmjs.com/package/@balena/dockerignore`;
 
 export const applicationIdInfo = `\
-Fleets may be specified by fleet name, slug, or numeric ID. Fleet slugs are
+Fleets may be specified by fleet name or slug. Fleet slugs are
 the recommended option, as they are unique and unambiguous. Slugs can be
 listed with the \`balena fleets\` command. Note that slugs may change if the
 fleet is renamed. Fleet names are not unique and may result in  "Fleet is
@@ -145,9 +145,7 @@ ambiguous" errors at any time (even if it "used to work in the past"), for
 example if the name clashes with a newly created public fleet, or with fleets
 from other balena accounts that you may be invited to join under any role.
 For this reason, fleet names are especially discouraged in scripts (e.g. CI
-environments). Numeric fleet IDs are deprecated because they consist of an
-implementation detail of the balena backend. We intend to remove support for
-numeric IDs at some point in the future.`;
+environments).`;
 
 export const applicationNameNote = `\
 Fleets may be specified by fleet name or slug. Slugs are recommended because


### PR DESCRIPTION
Drop support for fleet id in favor of fleet name and slug

Resolves: #2500 
Change-type: major
Signed-off-by: Matthew Yarmolinsky <matthew-timothy@balena.io>

---
Please check the CONTRIBUTING.md file for relevant information and some
guidance. Keep in mind that the CLI is a cross-platform application that runs
on Windows, macOS and Linux. Tests will be automatically run by balena CI on
all three operating systems, but this will only help if you have added test
code that exercises the modified or added feature code.

Note that each commit message (currently only the first line) will be
automatically copied to the CHANGELOG.md file, so try writing it in a way
that describes the feature or fix for CLI users.

If there isn't a linked issue or if the linked issue doesn't quite match the
PR, please add a PR description to explain its purpose or the features that it
implements. Adding PR comments to blocks of code that aren't self explanatory
usually helps with the review process.

If the PR introduces security considerations or affects the development, build
or release process, please be sure to highlight this in the PR description.

Thank you very much for your contribution!
