### PR TITLE
os configure, config generate: Add '--secureBoot' option to opt-in secure boot

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -23,7 +23,7 @@ jobs:
       )
     secrets: inherit
     with:
-      custom_runs_on: '[["self-hosted","Linux","distro:focal","X64"],["self-hosted","Linux","distro:focal","ARM64"],["macos-11"],["windows-2019"]]'
+      custom_runs_on: '[["self-hosted","Linux","distro:focal","X64"],["self-hosted","Linux","distro:focal","ARM64"],["macos-12"],["windows-2019"]]'
       repo_config: true
       repo_description: "The official balena CLI tool."
       github_prerelease: true

--- a/docs/balena-cli.md
+++ b/docs/balena-cli.md
@@ -2160,6 +2160,9 @@ confuse the balenaOS "development mode" with a device's "local mode", the latter
 being a supervisor feature that allows the "balena push" command to push a user's
 application directly to a device in the local network.
 
+The '--secureBoot' option is used to configure a balenaOS installer image to opt-in
+secure boot and disk encryption.
+
 The --system-connection (-c) option is used to inject NetworkManager connection
 profiles for additional network interfaces, such as cellular/GSM or additional
 WiFi or ethernet connections. This option may be passed multiple times in case there
@@ -2229,6 +2232,10 @@ WiFi SSID (network name) (non-interactive configuration)
 #### --dev
 
 Configure balenaOS to operate in development mode
+
+#### --secureBoot
+
+Configure balenaOS installer to opt-in secure boot and disk encryption
 
 #### -d, --device DEVICE
 
@@ -2314,6 +2321,9 @@ confuse the balenaOS "development mode" with a device's "local mode", the latter
 being a supervisor feature that allows the "balena push" command to push a user's
 application directly to a device in the local network.
 
+The '--secureBoot' option is used to configure a balenaOS installer image to opt-in
+secure boot and disk encryption.
+
 To configure an image for a fleet of mixed device types, use the --fleet option
 alongside the --deviceType option to specify the target device type.
 
@@ -2337,6 +2347,7 @@ Examples:
 	$ balena config generate --device 7cf02a6 --version 2.12.7 --deviceApiKey <existingDeviceKey>
 	$ balena config generate --device 7cf02a6 --version 2.12.7 --output config.json
 	$ balena config generate --fleet myorg/fleet --version 2.12.7 --dev
+	$ balena config generate --fleet myorg/fleet --version 2.12.7 --secureBoot
 	$ balena config generate --fleet myorg/fleet --version 2.12.7 --deviceType fincm3
 	$ balena config generate --fleet myorg/fleet --version 2.12.7 --output config.json
 	$ balena config generate --fleet myorg/fleet --version 2.12.7 --network wifi --wifiSsid mySsid --wifiKey abcdefgh --appUpdatePollInterval 15
@@ -2354,6 +2365,10 @@ fleet name or slug (preferred)
 #### --dev
 
 Configure balenaOS to operate in development mode
+
+#### --secureBoot
+
+Configure balenaOS installer to opt-in secure boot and disk encryption
 
 #### -d, --device DEVICE
 

--- a/lib/utils/common-flags.ts
+++ b/lib/utils/common-flags.ts
@@ -74,6 +74,12 @@ export const dev: IBooleanFlag<boolean> = flags.boolean({
 	default: false,
 });
 
