### PR TITLE
Drop `electron-notarize` dependency in favor of `@electron/notarize`

### DIFF
--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -3,29 +3,29 @@ name: package and draft GitHub release
 # https://github.com/product-os/flowzone/tree/master/.github/actions
 inputs:
   json:
-    description: "JSON stringified object containing all the inputs from the calling workflow"
+    description: 'JSON stringified object containing all the inputs from the calling workflow'
     required: true
   secrets:
-    description: "JSON stringified object containing all the secrets from the calling workflow"
+    description: 'JSON stringified object containing all the secrets from the calling workflow'
     required: true
   variables:
-    description: "JSON stringified object containing all the variables from the calling workflow"
+    description: 'JSON stringified object containing all the variables from the calling workflow'
     required: true
 
   # --- custom environment
   XCODE_APP_LOADER_EMAIL:
     type: string
-    default: "accounts+apple@balena.io"
+    default: 'accounts+apple@balena.io'
   NODE_VERSION:
     type: string
     default: '16.x'
   VERBOSE:
     type: string
-    default: "true"
+    default: 'true'
 
 runs:
   # https://docs.github.com/en/actions/creating-actions/creating-a-composite-action
-  using: "composite"
+  using: 'composite'
   steps:
     - name: Download custom source artifact
       uses: actions/download-artifact@v3
@@ -124,6 +124,7 @@ runs:
         # Apple notarization (automation/build-bin.ts)
         XCODE_APP_LOADER_EMAIL: ${{ inputs.XCODE_APP_LOADER_EMAIL }}
         XCODE_APP_LOADER_PASSWORD: ${{ fromJSON(inputs.secrets).XCODE_APP_LOADER_PASSWORD }}
+        XCODE_APP_LOADER_TEAM_ID: ${{ fromJSON(inputs.secrets).XCODE_APP_LOADER_TEAM_ID }}
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v3

--- a/automation/build-bin.ts
+++ b/automation/build-bin.ts
@@ -465,16 +465,17 @@ async function signWindowsInstaller() {
  * Wait for Apple Installer Notarization to continue
  */
 async function notarizeMacInstaller(): Promise<void> {
+	const teamId = process.env.XCODE_APP_LOADER_TEAM_ID;
 	const appleId =
 		process.env.XCODE_APP_LOADER_EMAIL || 'accounts+apple@balena.io';
-	const appBundleId = packageJSON.oclif.macos.identifier || 'io.balena.cli';
 	const appleIdPassword = process.env.XCODE_APP_LOADER_PASSWORD;
 
-	if (appleIdPassword) {
-		const { notarize } = await import('electron-notarize');
-		// https://github.com/electron/notarize/blob/main/README.md
+	if (appleIdPassword && teamId) {
+		const { notarize } = await import('@electron/notarize');
+		// https://github.com/electron/notarize#readme
 		await notarize({
-			appBundleId,
+			tool: 'notarytool',
+			teamId,
 			appPath: renamedOclifInstallers.darwin,
 			appleId,
 			appleIdPassword,

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -103,6 +103,7 @@
       },
       "devDependencies": {
         "@balena/lint": "^6.2.2",
+        "@electron/notarize": "^2.0.0",
         "@oclif/config": "^1.18.2",
         "@oclif/parser": "^3.8.6",
         "@octokit/plugin-throttling": "^3.5.1",
@@ -159,7 +160,6 @@
         "cross-env": "^7.0.3",
         "deep-object-diff": "^1.1.0",
         "diff": "^5.0.0",
-        "electron-notarize": "^1.0.0",
         "ent": "^2.2.0",
         "filehound": "^1.17.5",
         "fs-extra": "^9.1.0",
@@ -1619,6 +1619,19 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@electron/notarize": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@electron/notarize/-/notarize-2.0.0.tgz",
+      "integrity": "sha512-dqDpd2YCgl6PHJgXEuKGYH3+L4GIGV7ZbKYJjJv66ed+hVPxZA+GAL5JH8/hCnoyQa8WzJTzqd+qhiL5Oxr+SA==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "fs-extra": "^9.0.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
@@ -3048,9 +3061,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "16.18.36",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.36.tgz",
-      "integrity": "sha512-8egDX8dE50XyXWH6C6PRCNkTP106DuUrvdrednFouDSmCi7IOvrqr0frznfZaHifHH/3aq/7a7v9N4wdXMqhBQ=="
+      "version": "16.18.37",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.37.tgz",
+      "integrity": "sha512-ql+4dw4PlPFBP495k8JzUX/oMNRI2Ei4PrMHgj8oT4VhGlYUzF4EYr0qk2fW+XBVGIrq8Zzk13m4cvyXZuv4pA=="
     },
     "node_modules/@types/node-cleanup": {
       "version": "2.1.2",
@@ -4177,9 +4190,9 @@
       }
     },
     "node_modules/balena-sdk/node_modules/@types/node": {
-      "version": "14.18.51",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.51.tgz",
-      "integrity": "sha512-P9bsdGFPpVtofEKlhWMVS2qqx1A/rt9QBfihWlklfHHpUpjtYse5AzFz6j4DWrARLYh6gRnw9+5+DJcrq3KvBA=="
+      "version": "14.18.52",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.52.tgz",
+      "integrity": "sha512-DGhiXKOHSFVVm+PJD+9Y0ObxXLeG6qwc0HoOn+ooQKeNNu+T2mEJCM5UBDUREKAggl9MHYjb5E71PAmx6MbzIg=="
     },
     "node_modules/balena-sdk/node_modules/date-fns": {
       "version": "2.30.0",
@@ -7261,20 +7274,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/electron-notarize": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/electron-notarize/-/electron-notarize-1.0.0.tgz",
-      "integrity": "sha512-dsib1IAquMn0onCrNMJ6gtEIZn/azG8hZMCYOuZIMVMUeRMgBYHK1s5TK9P8xAcrAjh/2aN5WYHzgVSWX314og==",
-      "deprecated": "Please use @electron/notarize moving forward.  There is no API change, just a package name change",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.1.1",
-        "fs-extra": "^9.0.1"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/emoji-regex": {
@@ -19438,9 +19437,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-      "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
     },
     "node_modules/tslint": {
       "version": "6.1.3",
@@ -23652,6 +23651,16 @@
         }
       }
     },
+    "@electron/notarize": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@electron/notarize/-/notarize-2.0.0.tgz",
+      "integrity": "sha512-dqDpd2YCgl6PHJgXEuKGYH3+L4GIGV7ZbKYJjJv66ed+hVPxZA+GAL5JH8/hCnoyQa8WzJTzqd+qhiL5Oxr+SA==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "fs-extra": "^9.0.1"
+      }
+    },
     "@jridgewell/gen-mapping": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
