### PR TITLE
Bump balena-compose to v2.3.0

### DIFF
--- a/lib/utils/device/deploy.ts
+++ b/lib/utils/device/deploy.ts
@@ -588,7 +588,7 @@ async function assignDockerBuildOpts(
 				pull: opts.pull,
 			};
 			if (task.external) {
-				task.dockerOpts.authconfig = await getAuthConfigObj(
+				task.dockerOpts.authconfig = getAuthConfigObj(
 					task.imageName!,
 					opts.registrySecrets,
 				);

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@balena/compose": "^2.2.1",
+        "@balena/compose": "^2.3.0",
         "@balena/dockerignore": "^1.0.2",
         "@balena/es-version": "^1.0.1",
         "@oclif/command": "^1.8.16",
@@ -1296,9 +1296,9 @@
       }
     },
     "node_modules/@babel/template/node_modules/@babel/parser": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.5.tgz",
-      "integrity": "sha512-DFZMC9LJUG9PLOclRC32G63UXwzqS2koQC8dkx+PLdmt1xSePYpbT/NbsrJy8Q/muXz7o/h/d4A7Fuyixm559Q==",
+      "version": "7.22.6",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.6.tgz",
+      "integrity": "sha512-EIQu22vNkceq3LbjAq7knDf/UmtI2qbcNI8GRBlijez6TpQLvSodJPYfydQmNA5buwkxxxa/PVI44jjYZ+/cLw==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1343,9 +1343,9 @@
       }
     },
     "node_modules/@babel/traverse/node_modules/@babel/parser": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.5.tgz",
-      "integrity": "sha512-DFZMC9LJUG9PLOclRC32G63UXwzqS2koQC8dkx+PLdmt1xSePYpbT/NbsrJy8Q/muXz7o/h/d4A7Fuyixm559Q==",
+      "version": "7.22.6",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.6.tgz",
+      "integrity": "sha512-EIQu22vNkceq3LbjAq7knDf/UmtI2qbcNI8GRBlijez6TpQLvSodJPYfydQmNA5buwkxxxa/PVI44jjYZ+/cLw==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1394,9 +1394,9 @@
       }
     },
     "node_modules/@balena/compose": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@balena/compose/-/compose-2.2.1.tgz",
-      "integrity": "sha512-NxXXG6IN50fx5ZB6e41IsUKH/W1qCFPJeF1Tg0Tg2SqsPn7zq6o5LL0ENc0WkG+ytphxA8W+d4KjV2SQMe6ClA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@balena/compose/-/compose-2.3.0.tgz",
+      "integrity": "sha512-mNN3xzVOjz+VLlGS3T3Ng3SF4yUrrB1E6nSM7DcrM34aps9Gh9lbWnO5w/iaN0FEZkq2B6Wcvt4ntPEPIlS9QQ==",
       "dependencies": {
         "ajv": "^6.12.3",
         "bluebird": "^3.7.2",
@@ -1802,14 +1802,14 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@oclif/command": {
-      "version": "1.8.29",
-      "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.8.29.tgz",
-      "integrity": "sha512-wupMygd4nZ5B4oCjkjGBMzZKY9tjNKGg8iZgqjLpWs9zz8WlwIf0DemDkdaYfIkZ7vUGbPAKSg0zbD/qSdhMRw==",
+      "version": "1.8.30",
+      "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.8.30.tgz",
+      "integrity": "sha512-1l8t77foQJErqveIJwWIXLr/EtWSqQkEcSmHgVBZAVjUaJWvnLZKgohmugJcIp9aR+wYCowRrCL3rLxEMzpq4A==",
       "dependencies": {
         "@oclif/config": "^1.18.2",
         "@oclif/errors": "^1.3.6",
         "@oclif/help": "^1.0.1",
-        "@oclif/parser": "^3.8.12",
+        "@oclif/parser": "^3.8.13",
         "debug": "^4.1.1",
         "semver": "^7.5.3"
       },
@@ -2026,14 +2026,14 @@
       "integrity": "sha512-Ups2dShK52xXa8w6iBWLgcjPJWjais6KPJQq3gQ/88AY6BXoTX+MIGFPrWQO1KLMiQfoTpcLnUwloN4brrVUHw=="
     },
     "node_modules/@oclif/parser": {
-      "version": "3.8.12",
-      "resolved": "https://registry.npmjs.org/@oclif/parser/-/parser-3.8.12.tgz",
-      "integrity": "sha512-yGUrpddLHdPMJIS5jEd55cEPTIFRZRdx38zz0YdFp17Co4RdZvii2jnrnAoICHhumAoQ3EBxwjGpp88D7Bin4w==",
+      "version": "3.8.13",
+      "resolved": "https://registry.npmjs.org/@oclif/parser/-/parser-3.8.13.tgz",
+      "integrity": "sha512-M4RAB4VB5DuPF3ZoVJlXyemyxhflYBKrvP0cBI/ZJVelrfR7Z1fB/iUSrw7SyFvywI13mHmtEQ8Xz0bSUs7g8A==",
       "dependencies": {
         "@oclif/errors": "^1.3.6",
         "@oclif/linewrap": "^1.0.0",
         "chalk": "^4.1.0",
-        "tslib": "^2.5.3"
+        "tslib": "^2.6.0"
       },
       "engines": {
         "node": ">=8.0.0"
@@ -3061,9 +3061,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "16.18.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.37.tgz",
-      "integrity": "sha512-ql+4dw4PlPFBP495k8JzUX/oMNRI2Ei4PrMHgj8oT4VhGlYUzF4EYr0qk2fW+XBVGIrq8Zzk13m4cvyXZuv4pA=="
+      "version": "16.18.38",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.38.tgz",
+      "integrity": "sha512-6sfo1qTulpVbkxECP+AVrHV9OoJqhzCsfTNp5NIG+enM4HyM3HvZCO798WShIXBN0+QtDIcutJCjsVYnQP5rIQ=="
     },
     "node_modules/@types/node-cleanup": {
       "version": "2.1.2",
@@ -4190,9 +4190,9 @@
       }
     },
     "node_modules/balena-sdk/node_modules/@types/node": {
-      "version": "14.18.52",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.52.tgz",
-      "integrity": "sha512-DGhiXKOHSFVVm+PJD+9Y0ObxXLeG6qwc0HoOn+ooQKeNNu+T2mEJCM5UBDUREKAggl9MHYjb5E71PAmx6MbzIg=="
+      "version": "14.18.53",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.53.tgz",
+      "integrity": "sha512-soGmOpVBUq+gaBMwom1M+krC/NNbWlosh4AtGA03SyWNDiqSKtwp7OulO1M6+mg8YkHMvJ/y0AkCeO8d1hNb7A=="
     },
     "node_modules/balena-sdk/node_modules/date-fns": {
       "version": "2.30.0",
@@ -19177,9 +19177,9 @@
       }
     },
     "node_modules/ts-node/node_modules/acorn": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.9.0.tgz",