+export const secureBoot: IBooleanFlag<boolean> = flags.boolean({
+	description:
+		'Configure balenaOS installer to opt-in secure boot and disk encryption',
+	default: false,
+});
+
 export const drive = flags.string({
 	char: 'd',
 	description: stripIndent`

--- a/lib/utils/config.ts
+++ b/lib/utils/config.ts
@@ -52,6 +52,10 @@ export interface ImgConfig {
 	os?: {
 		sshKeys?: string[];
 	};
+
+	installer?: {
+		secureboot?: boolean;
+	};
 }
 
 export async function generateApplicationConfig(
@@ -63,6 +67,7 @@ export async function generateApplicationConfig(
 		os?: {
 			sshKeys?: string[];
 		};
+		secureBoot?: boolean;
 	},
 ): Promise<ImgConfig> {
 	options = {
@@ -82,6 +87,12 @@ export async function generateApplicationConfig(
 		config.os.sshKeys = config.os.sshKeys
 			? [...config.os.sshKeys, ...options.os.sshKeys]
 			: options.os.sshKeys;
+	}
+
+	// configure installer secure boot opt-in if specified
+	if (options.secureBoot) {
+		config.installer ??= {};
+		config.installer.secureboot = options.secureBoot;
 	}
 
 	return config;
@@ -164,4 +175,59 @@ export async function validateDevOptionAndWarn(
 		Please note that development mode allows unauthenticated, passwordless root ssh access
 		and exposes network ports such as 2375 that allows unencrypted access to balenaEngine.
 		Therefore, development mode should only be used in private, trusted local networks.`);
+}
+
+/**
+ * Chech whether the `--secureBoot` option of commands related to OS configuration
+ * such as `os configure` and `config generate` is compatible with a given
+ * OS release, and print a warning regarding the consequences of using that
+ * option.
+ */
+export async function validateSecureBootOptionAndWarn(
+	secureBoot?: boolean,
+	slug?: string,
+	version?: string,
+	logger?: import('./logger'),
+) {
+	if (!secureBoot) {
+		return;
+	}
+	const { ExpectedError } = await import('../errors');
+	if (!version) {
+		throw new ExpectedError(`Error: No version provided`);
+	}
+	if (!slug) {
+		throw new ExpectedError(`Error: No device type provided`);
+	}
+	const sdk = getBalenaSdk();
+	const [OsRelease]: BalenaSdk.OsVersion[] =
+		await sdk.models.os.getAllOsVersions(`${slug}`, {
+			$select: 'id',
+			$filter: { raw_version: `${version.replace(/^v/, '')}` },
+		});
+	if (!OsRelease) {
+		throw new ExpectedError(`Error: No ${version} release for ${slug}`);
+	}
+	const OsContract = await sdk.models.release.get(OsRelease.id, {
+		$select: 'contract',
+	});
+	const yaml = require('js-yaml');
+	const contract = yaml.load(OsContract['contract']);
+	if (
+		contract.provides.some((entry: Dictionary<string>) => {
+			return entry.type === 'sw.feature' && entry.slug === 'secureboot';
+		})
+	) {
+		if (!logger) {
+			const Logger = await import('./logger');
+			logger = Logger.getLogger();
+		}
+		logger.logInfo(stripIndent`
+			The '--secureBoot' option is being used to configure a balenaOS installer image
+			into secure boot and full disk encryption.`);
+	} else {
+		throw new ExpectedError(
+			`Error: The '--secureBoot' option is not supported for ${slug} in ${version}`,
+		);
+	}
 }

--- a/lib/utils/messages.ts
+++ b/lib/utils/messages.ts
@@ -169,6 +169,10 @@ confuse the balenaOS "development mode" with a device's "local mode", the latter
 being a supervisor feature that allows the "balena push" command to push a user's
 application directly to a device in the local network.`;
 
+export const secureBootInfo = `\
+The '--secureBoot' option is used to configure a balenaOS installer image to opt-in
+secure boot and disk encryption.`;
+
 export const jsonInfo = `\
 The --json option is recommended when scripting the output of this command,
 because field names are less likely to change in JSON format and because it

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2100,26 +2100,6 @@
         "@oclif/config": "^1"
       }
     },
