### PR TITLE
Remove patching tmp for windows runners

### DIFF
--- a/automation/run.ts
+++ b/automation/run.ts
@@ -65,21 +65,6 @@ async function parse(args?: string[]) {
 		}
 	}
 
-	// The BUILD_TMP env var is used as an alternative location for oclif
-	// (patched) to copy/extract the CLI files, run npm install and then
-	// create the NSIS executable installer for Windows. This was necessary
-	// to avoid issues with a 260-char limit on Windows paths (possibly a
-	// limitation of some library used by NSIS), as the "current working dir"
-	// provided by balena CI is a rather long path to start with.
-	if (process.platform === 'win32' && !process.env.BUILD_TMP) {
-		const randID = (await import('crypto'))
-			.randomBytes(6)
-			.toString('base64')
-			.replace(/\+/g, '-')
-			.replace(/\//g, '_'); // base64url (RFC 4648)
-		process.env.BUILD_TMP = `C:\\tmp\\${randID}`;
-	}
-
 	for (const arg of args) {
 		try {
 			const cmdFunc = commands[arg];

--- a/patches/all/oclif+3.17.2.dev.patch
+++ b/patches/all/oclif+3.17.2.dev.patch
@@ -16,20 +16,10 @@ index c0926bd..e4f645c 100644
    File /r bin
    File /r client
 diff --git a/node_modules/oclif/lib/tarballs/build.js b/node_modules/oclif/lib/tarballs/build.js
-index 384ea4b..72ad66f 100644
+index 384ea4b..8f5ed5d 100644
 --- a/node_modules/oclif/lib/tarballs/build.js
 +++ b/node_modules/oclif/lib/tarballs/build.js
-@@ -21,7 +21,8 @@ const pack = async (from, to) => {
-         await exec(`tar cfJ ${to} ${(path.basename(from))}`, { cwd }));
- };
- async function build(c, options = {}) {
--    const { xz, config } = c;
-+    const { xz, config, tmp } = c;
-+    console.error(`[debug] oclif c.root="${c.root}" c.workspace()="${c.workspace()}"`);
-     const packCLI = async () => {
-         const { stdout } = await exec('npm pack --unsafe-perm', { cwd: c.root });
-         return path.join(c.root, stdout.trim().split('\n').pop());
-@@ -30,7 +31,9 @@ async function build(c, options = {}) {
+@@ -30,7 +30,9 @@ async function build(c, options = {}) {
          await fs.emptyDir(c.workspace());
          const tarballNewLocation = path.join(c.workspace(), path.basename(tarball));
          await fs.move(tarball, tarballNewLocation);
@@ -40,7 +30,7 @@ index 384ea4b..72ad66f 100644
          await Promise.all((await fs.promises.readdir(path.join(c.workspace(), 'package'), { withFileTypes: true }))
              .map(i => fs.move(path.join(c.workspace(), 'package', i.name), path.join(c.workspace(), i.name))));
          await Promise.all([
-@@ -38,6 +41,13 @@ async function build(c, options = {}) {
+@@ -38,6 +40,13 @@ async function build(c, options = {}) {
              fs.promises.rm(path.join(c.workspace(), path.basename(tarball)), { recursive: true }),
              fs.remove(path.join(c.workspace(), 'bin', 'run.cmd')),
          ]);
@@ -54,7 +44,7 @@ index 384ea4b..72ad66f 100644
      };
      const updatePJSON = async () => {
          const pjsonPath = path.join(c.workspace(), 'package.json');
-@@ -49,35 +59,20 @@ async function build(c, options = {}) {
+@@ -49,35 +58,20 @@ async function build(c, options = {}) {
          await fs.writeJSON(pjsonPath, pjson, { spaces: 2 });
      };
      const addDependencies = async () => {
@@ -103,46 +93,3 @@ index 384ea4b..72ad66f 100644
      };
      const pretarball = async () => {
          const pjson = await fs.readJSON(path.join(c.workspace(), 'package.json'));
-@@ -115,7 +110,8 @@ async function build(c, options = {}) {
-             output: path.join(workspace, 'bin', 'node'),
-             platform: target.platform,
-             arch: target.arch,
--            tmp: path.join(config.root, 'tmp'),
-+            tmp,
-+            projectRootPath: c.root
-         });
-         if (options.pack === false)
-             return;
-@@ -158,6 +154,7 @@ async function build(c, options = {}) {
-         await fs.writeJSON(manifestFilepath, manifest, { spaces: 2 });
-     };
-     (0, log_1.log)(`gathering workspace for ${config.bin} to ${c.workspace()}`);
-+    console.error(`[debug] ${options.tarball}`);
-     await extractCLI(options.tarball ? options.tarball : await packCLI());
-     await updatePJSON();
-     await addDependencies();
-diff --git a/node_modules/oclif/lib/tarballs/config.js b/node_modules/oclif/lib/tarballs/config.js
-index 216759d..cab0e6e 100644
---- a/node_modules/oclif/lib/tarballs/config.js
-+++ b/node_modules/oclif/lib/tarballs/config.js
-@@ -25,7 +25,10 @@ async function gitSha(cwd, options = {}) {
- }
- exports.gitSha = gitSha;
- async function Tmp(config) {
--    const tmp = path.join(config.root, 'tmp');
-+     const tmp = process.env.BUILD_TMP
-+         ? path.join(process.env.BUILD_TMP, 'oclif')
-+         : path.join(config.root, 'tmp');
-+    console.error(`[debug] oclif tmp="${tmp}"`);
-     await fs.promises.mkdir(tmp, { recursive: true });
-     return tmp;
- }
-@@ -62,7 +65,7 @@ async function buildConfig(root, options = {}) {
-         s3Config: updateConfig.s3,
-         nodeVersion,
-         workspace(target) {
--            const base = path.join(config.root, 'tmp');
-+            const base = tmp;
-             if (target && target.platform)
-                 return path.join(base, [target.platform, target.arch].join('-'), (0, upload_util_1.templateShortKey)('baseDir', { bin: config.bin }));
-             return path.join(base, (0, upload_util_1.templateShortKey)('baseDir', { bin: config.bin }));


### PR DESCRIPTION
See: https://github.com/balena-io/balena-cli/pull/1298/files#r297236577
Change-type: patch

This patch was created in order for the previous CI to be able to run on windows where there is a limitation of 260 character for file path. Basically, as per the comments in https://github.com/balena-io/balena-cli/pull/1298/files#r297236577 it uses the root directory like `C:\tmp\reKXhCkj\oclif\balena` because the previous CI generated native very long initial path for installation. With flowzone/github actions this was already mitigated by making the default source used to be `D:\a\balena-cli\balena-cli` which is even shorter than the tmp workaround folder, which makes this patch no longer necessary.


---
Please check the CONTRIBUTING.md file for relevant information and some
guidance. Keep in mind that the CLI is a cross-platform application that runs
on Windows, macOS and Linux. Tests will be automatically run by balena CI on
all three operating systems, but this will only help if you have added test
code that exercises the modified or added feature code.

Note that each commit message (currently only the first line) will be
automatically copied to the CHANGELOG.md file, so try writing it in a way
that describes the feature or fix for CLI users.

If there isn't a linked issue or if the linked issue doesn't quite match the
PR, please add a PR description to explain its purpose or the features that it
implements. Adding PR comments to blocks of code that aren't self explanatory
usually helps with the review process.

If the PR introduces security considerations or affects the development, build
or release process, please be sure to highlight this in the PR description.

Thank you very much for your contribution!
