### PR TITLE
patch: fix outdated doc for "os configure"

### DIFF
--- a/docs/balena-cli.md
+++ b/docs/balena-cli.md
@@ -2834,11 +2834,6 @@ from other balena accounts that you may be invited to join under any role.
 For this reason, fleet names are especially discouraged in scripts (e.g. CI
 environments).
 
-Note: This command is currently not supported on Windows natively. Windows users
-are advised to install the Windows Subsystem for Linux (WSL) with Ubuntu, and use
-the Linux release of the balena CLI:
-https://docs.microsoft.com/en-us/windows/wsl/about
-
 Examples:
 
 	$ balena os configure ../path/rpi3.img --device 7cf02a6

--- a/lib/commands/os/configure.ts
+++ b/lib/commands/os/configure.ts
@@ -75,11 +75,6 @@ export default class OsConfigureCmd extends Command {
 		https://developer.gnome.org/NetworkManager/stable/ref-settings.html
 
 		${applicationIdInfo.split('\n').join('\n\t\t')}
-
-		Note: This command is currently not supported on Windows natively. Windows users
-		are advised to install the Windows Subsystem for Linux (WSL) with Ubuntu, and use
-		the Linux release of the balena CLI:
-		https://docs.microsoft.com/en-us/windows/wsl/about
 	`;
 
 	public static examples = [


### PR DESCRIPTION
There were an outdated warning for `os configure` on windows. The command actually works fine on windows.

see: https://balena.zulipchat.com/#narrow/stream/403752-channel.2Fsupport-help/topic/Cytiva.20image.20downloads/near/438786503