### PR TITLE
Move macos binary signing to oclif pretarball lifecycle

### DIFF
--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -44,6 +44,12 @@ runs:
         node-version: ${{ inputs.NODE_VERSION }}
         cache: npm
 
+    - name: Set up Python 3.11
+      if: runner.os == 'macOS'
+      uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435 # v4
+      with:
+        python-version: "3.11"
+
     - name: Install additional tools
       if: runner.os == 'Windows'
       shell: bash

--- a/automation/build-bin.ts
+++ b/automation/build-bin.ts
@@ -326,7 +326,11 @@ async function zipPkg() {
 	});
 }
 
-async function signFilesForNotarization() {
+export async function signFilesForNotarization() {
+	console.log('Signing files for notarization');
+	if (process.platform !== 'darwin') {
+		return;
+	}
 	console.log('Deleting unneeded zip files...');
 	await new Promise((resolve, reject) => {
 		klaw('node_modules/')
@@ -514,10 +518,6 @@ export async function buildOclifInstaller() {
 		for (const dir of dirs) {
 			console.log(`rimraf(${dir})`);
 			await Bluebird.fromCallback((cb) => rimraf(dir, cb));
-		}
-		if (process.platform === 'darwin') {
-			console.log('Signing files for notarization...');
-			await signFilesForNotarization();
 		}
 		console.log('=======================================================');
 		console.log(`oclif ${packCmd} ${packOpts.join(' ')}`);

--- a/automation/run.ts
+++ b/automation/run.ts
@@ -21,6 +21,7 @@ import {
 	buildOclifInstaller,
 	buildStandaloneZip,
 	catchUncommitted,
+	signFilesForNotarization,
 	testShrinkwrap,
 } from './build-bin';
 import {
@@ -54,6 +55,7 @@ async function parse(args?: string[]) {
 	const commands: { [cmd: string]: () => void | Promise<void> } = {
 		'build:installer': buildOclifInstaller,
 		'build:standalone': buildStandaloneZip,
+		'sign:binaries': signFilesForNotarization,
 		'catch-uncommitted': catchUncommitted,
 		'test-shrinkwrap': testShrinkwrap,
 		fix1359: updateDescriptionOfReleasesAffectedByIssue1359,

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1977,9 +1977,9 @@
       }
     },
     "node_modules/@oclif/core": {
-      "version": "3.24.0",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-3.24.0.tgz",
-      "integrity": "sha512-7winwcmTwimbihdDT8NjHppOEJG40DODLpP/F5DqLb+tVTxC8oFsoB7T9Ocj7fZyelgmMtnUz7XgvSZHj+6eCQ==",
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-3.25.0.tgz",
+      "integrity": "sha512-6O6Q2buS4uZcH0l5YDo3rYQyquRm6uoshEFE1O1RGQsZhT7PCXo3PAoBU8SKLBZoUIurupXZqNJpW+BHUmatBw==",
       "dependencies": {
         "@types/cli-progress": "^3.11.5",
         "ansi-escapes": "^4.3.2",
@@ -5640,9 +5640,9 @@
       "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg=="
     },
     "node_modules/aws4-axios": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/aws4-axios/-/aws4-axios-3.3.2.tgz",
-      "integrity": "sha512-uJXEe1Zp5FjG31r3x7sZ2N9uIe7obVV48eEOhbDr7c2mEY613nmurvjZlRAwFoLDgpCJR1ZKxQyBZYjRgH/PCA==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/aws4-axios/-/aws4-axios-3.3.4.tgz",
+      "integrity": "sha512-pcyliHZ1G6DqWvP1ITHX/LH+yc2vDzx6epB+/XDPA1oBZeIFyh71MlwjHcGemHRxcVq8pW5tzNln4S6GgZ1BFw==",
       "dependencies": {
         "@aws-sdk/client-sts": "^3.4.1",
         "aws4": "^1.12.0"
@@ -26828,9 +26828,9 @@
       }
     },
     "@oclif/core": {
-      "version": "3.24.0",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-3.24.0.tgz",
-      "integrity": "sha512-7winwcmTwimbihdDT8NjHppOEJG40DODLpP/F5DqLb+tVTxC8oFsoB7T9Ocj7fZyelgmMtnUz7XgvSZHj+6eCQ==",
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-3.25.0.tgz",
+      "integrity": "sha512-6O6Q2buS4uZcH0l5YDo3rYQyquRm6uoshEFE1O1RGQsZhT7PCXo3PAoBU8SKLBZoUIurupXZqNJpW+BHUmatBw==",
       "requires": {
         "@types/cli-progress": "^3.11.5",
         "ansi-escapes": "^4.3.2",
@@ -29787,9 +29787,9 @@
       "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg=="
     },
     "aws4-axios": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/aws4-axios/-/aws4-axios-3.3.2.tgz",
-      "integrity": "sha512-uJXEe1Zp5FjG31r3x7sZ2N9uIe7obVV48eEOhbDr7c2mEY613nmurvjZlRAwFoLDgpCJR1ZKxQyBZYjRgH/PCA==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/aws4-axios/-/aws4-axios-3.3.4.tgz",
+      "integrity": "sha512-pcyliHZ1G6DqWvP1ITHX/LH+yc2vDzx6epB+/XDPA1oBZeIFyh71MlwjHcGemHRxcVq8pW5tzNln4S6GgZ1BFw==",
       "requires": {
         "@aws-sdk/client-sts": "^3.4.1",
         "aws4": "^1.12.0"

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "scripts": {
     "postinstall": "node patches/apply-patches.js",
     "prebuild": "rimraf build/ build-bin/",
+    "pretarball": "ts-node --transpile-only ../../automation/run.ts sign:binaries",
     "build": "npm run build:src && npm run catch-uncommitted",
     "build:t": "npm run lint && npm run build:fast && npm run build:test",
     "build:src": "npm run lint && npm run build:fast && npm run build:test && npm run build:doc && npm run build:completion",

--- a/patches/all/@oclif+core+3.25.0.patch
+++ b/patches/all/@oclif+core+3.25.0.patch
@@ -12,7 +12,7 @@ index 607d8dc..07ba1f2 100644
      return lines.join('\n');
  }
 diff --git a/node_modules/@oclif/core/lib/help/command.js b/node_modules/@oclif/core/lib/help/command.js
-index 6640bf9..22dac8a 100644
+index bc54de4..cb246ce 100644
 --- a/node_modules/@oclif/core/lib/help/command.js
 +++ b/node_modules/@oclif/core/lib/help/command.js
 @@ -59,7 +59,9 @@ class CommandHelp extends formatter_1.HelpFormatter {
@@ -44,10 +44,10 @@ index 6640bf9..22dac8a 100644
          }
          return (0, theme_1.colorize)(this.config.theme?.flag, label);
 diff --git a/node_modules/@oclif/core/lib/help/index.js b/node_modules/@oclif/core/lib/help/index.js
-index 2aedfd3..f3d28a6 100644
+index 1dc30a3..ceefd4c 100644
 --- a/node_modules/@oclif/core/lib/help/index.js
 +++ b/node_modules/@oclif/core/lib/help/index.js
-@@ -169,11 +169,12 @@ class Help extends HelpBase {
+@@ -171,11 +171,12 @@ class Help extends HelpBase {
          }
          this.log(this.formatCommand(command));
          this.log('');
@@ -63,12 +63,12 @@ index 2aedfd3..f3d28a6 100644
              const uniqueSubCommands = subCommands.filter((p) => {
                  aliases.push(...p.aliases);
 diff --git a/node_modules/@oclif/core/lib/parser/errors.js b/node_modules/@oclif/core/lib/parser/errors.js
-index 656ec6b..cde9e38 100644
+index af490c9..a1d4add 100644
 --- a/node_modules/@oclif/core/lib/parser/errors.js
 +++ b/node_modules/@oclif/core/lib/parser/errors.js
-@@ -14,7 +14,8 @@ Object.defineProperty(exports, "CLIError", { enumerable: true, get: function ()
- class CLIParseError extends errors_1.CLIError {
+@@ -15,7 +15,8 @@ class CLIParseError extends errors_1.CLIError {
      parse;
+     showHelp = false;
      constructor(options) {
 -        options.message += '\nSee more help with --help';
 +        const help = options.command ? `\`${options.command} --help\`` : '--help';
@@ -76,7 +76,7 @@ index 656ec6b..cde9e38 100644
          super(options.message, { exit: options.exit });
          this.parse = options.parse;
      }
-@@ -37,7 +38,9 @@ exports.InvalidArgsSpecError = InvalidArgsSpecError;
+@@ -38,7 +39,9 @@ exports.InvalidArgsSpecError = InvalidArgsSpecError;
  class RequiredArgsError extends CLIParseError {
      args;
      constructor({ args, exit, flagsWithMultiple, parse, }) {
@@ -87,13 +87,12 @@ index 656ec6b..cde9e38 100644
          const namedArgs = args.filter((a) => a.name);
          if (namedArgs.length > 0) {
              const list = (0, list_1.renderList)(namedArgs.map((a) => [a.name, a.description]));
-@@ -48,8 +51,7 @@ class RequiredArgsError extends CLIParseError {
+@@ -49,7 +52,7 @@ class RequiredArgsError extends CLIParseError {
              message += `\n\nNote: ${flags} allow${flagsWithMultiple.length === 1 ? 's' : ''} multiple values. Because of this you need to provide all arguments before providing ${flagsWithMultiple.length === 1 ? 'that flag' : 'those flags'}.`;
              message += '\nAlternatively, you can use "--" to signify the end of the flags and the beginning of arguments.';
          }
 -        super({ exit: cache_1.default.getInstance().get('exitCodes')?.requiredArgs ?? exit, message, parse });
--        this.args = args;
-+        super({ exit: cache_1.default.getInstance().get('exitCodes')?.requiredArgs ?? exit, message, parse, command });        this.args = args;
++        super({ exit: cache_1.default.getInstance().get('exitCodes')?.requiredArgs ?? exit, message, parse, command });
+         this.args = args;
+         this.showHelp = true;
      }
- }
- exports.RequiredArgsError = RequiredArgsError;

--- a/patches/all/oclif+3.17.2.dev.patch
+++ b/patches/all/oclif+3.17.2.dev.patch
@@ -16,7 +16,7 @@ index c0926bd..e4f645c 100644
    File /r bin
    File /r client
 diff --git a/node_modules/oclif/lib/tarballs/build.js b/node_modules/oclif/lib/tarballs/build.js
-index 384ea4b..8f5ed5d 100644
+index 384ea4b..4d6593a 100644
 --- a/node_modules/oclif/lib/tarballs/build.js
 +++ b/node_modules/oclif/lib/tarballs/build.js
 @@ -30,7 +30,9 @@ async function build(c, options = {}) {
@@ -44,52 +44,3 @@ index 384ea4b..8f5ed5d 100644
      };
      const updatePJSON = async () => {
          const pjsonPath = path.join(c.workspace(), 'package.json');
-@@ -49,35 +58,20 @@ async function build(c, options = {}) {
-         await fs.writeJSON(pjsonPath, pjson, { spaces: 2 });
-     };
-     const addDependencies = async () => {
--        const yarnRoot = findYarnWorkspaceRoot(c.root) || c.root;
--        if (fs.existsSync(path.join(yarnRoot, 'yarn.lock'))) {
--            await fs.copy(path.join(yarnRoot, 'yarn.lock'), path.join(c.workspace(), 'yarn.lock'));
--            const yarnVersion = (await exec('yarn -v')).stdout.charAt(0);
--            if (yarnVersion === '1') {
--                await exec('yarn --no-progress --production --non-interactive', { cwd: c.workspace() });
--            }
--            else if (yarnVersion === '2') {
--                throw new Error('Yarn 2 is not supported yet. Try using Yarn 1, or Yarn 3');
--            }
--            else {
--                try {
--                    await exec('yarn workspaces focus --production', { cwd: c.workspace() });
--                }
--                catch (error) {
--                    if (error instanceof Error && error.message.includes('Command not found')) {
--                        throw new Error('Missing workspace tools. Run `yarn plugin import workspace-tools`.');
--                    }
--                    throw error;
--                }
--            }
--        }
--        else {
--            const lockpath = fs.existsSync(path.join(c.root, 'package-lock.json')) ?
--                path.join(c.root, 'package-lock.json') :
--                path.join(c.root, 'npm-shrinkwrap.json');
--            await fs.copy(lockpath, path.join(c.workspace(), path.basename(lockpath)));
--            await exec('npm install --production', { cwd: c.workspace() });
-+        const ws = c.workspace();
-+        exec(`cd ${ws}`);
-+        console.error(`[debug] oclif copying node_modules to "${ws}"`)
-+        const source = path.join(c.root, 'node_modules');
-+        if (process.platform === 'win32') {
-+            await exec(`xcopy "${source}" "${ws}\\node_modules" /S /E /B /I /K /Q /Y`);
-+        } else {
-+            // use the shell's `cp` on macOS in order to preserve extended
-+            // file attributes containing `codesign` digital signatures
-+            await exec(`cp -pR "${source}" "${ws}"`);
-         }
-+        console.error(`[debug] oclif running "npm prune --production" in "${ws}"`);
-+        await exec('npm prune --production', { cwd: c.workspace() });
-+        console.error(`[debug] oclif done`);
-     };
-     const pretarball = async () => {
-         const pjson = await fs.readJSON(path.join(c.workspace(), 'package.json'));


### PR DESCRIPTION
Change-type: patch

This is mostly removing the oclif patch to sign binaries and doing it on the `pretarball` step from oclif lifecycle, as recommended by oclif. This doesn't effectively change anything on any final binary and it was not done this way before because when it was created the `pretarball` life cycle step did not exist and no one realized it could be used after it was created. I manually tested on MacOS, linux & windows and everything seemed ok (including the use of the signed binaries)

---
Please check the CONTRIBUTING.md file for relevant information and some
guidance. Keep in mind that the CLI is a cross-platform application that runs
on Windows, macOS and Linux. Tests will be automatically run by balena CI on
all three operating systems, but this will only help if you have added test
code that exercises the modified or added feature code.

Note that each commit message (currently only the first line) will be
automatically copied to the CHANGELOG.md file, so try writing it in a way
that describes the feature or fix for CLI users.

If there isn't a linked issue or if the linked issue doesn't quite match the
PR, please add a PR description to explain its purpose or the features that it
implements. Adding PR comments to blocks of code that aren't self explanatory
usually helps with the review process.

If the PR introduces security considerations or affects the development, build
or release process, please be sure to highlight this in the PR description.

Thank you very much for your contribution!