-      "integrity": "sha512-jaVNAFBHNLXspO543WnNNPZFRtavh3skAkITqD0/2aeMkKZTN+254PyhwxFYrk3vQ1xfY+2wbesJMs/JC8/PwQ==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
+      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -23142,9 +23142,9 @@
       },
       "dependencies": {
         "@babel/parser": {
-          "version": "7.22.5",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.5.tgz",
-          "integrity": "sha512-DFZMC9LJUG9PLOclRC32G63UXwzqS2koQC8dkx+PLdmt1xSePYpbT/NbsrJy8Q/muXz7o/h/d4A7Fuyixm559Q==",
+          "version": "7.22.6",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.6.tgz",
+          "integrity": "sha512-EIQu22vNkceq3LbjAq7knDf/UmtI2qbcNI8GRBlijez6TpQLvSodJPYfydQmNA5buwkxxxa/PVI44jjYZ+/cLw==",
           "dev": true
         },
         "@babel/types": {
@@ -23179,9 +23179,9 @@
       },
       "dependencies": {
         "@babel/parser": {
-          "version": "7.22.5",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.5.tgz",
-          "integrity": "sha512-DFZMC9LJUG9PLOclRC32G63UXwzqS2koQC8dkx+PLdmt1xSePYpbT/NbsrJy8Q/muXz7o/h/d4A7Fuyixm559Q==",
+          "version": "7.22.6",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.6.tgz",
+          "integrity": "sha512-EIQu22vNkceq3LbjAq7knDf/UmtI2qbcNI8GRBlijez6TpQLvSodJPYfydQmNA5buwkxxxa/PVI44jjYZ+/cLw==",
           "dev": true
         },
         "@babel/types": {
@@ -23217,9 +23217,9 @@
       }
     },
     "@balena/compose": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@balena/compose/-/compose-2.2.1.tgz",
-      "integrity": "sha512-NxXXG6IN50fx5ZB6e41IsUKH/W1qCFPJeF1Tg0Tg2SqsPn7zq6o5LL0ENc0WkG+ytphxA8W+d4KjV2SQMe6ClA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@balena/compose/-/compose-2.3.0.tgz",
+      "integrity": "sha512-mNN3xzVOjz+VLlGS3T3Ng3SF4yUrrB1E6nSM7DcrM34aps9Gh9lbWnO5w/iaN0FEZkq2B6Wcvt4ntPEPIlS9QQ==",
       "requires": {
         "ajv": "^6.12.3",
         "bluebird": "^3.7.2",
@@ -23562,14 +23562,14 @@
       }
     },
     "@oclif/command": {
-      "version": "1.8.29",
-      "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.8.29.tgz",
-      "integrity": "sha512-wupMygd4nZ5B4oCjkjGBMzZKY9tjNKGg8iZgqjLpWs9zz8WlwIf0DemDkdaYfIkZ7vUGbPAKSg0zbD/qSdhMRw==",
+      "version": "1.8.30",
+      "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.8.30.tgz",
+      "integrity": "sha512-1l8t77foQJErqveIJwWIXLr/EtWSqQkEcSmHgVBZAVjUaJWvnLZKgohmugJcIp9aR+wYCowRrCL3rLxEMzpq4A==",
       "requires": {
         "@oclif/config": "^1.18.2",
         "@oclif/errors": "^1.3.6",
         "@oclif/help": "^1.0.1",
-        "@oclif/parser": "^3.8.12",
+        "@oclif/parser": "^3.8.13",
         "debug": "^4.1.1",
         "semver": "^7.5.3"
       }
@@ -23738,14 +23738,14 @@
       "integrity": "sha512-Ups2dShK52xXa8w6iBWLgcjPJWjais6KPJQq3gQ/88AY6BXoTX+MIGFPrWQO1KLMiQfoTpcLnUwloN4brrVUHw=="
     },
     "@oclif/parser": {
-      "version": "3.8.12",
-      "resolved": "https://registry.npmjs.org/@oclif/parser/-/parser-3.8.12.tgz",
-      "integrity": "sha512-yGUrpddLHdPMJIS5jEd55cEPTIFRZRdx38zz0YdFp17Co4RdZvii2jnrnAoICHhumAoQ3EBxwjGpp88D7Bin4w==",
+      "version": "3.8.13",
+      "resolved": "https://registry.npmjs.org/@oclif/parser/-/parser-3.8.13.tgz",
+      "integrity": "sha512-M4RAB4VB5DuPF3ZoVJlXyemyxhflYBKrvP0cBI/ZJVelrfR7Z1fB/iUSrw7SyFvywI13mHmtEQ8Xz0bSUs7g8A==",
       "requires": {
         "@oclif/errors": "^1.3.6",
         "@oclif/linewrap": "^1.0.0",
         "chalk": "^4.1.0",
-        "tslib": "^2.5.3"
+        "tslib": "^2.6.0"
       },
       "dependencies": {
         "chalk": {
@@ -24664,9 +24664,9 @@
       }
     },
     "@types/node": {
-      "version": "16.18.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.37.tgz",
-      "integrity": "sha512-ql+4dw4PlPFBP495k8JzUX/oMNRI2Ei4PrMHgj8oT4VhGlYUzF4EYr0qk2fW+XBVGIrq8Zzk13m4cvyXZuv4pA=="
+      "version": "16.18.38",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.38.tgz",
+      "integrity": "sha512-6sfo1qTulpVbkxECP+AVrHV9OoJqhzCsfTNp5NIG+enM4HyM3HvZCO798WShIXBN0+QtDIcutJCjsVYnQP5rIQ=="
     },
     "@types/node-cleanup": {
       "version": "2.1.2",
@@ -25614,9 +25614,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "14.18.52",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.52.tgz",
-          "integrity": "sha512-DGhiXKOHSFVVm+PJD+9Y0ObxXLeG6qwc0HoOn+ooQKeNNu+T2mEJCM5UBDUREKAggl9MHYjb5E71PAmx6MbzIg=="
+          "version": "14.18.53",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.53.tgz",
+          "integrity": "sha512-soGmOpVBUq+gaBMwom1M+krC/NNbWlosh4AtGA03SyWNDiqSKtwp7OulO1M6+mg8YkHMvJ/y0AkCeO8d1hNb7A=="
         },
         "date-fns": {
           "version": "2.30.0",
@@ -37393,9 +37393,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "8.9.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.9.0.tgz",
-          "integrity": "sha512-jaVNAFBHNLXspO543WnNNPZFRtavh3skAkITqD0/2aeMkKZTN+254PyhwxFYrk3vQ1xfY+2wbesJMs/JC8/PwQ==",
+          "version": "8.10.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
+          "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
           "dev": true
         },
         "diff": {

--- a/package.json
+++ b/package.json
@@ -193,7 +193,7 @@
     "typescript": "^5.1.3"
   },
   "dependencies": {
-    "@balena/compose": "^2.2.1",
+    "@balena/compose": "^2.3.0",
     "@balena/dockerignore": "^1.0.2",
     "@balena/es-version": "^1.0.1",
     "@oclif/command": "^1.8.16",


### PR DESCRIPTION
This allows the the CLI to use docker registry config when querying the images manifest.

Relates-to: balena-io-modules/balena-compose#31
Change-type: patch