### PR TITLE
Add to description that command is device specific

### DIFF
--- a/docs/balena-cli.md
+++ b/docs/balena-cli.md
@@ -2261,7 +2261,9 @@ expiry date assigned to generated provisioning api key (format: YYYY-MM-DD)
 ## os initialize &#60;image&#62;
 
 Initialize an os image for a device with a previously
-		configured operating system image.
+		configured operating system image and flash the
+		an external storage drive or the device's storage
+		medium depending on the device type.
 		
 
 Note: Initializing the device may ask for administrative permissions

--- a/lib/commands/os/initialize.ts
+++ b/lib/commands/os/initialize.ts
@@ -42,7 +42,9 @@ export default class OsInitializeCmd extends Command {
 		Initialize an os image for a device.
 
 		Initialize an os image for a device with a previously
-		configured operating system image.
+		configured operating system image and flash the
+		an external storage drive or the device's storage
+		medium depending on the device type.
 		${INIT_WARNING_MESSAGE}
 	`;
 


### PR DESCRIPTION
It seems that "initialize" is not well defined or referenced elsewhere, and it turns out that what happens is defined in the device type manifest. The `fincm3` runs "burn", which is an etcher-image-write (which, incidentally, is not sufficient to flash a Fin unless `rpiboot` is run first). So this is the best "clarification" I could come up with.

Change-type: patch
See: https://balena.zulipchat.com/#narrow/stream/345890-loop.2Fbalena-io/topic/cli.20-.20initialize.20command.3F/near/301237302