### PR TITLE
device: Add `--json` option for JSON output

### DIFF
--- a/docs/balena-cli.md
+++ b/docs/balena-cli.md
@@ -1261,10 +1261,17 @@ the uuid of the device to identify
 
 Show information about a single device.
 
+The --json option is recommended when scripting the output of this command,
+because field names are less likely to change in JSON format and because it
+better represents data types like arrays, empty strings and null values.
+The 'jq' utility may be helpful for querying JSON fields in shell scripts
+(https://stedolan.github.io/jq/manual/).
+
 Examples:
 
 	$ balena device 7cf02a6
 	$ balena device 7cf02a6 --view
+	$ balena device 7cf02a6 --json
 
 ### Arguments
 
@@ -1273,6 +1280,10 @@ Examples:
 the device uuid
 
 ### Options
+
+#### -j, --json
+
+produce JSON output instead of tabular output
 
 #### --view
 

--- a/tests/commands/device/device.spec.ts
+++ b/tests/commands/device/device.spec.ts
@@ -107,4 +107,19 @@ describe('balena device', function () {
 		expect(lines[0]).to.equal('== SPARKLING WOOD');
 		expect(lines[6].split(':')[1].trim()).to.equal('N/a');
 	});
+
+	it('outputs device as JSON with the -j/--json flag', async () => {
+		api.scope
+			.get(/^\/v6\/device\?.+&\$expand=device_tag\(\$select=tag_key,value\)/)
+			.replyWithFile(200, path.join(apiResponsePath, 'device.json'), {
+				'Content-Type': 'application/json',
+			});
+
+		const { out, err } = await runCommand('device 27fda508c --json');
+		expect(err).to.be.empty;
+		const json = JSON.parse(out.join(''));
+		expect(json.device_name).to.equal('sparkling-wood');
+		expect(json.belongs_to__application[0].app_name).to.equal('test app');
+		expect(json.device_tag[0].tag_key).to.equal('example');
+	});
 });

--- a/tests/test-data/api-response/device.json
+++ b/tests/test-data/api-response/device.json
@@ -8,6 +8,12 @@
 					"__metadata": {}
 				}
 			],
+			"device_tag": [
+				{
+					"tag_key": "example",
+					"value": "true"
+				}
+			],
 			"id": 1747415,
 			"is_managed_by__device": null,
 			"device_name": "sparkling-wood",


### PR DESCRIPTION
<!-- You can remove tags that do not apply. -->
Change-type: minor

Continuation of #2685 where we're using the CLI to automate targeting releases to certain devices based on the device tag, this adds `--json` to the `device` command, and includes `device_tag`.