### PR TITLE
release: Add `invalidate` and `validate` commands for invalidating and validating releases (respectively)

### DIFF
--- a/completion/_balena
+++ b/completion/_balena
@@ -20,7 +20,7 @@ _balena() {
   key_cmds=( add rm )
   local_cmds=( configure flash )
   os_cmds=( build-config configure download initialize versions )
-  release_cmds=( finalize )
+  release_cmds=( finalize invalidate validate )
   tag_cmds=( rm set )
 
 

--- a/completion/balena-completion.bash
+++ b/completion/balena-completion.bash
@@ -19,7 +19,7 @@ _balena_complete()
   key_cmds="add rm"
   local_cmds="configure flash"
   os_cmds="build-config configure download initialize versions"
-  release_cmds="finalize"
+  release_cmds="finalize invalidate validate"
   tag_cmds="rm set"
 
 

--- a/lib/commands/release/invalidate.ts
+++ b/lib/commands/release/invalidate.ts
@@ -1,0 +1,83 @@
+/**
+ * @license
+ * Copyright 2016-2020 Balena Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { flags } from '@oclif/command';
+import Command from '../../command';
+import * as cf from '../../utils/common-flags';
+import { getBalenaSdk, stripIndent } from '../../utils/lazy';
+import { tryAsInteger } from '../../utils/validation';
+
+interface FlagsDef {
+	help: void;
+}
+
+interface ArgsDef {
+	commitOrId: string | number;
+}
+
+export default class ReleaseInvalidateCmd extends Command {
+	public static description = stripIndent`
+		Invalidate a release.
+
+		Invalidate a release.
+
+		Invalid releases are not automatically deployed to devices tracking the latest
+		release. For an invalid release to be deployed to a device, the device should be
+		explicity pinned to that release.
+`;
+	public static examples = [
+		'$ balena release invalidate a777f7345fe3d655c1c981aa642e5555',
+		'$ balena release invalidate 1234567',
+	];
+
+	public static usage = 'release invalidate <commitOrId>';
+
+	public static flags: flags.Input<FlagsDef> = {
+		help: cf.help,
+	};
+
+	public static args = [
+		{
+			name: 'commitOrId',
+			description: 'the commit or ID of the release to invalidate',
+			required: true,
+			parse: (commitOrId: string) => tryAsInteger(commitOrId),
+		},
+	];
+
+	public static authenticated = true;
+
+	public async run() {
+		const { args: params } = this.parse<FlagsDef, ArgsDef>(
+			ReleaseInvalidateCmd,
+		);
+
+		const balena = getBalenaSdk();
+
+		const release = await balena.models.release.get(params.commitOrId, {
+			$select: ['id', 'is_invalidated'],
+		});
+
+		if (release.is_invalidated) {
+			console.log(`Release ${params.commitOrId} is already invalidated!`);
+			return;
+		}
+
+		await balena.models.release.setIsInvalidated(release.id, true);
+		console.log(`Release ${params.commitOrId} invalidated`);
+	}
+}

--- a/lib/commands/release/validate.ts
+++ b/lib/commands/release/validate.ts
@@ -1,0 +1,80 @@
+/**
+ * @license
+ * Copyright 2016-2020 Balena Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { flags } from '@oclif/command';
+import Command from '../../command';
+import * as cf from '../../utils/common-flags';
+import { getBalenaSdk, stripIndent } from '../../utils/lazy';
+import { tryAsInteger } from '../../utils/validation';
+
+interface FlagsDef {
+	help: void;
+}
+
+interface ArgsDef {
+	commitOrId: string | number;
+}
+
+export default class ReleaseValidateCmd extends Command {
+	public static description = stripIndent`
+		Validate a release.
+
+		Validate a release.
+
+		Valid releases are automatically deployed to devices tracking the latest
+		release if they are finalized.
+`;
+	public static examples = [
+		'$ balena release validate a777f7345fe3d655c1c981aa642e5555',
+		'$ balena release validate 1234567',
+	];
+
+	public static usage = 'release validate <commitOrId>';
+
+	public static flags: flags.Input<FlagsDef> = {
+		help: cf.help,
+	};
+
+	public static args = [
+		{
+			name: 'commitOrId',
+			description: 'the commit or ID of the release to validate',
+			required: true,
+			parse: (commitOrId: string) => tryAsInteger(commitOrId),
+		},
+	];
+
+	public static authenticated = true;
+
+	public async run() {
+		const { args: params } = this.parse<FlagsDef, ArgsDef>(ReleaseValidateCmd);
+
+		const balena = getBalenaSdk();
+
+		const release = await balena.models.release.get(params.commitOrId, {
+			$select: ['id', 'is_invalidated'],
+		});
+
+		if (!release.is_invalidated) {
+			console.log(`Release ${params.commitOrId} is already validated!`);
+			return;
+		}
+
+		await balena.models.release.setIsInvalidated(release.id, false);
+		console.log(`Release ${params.commitOrId} validated`);
+	}
+}


### PR DESCRIPTION
Resolves: #2512 
Change-type: minor
Signed-off-by: Matthew Yarmolinsky <matthew-timothy@balena.io>

---
Please check the CONTRIBUTING.md file for relevant information and some
guidance. Keep in mind that the CLI is a cross-platform application that runs
on Windows, macOS and Linux. Tests will be automatically run by balena CI on
all three operating systems, but this will only help if you have added test
code that exercises the modified or added feature code.

Note that each commit message (currently only the first line) will be
automatically copied to the CHANGELOG.md file, so try writing it in a way
that describes the feature or fix for CLI users.

If there isn't a linked issue or if the linked issue doesn't quite match the
PR, please add a PR description to explain its purpose or the features that it
implements. Adding PR comments to blocks of code that aren't self explanatory
usually helps with the review process.

If the PR introduces security considerations or affects the development, build
or release process, please be sure to highlight this in the PR description.

Thank you very much for your contribution!
