### PR TITLE
Bump oclif core & use default missing flag handler

### DIFF
--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -211,7 +211,6 @@ const EXPECTED_ERROR_REGEXES = [
 	/^BalenaOrganizationNotFound/, // balena-sdk
 	/Request error: Unauthorized$/, // balena-sdk
 	/^Missing \d+ required arg/, // oclif parser: RequiredArgsError
-	/Missing required flag/, // oclif parser: RequiredFlagError
 	/^Unexpected argument/, // oclif parser: UnexpectedArgsError
 	/to be one of/, // oclif parser: FlagInvalidOptionError, ArgInvalidOptionError
 	/must also be provided when using/, // oclif parser (depends-on)

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -13,7 +13,7 @@
         "@balena/compose": "^3.0.5",
         "@balena/dockerignore": "^1.0.2",
         "@balena/es-version": "^1.0.1",
-        "@oclif/core": "~3.11.0",
+        "@oclif/core": "^3.14.1",
         "@resin.io/valid-email": "^0.1.0",
         "@sentry/node": "^6.16.1",
         "@types/fast-levenshtein": "0.0.1",
@@ -2296,9 +2296,9 @@
       }
     },
     "node_modules/@oclif/core": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-3.11.0.tgz",
-      "integrity": "sha512-9A2LhDQATf1vrRqPoO0gGuBrey0jt3kDafC+eazxTNWV2EvlEpgY2587iyrxPK/fL2xg7f+0mtxYaSHdO2k8eg==",
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-3.14.1.tgz",
+      "integrity": "sha512-HLFL2s45DFdqYI2CFjVS/CIQ4cQ4yZqH0XqO9nnwcRWYboz2rEW/vLmidjIYGDjh6xA/k5psiAL3O1KEjqSHuQ==",
       "dependencies": {
         "ansi-escapes": "^4.3.2",
         "ansi-styles": "^4.3.0",
@@ -2306,6 +2306,7 @@
         "chalk": "^4.1.2",
         "clean-stack": "^3.0.1",
         "cli-progress": "^3.12.0",
+        "color": "^4.2.3",
         "debug": "^4.3.4",
         "ejs": "^3.1.9",
         "get-package-type": "^0.1.0",
@@ -3804,9 +3805,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.19.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.2.tgz",
-      "integrity": "sha512-6wzfBdbWpe8QykUkXBjtmO3zITA0A3FIjoy+in0Y2K4KrCiRhNYJIdwAPDffZ3G6GnaKaSLSEa9ZuORLfEoiwg==",
+      "version": "18.19.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.3.tgz",
+      "integrity": "sha512-k5fggr14DwAytoA/t8rPrIz++lXK7/DqckthCmoZOKNsEbJkId4Z//BqgApXBUGrGddrigYa1oqheo/7YmW4rg==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -6639,6 +6640,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -6659,6 +6672,15 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
     },
     "node_modules/color-support": {
       "version": "1.1.3",
@@ -9120,9 +9142,9 @@
       }
     },
     "node_modules/etcher-sdk/node_modules/node-abi": {
-      "version": "3.51.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.51.0.tgz",
-      "integrity": "sha512-SQkEP4hmNWjlniS5zdnfIXTk1x7Ome85RDzHlTbBtzE97Gfwz/Ipw4v/Ryk20DWIy3yCNVLVlGKApCnmvYoJbA==",
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.52.0.tgz",
+      "integrity": "sha512-JJ98b02z16ILv7859irtXn4oUaFWADtvkzy2c0IAatNVX2Mc9Yoh8z6hZInn3QwvMEYhHuQloYi+TTQy67SIdQ==",
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -11825,7 +11847,7 @@
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true
     },
     "node_modules/is-async-function": {
@@ -17173,9 +17195,9 @@
       }
     },
     "node_modules/pkg/node_modules/node-abi": {
-      "version": "3.51.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.51.0.tgz",
-      "integrity": "sha512-SQkEP4hmNWjlniS5zdnfIXTk1x7Ome85RDzHlTbBtzE97Gfwz/Ipw4v/Ryk20DWIy3yCNVLVlGKApCnmvYoJbA==",
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.52.0.tgz",
+      "integrity": "sha512-JJ98b02z16ILv7859irtXn4oUaFWADtvkzy2c0IAatNVX2Mc9Yoh8z6hZInn3QwvMEYhHuQloYi+TTQy67SIdQ==",
       "dev": true,
       "dependencies": {
         "semver": "^7.3.5"
@@ -19953,6 +19975,19 @@
         "url": "https://github.com/steveukx/git-js?sponsor=1"
       }
     },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/simple-swizzle/node_modules/is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+    },
     "node_modules/single-line-log": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/single-line-log/-/single-line-log-0.4.1.tgz",