-    "node_modules/@oclif/plugin-help/node_modules/@oclif/command/node_modules/@oclif/plugin-help": {
-      "version": "3.2.14",
-      "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-3.2.14.tgz",
-      "integrity": "sha512-NP5qmE2YfcW3MmXjcrxiqKe9Hf3G0uK/qNc0zAMYKU4crFyIsWj7dBfQVFZSb28YXGioOOpjMzG1I7VMxKF38Q==",
-      "dependencies": {
-        "@oclif/command": "^1.8.9",
-        "@oclif/config": "^1.18.2",
-        "@oclif/errors": "^1.3.5",
-        "chalk": "^4.1.2",
-        "indent-string": "^4.0.0",
-        "lodash": "^4.17.21",
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "widest-line": "^3.1.0",
-        "wrap-ansi": "^6.2.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/@oclif/plugin-help/node_modules/@oclif/errors": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@oclif/errors/-/errors-1.3.5.tgz",
@@ -2149,6 +2129,26 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@oclif/plugin-help/node_modules/@oclif/plugin-help": {
+      "version": "3.2.14",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-3.2.14.tgz",
+      "integrity": "sha512-NP5qmE2YfcW3MmXjcrxiqKe9Hf3G0uK/qNc0zAMYKU4crFyIsWj7dBfQVFZSb28YXGioOOpjMzG1I7VMxKF38Q==",
+      "dependencies": {
+        "@oclif/command": "^1.8.9",
+        "@oclif/config": "^1.18.2",
+        "@oclif/errors": "^1.3.5",
+        "chalk": "^4.1.2",
+        "indent-string": "^4.0.0",
+        "lodash": "^4.17.21",
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "widest-line": "^3.1.0",
+        "wrap-ansi": "^6.2.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/@oclif/plugin-help/node_modules/chalk": {
@@ -3048,9 +3048,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "16.18.30",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.30.tgz",
-      "integrity": "sha512-Kmp/wBZk19Dn7uRiol8kF8agnf8m0+TU9qIwyfPmXglVxMlmiIz0VQSMw5oFgwhmD2aKTlfBIO5FtsVj3y7hKQ=="
+      "version": "16.18.31",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.31.tgz",
+      "integrity": "sha512-KPXltf4z4g517OlVJO9XQ2357CYw7fvuJ3ZuBynjXC5Jos9i+K7LvFb7bUIwtJXSZj0vTp9Q6NJBSQpkwwO8Zw=="
     },
     "node_modules/@types/node-cleanup": {
       "version": "2.1.2",
@@ -19437,9 +19437,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+      "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
     },
     "node_modules/tslint": {
       "version": "6.1.3",
@@ -24029,25 +24029,6 @@
             "@oclif/plugin-help": "3.2.14",
             "debug": "^4.1.1",
             "semver": "^7.3.2"
-          },
-          "dependencies": {
-            "@oclif/plugin-help": {
-              "version": "3.2.14",
-              "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-3.2.14.tgz",
-              "integrity": "sha512-NP5qmE2YfcW3MmXjcrxiqKe9Hf3G0uK/qNc0zAMYKU4crFyIsWj7dBfQVFZSb28YXGioOOpjMzG1I7VMxKF38Q==",
-              "requires": {
-                "@oclif/command": "^1.8.9",
-                "@oclif/config": "^1.18.2",
-                "@oclif/errors": "^1.3.5",
-                "chalk": "^4.1.2",
-                "indent-string": "^4.0.0",
-                "lodash": "^4.17.21",
-                "string-width": "^4.2.0",
-                "strip-ansi": "^6.0.0",
-                "widest-line": "^3.1.0",
-                "wrap-ansi": "^6.2.0"
-              }
-            }
           }
         },
         "@oclif/errors": {
@@ -24072,6 +24053,23 @@
                 "strip-ansi": "^6.0.0"
               }
             }
+          }
+        },
+        "@oclif/plugin-help": {
+          "version": "3.2.14",
+          "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-3.2.14.tgz",
+          "integrity": "sha512-NP5qmE2YfcW3MmXjcrxiqKe9Hf3G0uK/qNc0zAMYKU4crFyIsWj7dBfQVFZSb28YXGioOOpjMzG1I7VMxKF38Q==",
+          "requires": {
+            "@oclif/command": "^1.8.9",
+            "@oclif/config": "^1.18.2",
+            "@oclif/errors": "^1.3.5",
+            "chalk": "^4.1.2",
+            "indent-string": "^4.0.0",
+            "lodash": "^4.17.21",
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "widest-line": "^3.1.0",
+            "wrap-ansi": "^6.2.0"
           }
         },
         "chalk": {
@@ -24894,9 +24892,9 @@
       }
     },
     "@types/node": {
-      "version": "16.18.30",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.30.tgz",
-      "integrity": "sha512-Kmp/wBZk19Dn7uRiol8kF8agnf8m0+TU9qIwyfPmXglVxMlmiIz0VQSMw5oFgwhmD2aKTlfBIO5FtsVj3y7hKQ=="
+      "version": "16.18.31",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.31.tgz",
+      "integrity": "sha512-KPXltf4z4g517OlVJO9XQ2357CYw7fvuJ3ZuBynjXC5Jos9i+K7LvFb7bUIwtJXSZj0vTp9Q6NJBSQpkwwO8Zw=="
     },
     "@types/node-cleanup": {
       "version": "2.1.2",
@@ -26153,6 +26151,7 @@
     },
     "bonjour": {
       "version": "git+ssh://git@github.com/balena-io-modules/bonjour.git#e018851dc823b4b3f670f658f71d0c1c7f3e637c",
+      "integrity": "sha512-JCw9ygNWGhAngIABMPiBlBlyPYVDFwllFa0Xuory9yatGday0pmSBRJhYMXqIJ4vmqDkPVqTD5JV+YM8ypLRKg==",
       "from": "bonjour@git+https://github.com/balena-io-modules/bonjour.git#fixed-mdns",
       "requires": {
         "array-flatten": "^2.1.0",
@@ -33194,6 +33193,7 @@
     },
     "multicast-dns": {
       "version": "git+ssh://git@github.com/resin-io-modules/multicast-dns.git#db98d68b79bbefc936b6799de9de1038ba49f85d",
+      "integrity": "sha512-AYHxmNN71KOfxHElYREhx8LqjIpfc3WFhq+Oht9IOEk82jXXF9qRavowyUvc9JLkPjUzLZmjy14/a1NtBduQoQ==",
       "from": "multicast-dns@git+https://github.com/resin-io-modules/multicast-dns#listen-on-all-interfaces",
       "requires": {
         "dns-packet": "^1.0.1",
@@ -37867,9 +37867,9 @@
       }
     },
     "tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
+      "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
     },
     "tslint": {
       "version": "6.1.3",
@@ -38121,6 +38121,7 @@
     },
     "unbzip2-stream": {
       "version": "git+ssh://git@github.com/balena-io-modules/unbzip2-stream.git#4a54f56a25b58950f9e4277c56db2912d62242e7",
+      "integrity": "sha512-brk1qgoQuqWAWifAFEyC7At0CZxuHL90kd3S2Sdmd1GrOcUGl2bey0Bu6MVc25xAXMz7WITNKD8hxyBpNmeOdg==",
       "from": "unbzip2-stream@github:balena-io-modules/unbzip2-stream#4a54f56a25b58950f9e4277c56db2912d62242e7"
     },
     "union-value": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -24,7 +24,7 @@
         "balena-image-fs": "^7.0.6",
         "balena-image-manager": "^8.0.0",
         "balena-preload": "^13.0.0",
