### PR TITLE
Disable injecting the platform flag for docker base images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@
 /package-lock.json
 /resinrc.yml
 /tmp/
+
+# direnv files
+.envrc
+.direnv

--- a/lib/utils/compose_ts.ts
+++ b/lib/utils/compose_ts.ts
@@ -45,6 +45,7 @@ import type { DeviceInfo } from './device/api';
 import { getBalenaSdk, getChalk, stripIndent } from './lazy';
 import Logger = require('./logger');
 import { exists } from './which';
+import { multibuild } from '@balena/compose';
 
 const allowedContractTypes = ['sw.application', 'sw.block'];
 
@@ -287,6 +288,7 @@ async function $buildProject(
 	opts: BuildProjectOpts,
 ): Promise<[BuiltImage[], Dictionary<string>]> {
 	const { logger, projectName } = opts;
+
 	logger.logInfo(`Building for ${opts.arch}/${opts.deviceType}`);
 
 	const needsQemu = await installQemuIfNeeded({ ...opts, imageDescriptors });
@@ -300,6 +302,12 @@ async function $buildProject(
 		logger,
 		projectName,
 	);
+
+	if (opts.emulated) {
+		_.each(tasks, (task) => {
+			task.dockerPlatform = multibuild.resolveDockerPlatform(opts.arch);;
+		});
+	}
 
 	const imageDescriptorsByServiceName = _.keyBy(
 		imageDescriptors,


### PR DESCRIPTION
This flag was a workaround for balenalib images incorrectly marked as 'amd64' manifests when they were actually ARM.

Recent balenalib images are correctly identified and this additional platform flag prevents us from pulling arm32 base images for arm64 fleet builds.

Change-type: minor