### PR TITLE
macos notarization: Expose team ID instead of keeping it in secrets

### DIFF
--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -124,7 +124,7 @@ runs:
         # Apple notarization (automation/build-bin.ts)
         XCODE_APP_LOADER_EMAIL: ${{ inputs.XCODE_APP_LOADER_EMAIL }}
         XCODE_APP_LOADER_PASSWORD: ${{ fromJSON(inputs.secrets).XCODE_APP_LOADER_PASSWORD }}
-        XCODE_APP_LOADER_TEAM_ID: ${{ fromJSON(inputs.secrets).XCODE_APP_LOADER_TEAM_ID }}
+        XCODE_APP_LOADER_TEAM_ID: ${{ inputs.XCODE_APP_LOADER_TEAM_ID }}
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v3

--- a/automation/build-bin.ts
+++ b/automation/build-bin.ts
@@ -465,7 +465,7 @@ async function signWindowsInstaller() {
  * Wait for Apple Installer Notarization to continue
  */
 async function notarizeMacInstaller(): Promise<void> {
-	const teamId = process.env.XCODE_APP_LOADER_TEAM_ID;
+	const teamId = process.env.XCODE_APP_LOADER_TEAM_ID || '66H43P8FRG';
 	const appleId =
 		process.env.XCODE_APP_LOADER_EMAIL || 'accounts+apple@balena.io';
 	const appleIdPassword = process.env.XCODE_APP_LOADER_PASSWORD;


### PR DESCRIPTION
macos notarization: Expose team ID instead of keeping it in secrets

Change-type: patch

---
Please check the CONTRIBUTING.md file for relevant information and some
guidance. Keep in mind that the CLI is a cross-platform application that runs
on Windows, macOS and Linux. Tests will be automatically run by balena CI on
all three operating systems, but this will only help if you have added test
code that exercises the modified or added feature code.

Note that each commit message (currently only the first line) will be
automatically copied to the CHANGELOG.md file, so try writing it in a way
that describes the feature or fix for CLI users.

If there isn't a linked issue or if the linked issue doesn't quite match the
PR, please add a PR description to explain its purpose or the features that it
implements. Adding PR comments to blocks of code that aren't self explanatory
usually helps with the review process.

If the PR introduces security considerations or affects the development, build
or release process, please be sure to highlight this in the PR description.

Thank you very much for your contribution!