@@ -21429,9 +21464,9 @@
       }
     },
     "node_modules/ts-node": {
-      "version": "10.9.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
-      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
@@ -21717,7 +21752,7 @@
     "node_modules/unbzip2-stream": {
       "version": "1.4.2",
       "resolved": "git+ssh://git@github.com/balena-io-modules/unbzip2-stream.git#4a54f56a25b58950f9e4277c56db2912d62242e7",
-      "integrity": "sha512-brk1qgoQuqWAWifAFEyC7At0CZxuHL90kd3S2Sdmd1GrOcUGl2bey0Bu6MVc25xAXMz7WITNKD8hxyBpNmeOdg==",
+      "integrity": "sha512-hqSQ+EGPNNs80IGpZszUngM7ttKBCgjRtrw+2PTRDUd1UNvPOoSL4M7V1bDBJXktGv8KaVJFRKk2mWi6RmbiEg==",
       "license": "MIT"
     },
     "node_modules/undici-types": {
@@ -22577,9 +22612,9 @@
       }
     },
     "node_modules/winusb-driver-generator/node_modules/node-abi": {
-      "version": "3.51.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.51.0.tgz",
-      "integrity": "sha512-SQkEP4hmNWjlniS5zdnfIXTk1x7Ome85RDzHlTbBtzE97Gfwz/Ipw4v/Ryk20DWIy3yCNVLVlGKApCnmvYoJbA==",
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.52.0.tgz",
+      "integrity": "sha512-JJ98b02z16ILv7859irtXn4oUaFWADtvkzy2c0IAatNVX2Mc9Yoh8z6hZInn3QwvMEYhHuQloYi+TTQy67SIdQ==",
       "optional": true,
       "dependencies": {
         "semver": "^7.3.5"
@@ -26423,9 +26458,9 @@
       }
     },
     "@oclif/core": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-3.11.0.tgz",
