### PR TITLE
Bump multicast-dns to rebased commit (again)

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -11454,7 +11454,7 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "multicast-dns": {
-      "version": "git+https://github.com/resin-io-modules/multicast-dns.git#a15c63464eb43e8925b187ed5cb9de6892e8aacc",
+      "version": "git+https://github.com/resin-io-modules/multicast-dns.git#db98d68b79bbefc936b6799de9de1038ba49f85d",
       "from": "git+https://github.com/resin-io-modules/multicast-dns.git#listen-on-all-interfaces",
       "requires": {
         "dns-packet": "^1.0.1",


### PR DESCRIPTION
A recent PR reverted the multicast-dns commit bump from PR #2401. This means that under some conditions, `npm install` will fail.

Change-type: patch
See: https://github.com/balena-io-modules/multicast-dns/pull/1
See: https://github.com/balena-io/balena-cli/pull/2401