### PR TITLE
device: Add `services` command for seeing info about services running on a device

### DIFF
--- a/completion/_balena
+++ b/completion/_balena
@@ -12,7 +12,7 @@ _balena() {
   # Sub-completions
   api_key_cmds=( generate )
   config_cmds=( generate inject read reconfigure write )
-  device_cmds=( deactivate identify init local-mode move os-update pin public-url purge reboot register rename restart rm shutdown track-fleet )
+  device_cmds=( deactivate identify init local-mode move os-update pin public-url purge reboot register rename restart rm services shutdown track-fleet )
   devices_cmds=( supported )
   env_cmds=( add rename rm )
   fleet_cmds=( create pin purge rename restart rm track-latest )

--- a/completion/balena-completion.bash
+++ b/completion/balena-completion.bash
@@ -11,7 +11,7 @@ _balena_complete()
   # Sub-completions
   api_key_cmds="generate"
   config_cmds="generate inject read reconfigure write"
-  device_cmds="deactivate identify init local-mode move os-update pin public-url purge reboot register rename restart rm shutdown track-fleet"
+  device_cmds="deactivate identify init local-mode move os-update pin public-url purge reboot register rename restart rm services shutdown track-fleet"
   devices_cmds="supported"
   env_cmds="add rename rm"
   fleet_cmds="create pin purge rename restart rm track-latest"

--- a/lib/commands/device/services.ts
+++ b/lib/commands/device/services.ts
@@ -1,0 +1,93 @@
+/**
+ * @license
+ * Copyright 2016-2020 Balena Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { flags } from '@oclif/command';
+import type { IArg } from '@oclif/parser/lib/args';
+import { ImageInstall } from 'balena-sdk';
+import Command from '../../command';
+import * as cf from '../../utils/common-flags';
+import { getBalenaSdk, getVisuals, stripIndent } from '../../utils/lazy';
+import { getExpandedProp } from '../../utils/pine';
+
+interface FlagsDef {
+	help: void;
+}
+
+interface ArgsDef {
+	uuid: string;
+}
+
+interface AugmentedImageInstall extends ImageInstall {
+	name?: string;
+	release?: string;
+}
+
+export default class DeviceServicesCmd extends Command {
+	public static description = stripIndent`
+         Show info about a device's services.
+ 
+         Show info about a device's services.
+         `;
+	public static examples = ['$ balena device services 23c73a1'];
+
+	public static args: Array<IArg<any>> = [
+		{
+			name: 'uuid',
+			description: 'the uuid of the device whose services to show info about',
+			required: true,
+		},
+	];
+
+	public static usage = 'device services <uuid>';
+
+	public static flags: flags.Input<FlagsDef> = {
+		help: cf.help,
+	};
+
+	public static authenticated = true;
+
+	public async run() {
+		const { args: params } = this.parse<FlagsDef, ArgsDef>(DeviceServicesCmd);
+
+		const balena = getBalenaSdk();
+
+		try {
+			const device = await balena.models.device.getWithServiceDetails(
+				params.uuid,
+			);
+			console.log(
+				getVisuals().table.horizontal(
+					device.image_install?.map((imageInstall) => {
+						const newImageInstall: AugmentedImageInstall = { ...imageInstall };
+						newImageInstall.name = getExpandedProp(
+							getExpandedProp(imageInstall.image, 'is_a_build_of__service')!,
+							'service_name',
+						);
+						newImageInstall.release = getExpandedProp(
+							imageInstall.is_provided_by__release,
+							'commit',
+						);
+						return newImageInstall;
+					}),
+					['name', 'status', 'release', 'id'],
+				),
+			);
+		} catch (e) {
+			throw e;
+		}
+	}
+}


### PR DESCRIPTION
device: Add `services` command for seeing info about services running on a device

Change-type: minor
Signed-off-by: Matthew Yarmolinsky <matthew-timothy@balena.io>

Ex. output (ran on a BoB device):
```
NAME             STATUS  RELEASE                          ID
admin            Running 809e9f87824da8ce0c6e283e8db2161d 152276024
api              Running 809e9f87824da8ce0c6e283e8db2161d 152276025
builder          Running 809e9f87824da8ce0c6e283e8db2161d 152276026
delta            Running 809e9f87824da8ce0c6e283e8db2161d 152276027
devices          Running 809e9f87824da8ce0c6e283e8db2161d 152276028
git              Running 809e9f87824da8ce0c6e283e8db2161d 152276029
img              Running 809e9f87824da8ce0c6e283e8db2161d 152276030
registry         Running 809e9f87824da8ce0c6e283e8db2161d 152276031
registry-cache   Running 809e9f87824da8ce0c6e283e8db2161d 152276032
registry-proxy   Running 809e9f87824da8ce0c6e283e8db2161d 152276033
ui               Running 809e9f87824da8ce0c6e283e8db2161d 152276034
vpn              Running 809e9f87824da8ce0c6e283e8db2161d 152276035
db               Running 809e9f87824da8ce0c6e283e8db2161d 152276036
haproxy-exporter Running 809e9f87824da8ce0c6e283e8db2161d 152276037
s3               Running 809e9f87824da8ce0c6e283e8db2161d 152276038
redis            Running 809e9f87824da8ce0c6e283e8db2161d 152276039
sentry           Running 809e9f87824da8ce0c6e283e8db2161d 152276040
pg-exporter      Running 809e9f87824da8ce0c6e283e8db2161d 152276041
redis-exporter   Running 809e9f87824da8ce0c6e283e8db2161d 152276042
monitor          Running 809e9f87824da8ce0c6e283e8db2161d 152276043
alertmanager     Running 809e9f87824da8ce0c6e283e8db2161d 152276044
loki             Running 809e9f87824da8ce0c6e283e8db2161d 152276045
logshipper       Running 809e9f87824da8ce0c6e283e8db2161d 152276046
vector           Running 809e9f87824da8ce0c6e283e8db2161d 152276047
netdata          Running 809e9f87824da8ce0c6e283e8db2161d 152276048
wifi-connect     Running 809e9f87824da8ce0c6e283e8db2161d 152276049
haproxy          Running 809e9f87824da8ce0c6e283e8db2161d 152276050
haproxy-sidecar  Running 809e9f87824da8ce0c6e283e8db2161d 152276051
mdns             Running 809e9f87824da8ce0c6e283e8db2161d 152276052
cert-manager     Running 809e9f87824da8ce0c6e283e8db2161d 152276053
balena-ca        Running 809e9f87824da8ce0c6e283e8db2161d 152276054
sideshow-bob     Running 809e9f87824da8ce0c6e283e8db2161d 152276055
test-bob         Running 809e9f87824da8ce0c6e283e8db2161d 152276056
autohat          Running 809e9f87824da8ce0c6e283e8db2161d 152276057
tag-sidecar      exited  809e9f87824da8ce0c6e283e8db2161d 152276058
ssm-agent        Running 809e9f87824da8ce0c6e283e8db2161d 152276059
```

---
Please check the CONTRIBUTING.md file for relevant information and some
guidance. Keep in mind that the CLI is a cross-platform application that runs
on Windows, macOS and Linux. Tests will be automatically run by balena CI on
all three operating systems, but this will only help if you have added test
code that exercises the modified or added feature code.

Note that each commit message (currently only the first line) will be
automatically copied to the CHANGELOG.md file, so try writing it in a way
that describes the feature or fix for CLI users.

If there isn't a linked issue or if the linked issue doesn't quite match the
PR, please add a PR description to explain its purpose or the features that it
implements. Adding PR comments to blocks of code that aren't self explanatory
usually helps with the review process.

If the PR introduces security considerations or affects the development, build
or release process, please be sure to highlight this in the PR description.

Thank you very much for your contribution!
