### PR TITLE
Use valid release uuid for local releases

### DIFF
--- a/lib/utils/device/deploy.ts
+++ b/lib/utils/device/deploy.ts
@@ -44,7 +44,7 @@ import { displayBuildLog } from './logs';
 import { stripIndent } from '../lazy';
 
 const LOCAL_APPNAME = 'localapp';
-const LOCAL_RELEASEHASH = 'localrelease';
+const LOCAL_RELEASEHASH = '10ca12e1ea5e';
 const LOCAL_PROJECT_NAME = 'local_image';
 
 // Define the logger here so the debug output


### PR DESCRIPTION
On local push, the CLI uses `localrelease` as the `commit` property for the development application. This is not a valid uuid and will not be read properly by the supervisor, as seen in

https://github.com/balena-os/balena-supervisor/blob/master/src/compose/service.ts#L652

While this is not a problem right now, the commit is becoming the main way to identify a service release (replacing `releaseId` and `imageId`), and the invalid release uuid could cause update issues when pushing a local release on when using some API endpoints.

Change-type: patch
Relates-to: balena-os/balena-supervisor#2136