### PR TITLE
Add --json option to `release` and `releases`

### DIFF
--- a/docs/balena-cli.md
+++ b/docs/balena-cli.md
@@ -1172,9 +1172,16 @@ created public/open fleet, or with fleets from other balena accounts that you
 may be invited to join under any role.  For this reason, fleet names are
 especially discouraged in scripts (e.g. CI environments).
 
+The --json option is recommended when scripting the output of this command,
+because field names are less likely to change in JSON format and because it
+better represents data types like arrays, empty strings and null values.
+The 'jq' utility may be helpful for querying JSON fields in shell scripts
+(https://stedolan.github.io/jq/manual/).
+
 Examples:
 
 	$ balena releases myorg/myfleet
+	$ balena releases myorg/myfleet --json
 
 ### Arguments
 
@@ -1183,6 +1190,10 @@ Examples:
 fleet name or slug (preferred)
 
 ### Options
+
+#### -j, --json
+
+produce JSON output instead of tabular output
 
 ## release &#60;commitOrId&#62;
 

--- a/docs/balena-cli.md
+++ b/docs/balena-cli.md
@@ -1197,12 +1197,17 @@ produce JSON output instead of tabular output
 
 ## release &#60;commitOrId&#62;
 
-
+The --json option is recommended when scripting the output of this command,
+because field names are less likely to change in JSON format and because it
+better represents data types like arrays, empty strings and null values.
+The 'jq' utility may be helpful for querying JSON fields in shell scripts
+(https://stedolan.github.io/jq/manual/).
 
 Examples:
 
 	$ balena release a777f7345fe3d655c1c981aa642e5555
 	$ balena release 1234567
+	$ balena release d3f3151f5ad25ca6b070aa4d08296aca --json
 
 ### Arguments
 
@@ -1211,6 +1216,10 @@ Examples:
 the commit or ID of the release to get information
 
 ### Options
+
+#### -j, --json
+
+produce JSON output instead of tabular output
 
 #### -c, --composition
 

--- a/tests/commands/release.spec.ts
+++ b/tests/commands/release.spec.ts
@@ -65,4 +65,17 @@ describe('balena release', function () {
 		expect(lines[1]).to.contain('142334');
 		expect(lines[1]).to.contain('90247b54de4fa7a0a3cbc85e73c68039');
 	});
+
+	it('should list releases as JSON with the -j/--json flag', async () => {
+		api.expectGetRelease();
+		api.expectGetApplication();
+		const { err, out } = await runCommand('releases someapp --json');
+		expect(err).to.be.empty;
+		const json = JSON.parse(out.join(''));
+		expect(json[0].commit).to.equal('90247b54de4fa7a0a3cbc85e73c68039');
+		expect(json[0].contains__image[0].image[0].start_timestamp).to.equal(
+			'2020-01-04T01:13:08.583Z',
+		);
+		expect(json[0].__metadata.uri).to.equal('/resin/release(@id)?@id=142334');
+	});
 });

--- a/tests/commands/release.spec.ts
+++ b/tests/commands/release.spec.ts
@@ -56,6 +56,16 @@ describe('balena release', function () {
 		expect(lines[5]).to.be.equal('main:');
 	});
 
+	it('should print version information as JSON with the the -j/--json flag', async () => {
+		api.expectGetRelease();
+		const { err, out } = await runCommand('release 27fda508c --json');
+		expect(err).to.be.empty;
+		const json = JSON.parse(out.join(''));
+		expect(json.commit).to.equal('90247b54de4fa7a0a3cbc85e73c68039');
+		expect(json.release_tag[0].tag_key).to.equal('testtag1');
+		expect(json.composition.services.main.network_mode).to.equal('host');
+	});
+
 	it('should list releases', async () => {
 		api.expectGetRelease();
 		api.expectGetApplication();


### PR DESCRIPTION
<!-- You can remove tags that do not apply. -->
Resolves: #2351
Change-type: minor

---

This adds `-j`/`--json` to the `release` and `releases` subcommands. #2351 mentions that support would be added in v14 but there's nothing yet in v17!

We needed this for automating pinning multiple testing devices based on release tags, beyond what balenaCloud allows with "pin to latest". 

I followed existing commands so it should match the existing codebase, and I added spec tests for the functionality.