-      "integrity": "sha512-9A2LhDQATf1vrRqPoO0gGuBrey0jt3kDafC+eazxTNWV2EvlEpgY2587iyrxPK/fL2xg7f+0mtxYaSHdO2k8eg==",
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-3.14.1.tgz",
+      "integrity": "sha512-HLFL2s45DFdqYI2CFjVS/CIQ4cQ4yZqH0XqO9nnwcRWYboz2rEW/vLmidjIYGDjh6xA/k5psiAL3O1KEjqSHuQ==",
       "requires": {
         "ansi-escapes": "^4.3.2",
         "ansi-styles": "^4.3.0",
@@ -26433,6 +26468,7 @@
         "chalk": "^4.1.2",
         "clean-stack": "^3.0.1",
         "cli-progress": "^3.12.0",
+        "color": "^4.2.3",
         "debug": "^4.3.4",
         "ejs": "^3.1.9",
         "get-package-type": "^0.1.0",
@@ -27706,9 +27742,9 @@
       }
     },
     "@types/node": {
-      "version": "18.19.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.2.tgz",
-      "integrity": "sha512-6wzfBdbWpe8QykUkXBjtmO3zITA0A3FIjoy+in0Y2K4KrCiRhNYJIdwAPDffZ3G6GnaKaSLSEa9ZuORLfEoiwg==",
+      "version": "18.19.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.3.tgz",
+      "integrity": "sha512-k5fggr14DwAytoA/t8rPrIz++lXK7/DqckthCmoZOKNsEbJkId4Z//BqgApXBUGrGddrigYa1oqheo/7YmW4rg==",
       "requires": {
         "undici-types": "~5.26.4"
       }
@@ -29958,6 +29994,15 @@
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
+    "color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "requires": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      }
+    },
     "color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -29975,6 +30020,15 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "requires": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
     },
     "color-support": {
       "version": "1.1.3",
@@ -31882,9 +31936,9 @@
           "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="
         },
         "node-abi": {
-          "version": "3.51.0",
-          "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.51.0.tgz",
-          "integrity": "sha512-SQkEP4hmNWjlniS5zdnfIXTk1x7Ome85RDzHlTbBtzE97Gfwz/Ipw4v/Ryk20DWIy3yCNVLVlGKApCnmvYoJbA==",
+          "version": "3.52.0",
+          "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.52.0.tgz",
+          "integrity": "sha512-JJ98b02z16ILv7859irtXn4oUaFWADtvkzy2c0IAatNVX2Mc9Yoh8z6hZInn3QwvMEYhHuQloYi+TTQy67SIdQ==",
           "requires": {
             "semver": "^7.3.5"
           }
@@ -33969,7 +34023,7 @@
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true
     },
     "is-async-function": {
@@ -38024,9 +38078,9 @@
           "dev": true
         },
         "node-abi": {
-          "version": "3.51.0",
-          "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.51.0.tgz",
-          "integrity": "sha512-SQkEP4hmNWjlniS5zdnfIXTk1x7Ome85RDzHlTbBtzE97Gfwz/Ipw4v/Ryk20DWIy3yCNVLVlGKApCnmvYoJbA==",
+          "version": "3.52.0",
+          "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.52.0.tgz",
+          "integrity": "sha512-JJ98b02z16ILv7859irtXn4oUaFWADtvkzy2c0IAatNVX2Mc9Yoh8z6hZInn3QwvMEYhHuQloYi+TTQy67SIdQ==",
           "dev": true,
           "requires": {
             "semver": "^7.3.5"
@@ -40255,6 +40309,21 @@
         "debug": "^4.3.4"
       }
     },
+    "simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+      "requires": {
+        "is-arrayish": "^0.3.1"
+      },
+      "dependencies": {
+        "is-arrayish": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+        }
+      }
+    },
     "single-line-log": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/single-line-log/-/single-line-log-0.4.1.tgz",
