### PR TITLE
Update balena-compose to v3.0.2

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@balena/compose": "^2.3.0",
+        "@balena/compose": "^3.0.2",
         "@balena/dockerignore": "^1.0.2",
         "@balena/es-version": "^1.0.1",
         "@oclif/command": "^1.8.16",
@@ -1394,9 +1394,9 @@
       }
     },
     "node_modules/@balena/compose": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@balena/compose/-/compose-2.3.0.tgz",
-      "integrity": "sha512-mNN3xzVOjz+VLlGS3T3Ng3SF4yUrrB1E6nSM7DcrM34aps9Gh9lbWnO5w/iaN0FEZkq2B6Wcvt4ntPEPIlS9QQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@balena/compose/-/compose-3.0.2.tgz",
+      "integrity": "sha512-CZnGpAmt1g1ltm6f8UhnWX3/iglpOOgWtphAhh9wPirR5v3KkzjbRRnXbBNLWC5UIyxJNwXvmioByPVEaNE6mQ==",
       "dependencies": {
         "ajv": "^6.12.3",
         "bluebird": "^3.7.2",
@@ -1421,12 +1421,12 @@
         "request": "^2.88.2",
         "semver": "^7.3.5",
         "stream-to-promise": "^3.0.0",
-        "tar-stream": "^2.1.3",
-        "tar-utils": "^2.1.0",
+        "tar-stream": "^3.1.6",
+        "tar-utils": "^3.0.2",
         "typed-error": "^3.2.1"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=16.13.0"
       }
     },
     "node_modules/@balena/compose/node_modules/docker-modem": {
@@ -1500,6 +1500,27 @@
       },
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@balena/compose/node_modules/tar-stream": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.6.tgz",
+      "integrity": "sha512-B/UyjYwPpMBv+PaFSWAmtYjwdrlEaZQEhMIBFNC5oEG8lpiW8XjcSdmEaClj28ArfKScKHs2nshz3k2le6crsg==",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/@balena/compose/node_modules/tar-utils": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tar-utils/-/tar-utils-3.0.2.tgz",
+      "integrity": "sha512-UimIIz7AKMvSKPF09ma4QG++NKjeHL/IylmCXOWgCAaAikruR40PlbhfxDmWVM/JKwc4umHGSp65UFIeJ/5/Hw==",
+      "dependencies": {
+        "tar-stream": "^3.1.6"
+      },
+      "engines": {
+        "node": ">=16.13.0"
       }
     },
     "node_modules/@balena/dockerignore": {
@@ -3905,6 +3926,11 @@
       "dependencies": {
         "follow-redirects": "^1.14.0"
       }
+    },
+    "node_modules/b4a": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.4.tgz",
+      "integrity": "sha512-fpWrvyVHEKyeEvbKZTVOeZF3VSKKWtJxFIxX/jaVPf+cLbGUSitjb49pHLqPV2BUNNZ0LcoeEGfE/YCpyDYHIw=="
     },
     "node_modules/balanced-match": {
       "version": "1.0.0",
@@ -8290,6 +8316,11 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.0.tgz",
+      "integrity": "sha512-IgfweLvEpwyA4WgiQe9Nx6VV2QkML2NkvZnk1oKnIzXgXdWxuhF7zw4DvLTPZJn6PIUneiAXPF24QmoEqHTjyw=="
     },
     "node_modules/fast-glob": {
       "version": "3.3.0",
@@ -16110,6 +16141,11 @@
         "lodash": "^4.17.21"
       }
     },
+    "node_modules/queue-tick": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
+      "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag=="
+    },
     "node_modules/quick-lru": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
@@ -18184,6 +18220,15 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/streamx": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.15.0.tgz",
+      "integrity": "sha512-HcxY6ncGjjklGs1xsP1aR71INYcsXFJet5CU1CHqihQ2J5nOsbd4OjgjHO42w/4QNv9gZb3BueV+Vxok5pLEXg==",
+      "dependencies": {
+        "fast-fifo": "^1.1.0",
+        "queue-tick": "^1.0.1"
+      }
+    },
     "node_modules/strict-event-emitter-types": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strict-event-emitter-types/-/strict-event-emitter-types-2.0.0.tgz",
@@ -18790,9 +18835,9 @@
       }
     },
     "node_modules/tar-utils": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/tar-utils/-/tar-utils-2.1.2.tgz",
-      "integrity": "sha512-NBnDhRG1KE/FDYgrAz3KfgDKGsqczeTj+ZVXZFNMq21iQjRzvu5/l405kgP9qRWVMysZRwkYnGat6EDlKmauzg==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/tar-utils/-/tar-utils-2.1.3.tgz",
+      "integrity": "sha512-qNT76v6A4kF3Ye9p0EpVTLIS3Dbr2amGbJRW3t7mOIYiuI7hHIZ6VHWyiMW5JgxoB4RmRfShVSCGZEHomO8hNw==",
       "dependencies": {
         "bluebird": "^3.7.2",
         "tar-stream": "^2.1.3"
@@ -23229,9 +23274,9 @@
       }
     },
     "@balena/compose": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@balena/compose/-/compose-2.3.0.tgz",