@@ -24893,9 +24902,9 @@
       }
     },
     "@types/node": {
-      "version": "16.18.36",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.36.tgz",
-      "integrity": "sha512-8egDX8dE50XyXWH6C6PRCNkTP106DuUrvdrednFouDSmCi7IOvrqr0frznfZaHifHH/3aq/7a7v9N4wdXMqhBQ=="
+      "version": "16.18.37",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.37.tgz",
+      "integrity": "sha512-ql+4dw4PlPFBP495k8JzUX/oMNRI2Ei4PrMHgj8oT4VhGlYUzF4EYr0qk2fW+XBVGIrq8Zzk13m4cvyXZuv4pA=="
     },
     "@types/node-cleanup": {
       "version": "2.1.2",
@@ -25843,9 +25852,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "14.18.51",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.51.tgz",
-          "integrity": "sha512-P9bsdGFPpVtofEKlhWMVS2qqx1A/rt9QBfihWlklfHHpUpjtYse5AzFz6j4DWrARLYh6gRnw9+5+DJcrq3KvBA=="
+          "version": "14.18.52",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.52.tgz",
+          "integrity": "sha512-DGhiXKOHSFVVm+PJD+9Y0ObxXLeG6qwc0HoOn+ooQKeNNu+T2mEJCM5UBDUREKAggl9MHYjb5E71PAmx6MbzIg=="
         },
         "date-fns": {
           "version": "2.30.0",
@@ -28329,16 +28338,6 @@
       "integrity": "sha512-rC+QVNMJWv+MtPgkt0y+0rVEIdbtxVADApW9JXrUVlzHetgcyczP/E7DJmWJ4fJCZF2cPcBk0laWO9ZHMG3DmQ==",
       "requires": {
         "jake": "^10.8.5"
-      }
-    },
-    "electron-notarize": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/electron-notarize/-/electron-notarize-1.0.0.tgz",
-      "integrity": "sha512-dsib1IAquMn0onCrNMJ6gtEIZn/azG8hZMCYOuZIMVMUeRMgBYHK1s5TK9P8xAcrAjh/2aN5WYHzgVSWX314og==",
-      "dev": true,
-      "requires": {
-        "debug": "^4.1.1",
-        "fs-extra": "^9.0.1"
       }
     },
     "emoji-regex": {
@@ -37869,9 +37868,9 @@
       }
     },
     "tslib": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-      "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
     },
     "tslint": {
       "version": "6.1.3",

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
   },
   "devDependencies": {
     "@balena/lint": "^6.2.2",
+    "@electron/notarize": "^2.0.0",
     "@oclif/config": "^1.18.2",
     "@oclif/parser": "^3.8.6",
     "@octokit/plugin-throttling": "^3.5.1",
@@ -170,7 +171,6 @@
     "cross-env": "^7.0.3",
     "deep-object-diff": "^1.1.0",
     "diff": "^5.0.0",
-    "electron-notarize": "^1.0.0",
     "ent": "^2.2.0",
     "filehound": "^1.17.5",
     "fs-extra": "^9.1.0",


### PR DESCRIPTION
Drop `electron-notarize` dependency in favor of `@electron/notarize`

Change-type: patch

---
Please check the CONTRIBUTING.md file for relevant information and some
guidance. Keep in mind that the CLI is a cross-platform application that runs
on Windows, macOS and Linux. Tests will be automatically run by balena CI on
all three operating systems, but this will only help if you have added test
code that exercises the modified or added feature code.

Note that each commit message (currently only the first line) will be
automatically copied to the CHANGELOG.md file, so try writing it in a way
that describes the feature or fix for CLI users.

If there isn't a linked issue or if the linked issue doesn't quite match the
PR, please add a PR description to explain its purpose or the features that it
implements. Adding PR comments to blocks of code that aren't self explanatory
usually helps with the review process.

If the PR introduces security considerations or affects the development, build
or release process, please be sure to highlight this in the PR description.

Thank you very much for your contribution!