-        "balena-sdk": "^16.40.0",
+        "balena-sdk": "^16.44.2",
         "balena-semver": "^2.3.0",
         "balena-settings-client": "^4.0.7",
         "balena-settings-storage": "^7.0.0",
@@ -2100,6 +2100,26 @@
         "@oclif/config": "^1"
       }
     },
+    "node_modules/@oclif/plugin-help/node_modules/@oclif/command/node_modules/@oclif/plugin-help": {
+      "version": "3.2.14",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-3.2.14.tgz",
+      "integrity": "sha512-NP5qmE2YfcW3MmXjcrxiqKe9Hf3G0uK/qNc0zAMYKU4crFyIsWj7dBfQVFZSb28YXGioOOpjMzG1I7VMxKF38Q==",
+      "dependencies": {
+        "@oclif/command": "^1.8.9",
+        "@oclif/config": "^1.18.2",
+        "@oclif/errors": "^1.3.5",
+        "chalk": "^4.1.2",
+        "indent-string": "^4.0.0",
+        "lodash": "^4.17.21",
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "widest-line": "^3.1.0",
+        "wrap-ansi": "^6.2.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@oclif/plugin-help/node_modules/@oclif/errors": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@oclif/errors/-/errors-1.3.5.tgz",
@@ -2129,26 +2149,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/@oclif/plugin-help/node_modules/@oclif/plugin-help": {
-      "version": "3.2.14",
-      "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-3.2.14.tgz",
-      "integrity": "sha512-NP5qmE2YfcW3MmXjcrxiqKe9Hf3G0uK/qNc0zAMYKU4crFyIsWj7dBfQVFZSb28YXGioOOpjMzG1I7VMxKF38Q==",
-      "dependencies": {
-        "@oclif/command": "^1.8.9",
-        "@oclif/config": "^1.18.2",
-        "@oclif/errors": "^1.3.5",
-        "chalk": "^4.1.2",
-        "indent-string": "^4.0.0",
-        "lodash": "^4.17.21",
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "widest-line": "^3.1.0",
-        "wrap-ansi": "^6.2.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/@oclif/plugin-help/node_modules/chalk": {
@@ -4148,9 +4148,9 @@
       }
     },
     "node_modules/balena-sdk": {
-      "version": "16.40.0",
-      "resolved": "https://registry.npmjs.org/balena-sdk/-/balena-sdk-16.40.0.tgz",
-      "integrity": "sha512-w7oP/oESZnymWtngieQrR3YJAR+CLSnys5RllPZBtZ5vYZsSHdrdRRMamlemy5ydCQN4q66Uw95U20bBXigT5g==",
+      "version": "16.45.1",
+      "resolved": "https://registry.npmjs.org/balena-sdk/-/balena-sdk-16.45.1.tgz",
+      "integrity": "sha512-pY3anTkmEcOp8GEgjkeJl8aj7SZBWifh4DSp8sUnryE0U7IGA3UcKggsfMjYsP1ZKvPlAvweNHQuUujfBOHbXg==",
       "dependencies": {
         "@balena/es-version": "^1.0.0",
         "@types/json-schema": "^7.0.9",
@@ -4527,6 +4527,7 @@
     "node_modules/bonjour": {
       "version": "3.5.0",
       "resolved": "git+ssh://git@github.com/balena-io-modules/bonjour.git#e018851dc823b4b3f670f658f71d0c1c7f3e637c",
+      "integrity": "sha512-JCw9ygNWGhAngIABMPiBlBlyPYVDFwllFa0Xuory9yatGday0pmSBRJhYMXqIJ4vmqDkPVqTD5JV+YM8ypLRKg==",
       "license": "MIT",
       "dependencies": {
         "array-flatten": "^2.1.0",
@@ -13488,6 +13489,7 @@
     "node_modules/multicast-dns": {
       "version": "6.1.1",
       "resolved": "git+ssh://git@github.com/resin-io-modules/multicast-dns.git#db98d68b79bbefc936b6799de9de1038ba49f85d",
+      "integrity": "sha512-AYHxmNN71KOfxHElYREhx8LqjIpfc3WFhq+Oht9IOEk82jXXF9qRavowyUvc9JLkPjUzLZmjy14/a1NtBduQoQ==",
       "license": "MIT",
       "dependencies": {
         "dns-packet": "^1.0.1",
@@ -24027,6 +24029,25 @@
             "@oclif/plugin-help": "3.2.14",
             "debug": "^4.1.1",
             "semver": "^7.3.2"
+          },
+          "dependencies": {
+            "@oclif/plugin-help": {
+              "version": "3.2.14",
+              "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-3.2.14.tgz",
+              "integrity": "sha512-NP5qmE2YfcW3MmXjcrxiqKe9Hf3G0uK/qNc0zAMYKU4crFyIsWj7dBfQVFZSb28YXGioOOpjMzG1I7VMxKF38Q==",
+              "requires": {
+                "@oclif/command": "^1.8.9",
+                "@oclif/config": "^1.18.2",
+                "@oclif/errors": "^1.3.5",
+                "chalk": "^4.1.2",
+                "indent-string": "^4.0.0",
+                "lodash": "^4.17.21",
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.0",
+                "widest-line": "^3.1.0",
+                "wrap-ansi": "^6.2.0"
+              }
+            }
           }
         },
         "@oclif/errors": {
@@ -24051,23 +24072,6 @@
                 "strip-ansi": "^6.0.0"
               }
             }
-          }
-        },
-        "@oclif/plugin-help": {
-          "version": "3.2.14",
-          "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-3.2.14.tgz",
-          "integrity": "sha512-NP5qmE2YfcW3MmXjcrxiqKe9Hf3G0uK/qNc0zAMYKU4crFyIsWj7dBfQVFZSb28YXGioOOpjMzG1I7VMxKF38Q==",
-          "requires": {
-            "@oclif/command": "^1.8.9",
-            "@oclif/config": "^1.18.2",
-            "@oclif/errors": "^1.3.5",
-            "chalk": "^4.1.2",
-            "indent-string": "^4.0.0",
-            "lodash": "^4.17.21",
-            "string-width": "^4.2.0",
-            "strip-ansi": "^6.0.0",
-            "widest-line": "^3.1.0",
-            "wrap-ansi": "^6.2.0"
           }
         },
         "chalk": {
@@ -25814,9 +25818,9 @@
       }
     },
     "balena-sdk": {
-      "version": "16.40.0",
-      "resolved": "https://registry.npmjs.org/balena-sdk/-/balena-sdk-16.40.0.tgz",
-      "integrity": "sha512-w7oP/oESZnymWtngieQrR3YJAR+CLSnys5RllPZBtZ5vYZsSHdrdRRMamlemy5ydCQN4q66Uw95U20bBXigT5g==",
+      "version": "16.45.1",
+      "resolved": "https://registry.npmjs.org/balena-sdk/-/balena-sdk-16.45.1.tgz",
+      "integrity": "sha512-pY3anTkmEcOp8GEgjkeJl8aj7SZBWifh4DSp8sUnryE0U7IGA3UcKggsfMjYsP1ZKvPlAvweNHQuUujfBOHbXg==",
       "requires": {
         "@balena/es-version": "^1.0.0",
         "@types/json-schema": "^7.0.9",
@@ -38117,7 +38121,6 @@
     },
     "unbzip2-stream": {
       "version": "git+ssh://git@github.com/balena-io-modules/unbzip2-stream.git#4a54f56a25b58950f9e4277c56db2912d62242e7",
-      "integrity": "sha512-brk1qgoQuqWAWifAFEyC7At0CZxuHL90kd3S2Sdmd1GrOcUGl2bey0Bu6MVc25xAXMz7WITNKD8hxyBpNmeOdg==",
       "from": "unbzip2-stream@github:balena-io-modules/unbzip2-stream#4a54f56a25b58950f9e4277c56db2912d62242e7"
     },
     "union-value": {

--- a/package.json
+++ b/package.json
@@ -207,7 +207,7 @@
     "balena-image-fs": "^7.0.6",
     "balena-image-manager": "^8.0.0",
     "balena-preload": "^13.0.0",
-    "balena-sdk": "^16.40.0",
+    "balena-sdk": "^16.44.2",
     "balena-semver": "^2.3.0",
     "balena-settings-client": "^4.0.7",
     "balena-settings-storage": "^7.0.0",


### PR DESCRIPTION
Allow to generate a config file with `installer.secureboot` set so that a secure boot and disk encrypted system can be installed.

Change-type: minor

<!-- You can remove tags that do not apply. -->
Resolves: # <!-- Refer an issue of this repository that this PR fixes -->  
Change-type: major|minor|patch <!-- See https://semver.org/ -->  
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->  
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->  

---
Please check the CONTRIBUTING.md file for relevant information and some
guidance. Keep in mind that the CLI is a cross-platform application that runs
on Windows, macOS and Linux. Tests will be automatically run by balena CI on
all three operating systems, but this will only help if you have added test
code that exercises the modified or added feature code.

Note that each commit message (currently only the first line) will be
automatically copied to the CHANGELOG.md file, so try writing it in a way
that describes the feature or fix for CLI users.

If there isn't a linked issue or if the linked issue doesn't quite match the
PR, please add a PR description to explain its purpose or the features that it
implements. Adding PR comments to blocks of code that aren't self explanatory
usually helps with the review process.

If the PR introduces security considerations or affects the development, build
or release process, please be sure to highlight this in the PR description.

Thank you very much for your contribution!