-      "integrity": "sha512-mNN3xzVOjz+VLlGS3T3Ng3SF4yUrrB1E6nSM7DcrM34aps9Gh9lbWnO5w/iaN0FEZkq2B6Wcvt4ntPEPIlS9QQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@balena/compose/-/compose-3.0.2.tgz",
+      "integrity": "sha512-CZnGpAmt1g1ltm6f8UhnWX3/iglpOOgWtphAhh9wPirR5v3KkzjbRRnXbBNLWC5UIyxJNwXvmioByPVEaNE6mQ==",
       "requires": {
         "ajv": "^6.12.3",
         "bluebird": "^3.7.2",
@@ -23256,8 +23301,8 @@
         "request": "^2.88.2",
         "semver": "^7.3.5",
         "stream-to-promise": "^3.0.0",
-        "tar-stream": "^2.1.3",
-        "tar-utils": "^2.1.0",
+        "tar-stream": "^3.1.6",
+        "tar-utils": "^3.0.2",
         "typed-error": "^3.2.1"
       },
       "dependencies": {
@@ -23314,6 +23359,24 @@
             "any-promise": "~1.3.0",
             "end-of-stream": "~1.4.1",
             "stream-to-array": "~2.3.0"
+          }
+        },
+        "tar-stream": {
+          "version": "3.1.6",
+          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.6.tgz",
+          "integrity": "sha512-B/UyjYwPpMBv+PaFSWAmtYjwdrlEaZQEhMIBFNC5oEG8lpiW8XjcSdmEaClj28ArfKScKHs2nshz3k2le6crsg==",
+          "requires": {
+            "b4a": "^1.6.4",
+            "fast-fifo": "^1.2.0",
+            "streamx": "^2.15.0"
+          }
+        },
+        "tar-utils": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/tar-utils/-/tar-utils-3.0.2.tgz",
+          "integrity": "sha512-UimIIz7AKMvSKPF09ma4QG++NKjeHL/IylmCXOWgCAaAikruR40PlbhfxDmWVM/JKwc4umHGSp65UFIeJ/5/Hw==",
+          "requires": {
+            "tar-stream": "^3.1.6"
           }
         }
       }
@@ -25388,6 +25451,11 @@
       "requires": {
         "follow-redirects": "^1.14.0"
       }
+    },
+    "b4a": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.4.tgz",
+      "integrity": "sha512-fpWrvyVHEKyeEvbKZTVOeZF3VSKKWtJxFIxX/jaVPf+cLbGUSitjb49pHLqPV2BUNNZ0LcoeEGfE/YCpyDYHIw=="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -28890,6 +28958,11 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "fast-fifo": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.0.tgz",
+      "integrity": "sha512-IgfweLvEpwyA4WgiQe9Nx6VV2QkML2NkvZnk1oKnIzXgXdWxuhF7zw4DvLTPZJn6PIUneiAXPF24QmoEqHTjyw=="
     },
     "fast-glob": {
       "version": "3.3.0",
@@ -34946,6 +35019,11 @@
         "lodash": "^4.17.21"
       }
     },
+    "queue-tick": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
+      "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag=="
+    },
     "quick-lru": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
@@ -36633,6 +36711,15 @@
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
       "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
     },
+    "streamx": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.15.0.tgz",
+      "integrity": "sha512-HcxY6ncGjjklGs1xsP1aR71INYcsXFJet5CU1CHqihQ2J5nOsbd4OjgjHO42w/4QNv9gZb3BueV+Vxok5pLEXg==",
+      "requires": {
+        "fast-fifo": "^1.1.0",
+        "queue-tick": "^1.0.1"
+      }
+    },
     "strict-event-emitter-types": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strict-event-emitter-types/-/strict-event-emitter-types-2.0.0.tgz",
@@ -37115,9 +37202,9 @@
       }
     },
     "tar-utils": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/tar-utils/-/tar-utils-2.1.2.tgz",
-      "integrity": "sha512-NBnDhRG1KE/FDYgrAz3KfgDKGsqczeTj+ZVXZFNMq21iQjRzvu5/l405kgP9qRWVMysZRwkYnGat6EDlKmauzg==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/tar-utils/-/tar-utils-2.1.3.tgz",
+      "integrity": "sha512-qNT76v6A4kF3Ye9p0EpVTLIS3Dbr2amGbJRW3t7mOIYiuI7hHIZ6VHWyiMW5JgxoB4RmRfShVSCGZEHomO8hNw==",
       "requires": {
         "bluebird": "^3.7.2",
         "tar-stream": "^2.1.3"

--- a/package.json
+++ b/package.json
@@ -193,7 +193,7 @@
     "typescript": "^5.1.3"
   },
   "dependencies": {
-    "@balena/compose": "^2.3.0",
+    "@balena/compose": "^3.0.2",
     "@balena/dockerignore": "^1.0.2",
     "@balena/es-version": "^1.0.1",
     "@oclif/command": "^1.8.16",


### PR DESCRIPTION
Update balena-compose to v3.0.2

That release removes the use of the `cachefrom` on pull tasks, which there is good evidence to suggest is the cause of #2165

Change-type: patch