### PR TITLE
Update @oclif/core from 3.26.9 to 3.27.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -14,7 +14,7 @@
         "@balena/dockerignore": "^1.0.2",
         "@balena/env-parsing": "^1.1.8",
         "@balena/es-version": "^1.0.1",
-        "@oclif/core": "~3.26.9",
+        "@oclif/core": "^3.27.0",
         "@resin.io/valid-email": "^0.1.0",
         "@sentry/node": "^6.16.1",
         "@types/fast-levenshtein": "0.0.1",
@@ -1910,10 +1910,9 @@
       }
     },
     "node_modules/@oclif/core": {
-      "version": "3.26.9",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-3.26.9.tgz",
-      "integrity": "sha512-yB5Yxd62DsHqqCK/60L8IiGpTRIU4J+fzCqfbPRiIYE5+agfN63kppaM+TbqyMBdsnt/PQOnYD8Bhs1quUr6fg==",
-      "license": "MIT",
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-3.27.0.tgz",
+      "integrity": "sha512-Fg93aNFvXzBq5L7ztVHFP2nYwWU1oTCq48G0TjF/qC1UN36KWa2H5Hsm72kERd5x/sjy2M2Tn4kDEorUlpXOlw==",
       "dependencies": {
         "@types/cli-progress": "^3.11.5",
         "ansi-escapes": "^4.3.2",

--- a/package.json
+++ b/package.json
@@ -202,7 +202,7 @@
     "@balena/dockerignore": "^1.0.2",
     "@balena/env-parsing": "^1.1.8",
     "@balena/es-version": "^1.0.1",
-    "@oclif/core": "~3.26.9",
+    "@oclif/core": "^3.27.0",
     "@resin.io/valid-email": "^0.1.0",
     "@sentry/node": "^6.16.1",
     "@types/fast-levenshtein": "0.0.1",

--- a/patches/all/@oclif+core+3.27.0.patch
+++ b/patches/all/@oclif+core+3.27.0.patch
@@ -12,37 +12,19 @@ index 607d8dc..07ba1f2 100644
      return lines.join('\n');
  }
 diff --git a/node_modules/@oclif/core/lib/help/command.js b/node_modules/@oclif/core/lib/help/command.js
-index bc54de4..cb246ce 100644
+index 930598f..867799b 100644
 --- a/node_modules/@oclif/core/lib/help/command.js
 +++ b/node_modules/@oclif/core/lib/help/command.js
-@@ -59,7 +59,9 @@ class CommandHelp extends formatter_1.HelpFormatter {
+@@ -59,7 +59,8 @@ class CommandHelp extends formatter_1.HelpFormatter {
              return;
          return args.map((a) => {
              // Add ellipsis to indicate that the argument takes multiple values if strict is false
 -            const name = this.command.strict === false ? `${a.name.toUpperCase()}...` : a.name.toUpperCase();
 +            let name = this.command.strict === false ? `${a.name.toUpperCase()}...` : a.name.toUpperCase();
 +            name = a.required ? `<${name}>` : `[${name}]`;
-+
              let description = a.description || '';
              if (a.default)
                  description = `${(0, theme_1.colorize)(this.config?.theme?.flagDefaultValue, `[default: ${a.default}]`)} ${description}`;
-@@ -154,14 +156,12 @@ class CommandHelp extends formatter_1.HelpFormatter {
-             label = labels.join(flag.char ? (0, theme_1.colorize)(this.config?.theme?.flagSeparator, ', ') : '  ');
-         }
-         if (flag.type === 'option') {
--            let value = flag.helpValue || (this.opts.showFlagNameInTitle ? flag.name : '<value>');
-+            let value = flag.helpValue || (this.opts.showFlagNameInTitle ? flag.name : `<${flag.name}>`);
-             if (!flag.helpValue && flag.options) {
-                 value = showOptions || this.opts.showFlagOptionsInTitle ? `${flag.options.join('|')}` : '<option>';
-             }
-             if (flag.multiple)
--                value += '...';
--            if (!value.includes('|'))
--                value = chalk_1.default.underline(value);
-+                value += ' ...';
-             label += `=${value}`;
-         }
-         return (0, theme_1.colorize)(this.config.theme?.flag, label);
 diff --git a/node_modules/@oclif/core/lib/help/index.js b/node_modules/@oclif/core/lib/help/index.js
 index e1859e1..756654c 100644
 --- a/node_modules/@oclif/core/lib/help/index.js
@@ -63,7 +45,7 @@ index e1859e1..756654c 100644
              const uniqueSubCommands = subCommands.filter((p) => {
                  aliases.push(...p.aliases);
 diff --git a/node_modules/@oclif/core/lib/parser/errors.js b/node_modules/@oclif/core/lib/parser/errors.js
-index b37743a..489d66e 100644
+index b37743a..6b2e5c3 100644
 --- a/node_modules/@oclif/core/lib/parser/errors.js
 +++ b/node_modules/@oclif/core/lib/parser/errors.js
 @@ -15,7 +15,8 @@ class CLIParseError extends errors_1.CLIError {
@@ -76,18 +58,17 @@ index b37743a..489d66e 100644
          super(options.message, { exit: options.exit });
          this.parse = options.parse;
      }
-@@ -38,7 +39,9 @@ exports.InvalidArgsSpecError = InvalidArgsSpecError;
+@@ -38,7 +39,8 @@ exports.InvalidArgsSpecError = InvalidArgsSpecError;
  class RequiredArgsError extends CLIParseError {
      args;
      constructor({ args, exit, flagsWithMultiple, parse, }) {
 -        let message = `Missing ${args.length} required arg${args.length === 1 ? '' : 's'}`;
 +        const command = 'balena ' + parse.input.context.id.replace(/:/g, ' ');
 +        let message = `Missing ${args.length} required argument${args.length === 1 ? '' : 's'}`;
-+
          const namedArgs = args.filter((a) => a.name);
          if (namedArgs.length > 0) {
              const list = (0, list_1.renderList)(namedArgs.map((a) => {
-@@ -52,7 +55,7 @@ class RequiredArgsError extends CLIParseError {
+@@ -52,7 +54,7 @@ class RequiredArgsError extends CLIParseError {
              message += `\n\nNote: ${flags} allow${flagsWithMultiple.length === 1 ? 's' : ''} multiple values. Because of this you need to provide all arguments before providing ${flagsWithMultiple.length === 1 ? 'that flag' : 'those flags'}.`;
              message += '\nAlternatively, you can use "--" to signify the end of the flags and the beginning of arguments.';
          }


### PR DESCRIPTION
This has a slightly small change on the visualization of flags but allows us to not mantain a patch on @oclif/core:

From:
![Screenshot from 2024-06-21 09-52-30](https://github.com/balena-io/balena-cli/assets/14330369/1be06f43-4b82-4002-aa03-91def635890f)

To:
![Screenshot from 2024-06-21 09-52-11](https://github.com/balena-io/balena-cli/assets/14330369/1d3ad768-4636-4649-a787-f5d5336c204b)




Change-type: patch

<!-- You can remove tags that do not apply. -->
Resolves: # <!-- Refer an issue of this repository that this PR fixes -->  
Change-type: major|minor|patch <!-- See https://semver.org/ -->  
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->  
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->  

---
Please check the CONTRIBUTING.md file for relevant information and some
guidance. Keep in mind that the CLI is a cross-platform application that runs
on Windows, macOS and Linux. Tests will be automatically run by balena CI on
all three operating systems, but this will only help if you have added test
code that exercises the modified or added feature code.

Note that each commit message (currently only the first line) will be
automatically copied to the CHANGELOG.md file, so try writing it in a way
that describes the feature or fix for CLI users.

If there isn't a linked issue or if the linked issue doesn't quite match the
PR, please add a PR description to explain its purpose or the features that it
implements. Adding PR comments to blocks of code that aren't self explanatory
usually helps with the review process.

If the PR introduces security considerations or affects the development, build
or release process, please be sure to highlight this in the PR description.

Thank you very much for your contribution!