@@ -41448,9 +41517,9 @@
       "requires": {}
     },
     "ts-node": {
-      "version": "10.9.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
-      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "requires": {
         "@cspotcode/source-map-support": "^0.8.0",
@@ -41640,7 +41709,7 @@
     },
     "unbzip2-stream": {
       "version": "git+ssh://git@github.com/balena-io-modules/unbzip2-stream.git#4a54f56a25b58950f9e4277c56db2912d62242e7",
-      "integrity": "sha512-brk1qgoQuqWAWifAFEyC7At0CZxuHL90kd3S2Sdmd1GrOcUGl2bey0Bu6MVc25xAXMz7WITNKD8hxyBpNmeOdg==",
+      "integrity": "sha512-hqSQ+EGPNNs80IGpZszUngM7ttKBCgjRtrw+2PTRDUd1UNvPOoSL4M7V1bDBJXktGv8KaVJFRKk2mWi6RmbiEg==",
       "from": "unbzip2-stream@github:balena-io-modules/unbzip2-stream#4a54f56a25b58950f9e4277c56db2912d62242e7"
     },
     "undici-types": {
@@ -42338,9 +42407,9 @@
           "optional": true
         },
         "node-abi": {
-          "version": "3.51.0",
-          "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.51.0.tgz",
-          "integrity": "sha512-SQkEP4hmNWjlniS5zdnfIXTk1x7Ome85RDzHlTbBtzE97Gfwz/Ipw4v/Ryk20DWIy3yCNVLVlGKApCnmvYoJbA==",
+          "version": "3.52.0",
+          "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.52.0.tgz",
+          "integrity": "sha512-JJ98b02z16ILv7859irtXn4oUaFWADtvkzy2c0IAatNVX2Mc9Yoh8z6hZInn3QwvMEYhHuQloYi+TTQy67SIdQ==",
           "optional": true,
           "requires": {
             "semver": "^7.3.5"

--- a/package.json
+++ b/package.json
@@ -197,7 +197,7 @@
     "@balena/compose": "^3.0.5",
     "@balena/dockerignore": "^1.0.2",
     "@balena/es-version": "^1.0.1",
-    "@oclif/core": "~3.11.0",
+    "@oclif/core": "^3.14.1",
     "@resin.io/valid-email": "^0.1.0",
     "@sentry/node": "^6.16.1",
     "@types/fast-levenshtein": "0.0.1",

--- a/patches/all/@oclif+core+3.14.1.patch
+++ b/patches/all/@oclif+core+3.14.1.patch
@@ -12,10 +12,10 @@ index 607d8dc..07ba1f2 100644
      return lines.join('\n');
  }
 diff --git a/node_modules/@oclif/core/lib/help/command.js b/node_modules/@oclif/core/lib/help/command.js
-index c528e93..2c20760 100644
+index 82d9eed..0a8d45f 100644
 --- a/node_modules/@oclif/core/lib/help/command.js
 +++ b/node_modules/@oclif/core/lib/help/command.js
-@@ -45,7 +45,7 @@ class CommandHelp extends formatter_1.HelpFormatter {
+@@ -48,7 +48,7 @@ class CommandHelp extends formatter_1.HelpFormatter {
          if (args.filter((a) => a.description).length === 0)
              return;
          return args.map((a) => {
@@ -23,9 +23,9 @@ index c528e93..2c20760 100644
 +            const name = a.required ? `<${a.name}>` : `[${a.name}]`;
              let description = a.description || '';
              if (a.default)
-                 description = `[default: ${a.default}] ${description}`;
-@@ -137,14 +137,12 @@ class CommandHelp extends formatter_1.HelpFormatter {
-             label = labels.join(flag.char ? ', ' : '  ');
+                 description = `${(0, theme_1.colorize)(this.config?.theme?.flagDefaultValue, `[default: ${a.default}]`)} ${description}`;
+@@ -143,14 +143,12 @@ class CommandHelp extends formatter_1.HelpFormatter {
+             label = labels.join((0, theme_1.colorize)(this.config?.theme?.flagSeparator, flag.char ? ', ' : '  '));
          }
          if (flag.type === 'option') {
 -            let value = flag.helpValue || (this.opts.showFlagNameInTitle ? flag.name : '<value>');
@@ -42,10 +42,10 @@ index c528e93..2c20760 100644
          }
          return label;
 diff --git a/node_modules/@oclif/core/lib/help/index.js b/node_modules/@oclif/core/lib/help/index.js
-index 38494f5..213b8b0 100644
+index 242538a..efde8ac 100644
 --- a/node_modules/@oclif/core/lib/help/index.js
 +++ b/node_modules/@oclif/core/lib/help/index.js
-@@ -158,11 +158,12 @@ class Help extends HelpBase {
+@@ -168,11 +168,12 @@ class Help extends HelpBase {
          }
          this.log(this.formatCommand(command));
          this.log('');
@@ -56,12 +56,12 @@ index 38494f5..213b8b0 100644
              this.log('');
          }
 -        if (subCommands.length > 0) {
-+        if (subCommands.length > 0 && !SUPPRESS_SUBTOPICS) {
++        if (subTopics.length > 0 && !SUPPRESS_SUBTOPICS) {
              const aliases = [];
              const uniqueSubCommands = subCommands.filter((p) => {
                  aliases.push(...p.aliases);
 diff --git a/node_modules/@oclif/core/lib/parser/errors.js b/node_modules/@oclif/core/lib/parser/errors.js
-index 51be624..768d589 100644
+index 656ec6b..2bbf36b 100644
 --- a/node_modules/@oclif/core/lib/parser/errors.js
 +++ b/node_modules/@oclif/core/lib/parser/errors.js
 @@ -14,7 +14,8 @@ Object.defineProperty(exports, "CLIError", { enumerable: true, get: function ()
@@ -71,13 +71,13 @@ index 51be624..768d589 100644
 -        options.message += '\nSee more help with --help';
 +        const help = options.command ? `\`${options.command} --help\`` : '--help';
 +        options.message += `\nSee more help with ${help}`;
-         super(options.message);
+         super(options.message, { exit: options.exit });
          this.parse = options.parse;
      }
 @@ -37,7 +38,8 @@ exports.InvalidArgsSpecError = InvalidArgsSpecError;
  class RequiredArgsError extends CLIParseError {
      args;
-     constructor({ args, flagsWithMultiple, parse, }) {
+     constructor({ args, exit, flagsWithMultiple, parse, }) {
 -        let message = `Missing ${args.length} required arg${args.length === 1 ? '' : 's'}`;
 +        const command = 'balena ' + parse.input.context.id.replace(/:/g, ' ');
 +        let message = `Missing ${args.length} required argument${args.length === 1 ? '' : 's'}`;
@@ -88,20 +88,8 @@ index 51be624..768d589 100644
              message += `\n\nNote: ${flags} allow${flagsWithMultiple.length === 1 ? 's' : ''} multiple values. Because of this you need to provide all arguments before providing ${flagsWithMultiple.length === 1 ? 'that flag' : 'those flags'}.`;
              message += '\nAlternatively, you can use "--" to signify the end of the flags and the beginning of arguments.';
          }
--        super({ message, parse });
-+        super({ message, parse, command });
+-        super({ exit: cache_1.default.getInstance().get('exitCodes')?.requiredArgs ?? exit, message, parse });
++        super({ exit: cache_1.default.getInstance().get('exitCodes')?.requiredArgs ?? exit, message, parse, command });
          this.args = args;
-     }
- }
-@@ -56,9 +58,10 @@ exports.RequiredArgsError = RequiredArgsError;
- class RequiredFlagError extends CLIParseError {
-     flag;
-     constructor({ flag, parse }) {
-+        const command = 'balena ' + parse.input.context.id.replace(/:/g, ' ');
-         const usage = (0, list_1.renderList)((0, help_1.flagUsages)([flag], { displayRequired: false }));
-         const message = `Missing required flag:\n${usage}`;
--        super({ message, parse });
-+        super({ message, parse, command });
-         this.flag = flag;
      }
  }

--- a/tests/errors.spec.ts
+++ b/tests/errors.spec.ts
@@ -131,7 +131,6 @@ describe('handleError() function', () => {
 	const messagesToMatch = [
 		'Missing 1 required argument', // oclif
 		'Missing 2 required arguments', // oclif
-		'Missing required flag', // oclif
 		'Unexpected argument', // oclif
 		'Unexpected arguments', // oclif
 		'to be one of', // oclif


### PR DESCRIPTION
Change-type: patch

For context @oclif/core library won't throw "Missing required Flag" anymore as per: https://github.com/oclif/core/pull/861/files#diff-7219ede97254ede20475fce02b9cf5cd9285f3422de87f844b96fc156d44ec94L79

The error is handled in a different way now since several releases ago: https://github.com/oclif/core/blob/0b49d9e2d300f30519d58bf61f0d662493ce5dd5/src/parser/validate.ts#L78

<!-- You can remove tags that do not apply. -->
Resolves: # <!-- Refer an issue of this repository that this PR fixes -->  
Change-type: major|minor|patch <!-- See https://semver.org/ -->  
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->  
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->  

---
Please check the CONTRIBUTING.md file for relevant information and some
guidance. Keep in mind that the CLI is a cross-platform application that runs
on Windows, macOS and Linux. Tests will be automatically run by balena CI on
all three operating systems, but this will only help if you have added test
code that exercises the modified or added feature code.

Note that each commit message (currently only the first line) will be
automatically copied to the CHANGELOG.md file, so try writing it in a way
that describes the feature or fix for CLI users.

If there isn't a linked issue or if the linked issue doesn't quite match the
PR, please add a PR description to explain its purpose or the features that it
implements. Adding PR comments to blocks of code that aren't self explanatory
usually helps with the review process.

If the PR introduces security considerations or affects the development, build
or release process, please be sure to highlight this in the PR description.

Thank you very much for your contribution!
