### PR TITLE
Update balena-sdk to 19.7.2

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1373,35 +1373,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@balena/abstract-sql-compiler": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/@balena/abstract-sql-compiler/-/abstract-sql-compiler-9.2.0.tgz",
-      "integrity": "sha512-sKSbGNcL19QvqUrslms/k8GsVWjq75g0b8uVh/jpZEUWHniixWq402b+OKs0wRIhtRMsWSVA3CLuC33tYj6KCA==",
-      "dependencies": {
-        "@balena/sbvr-types": "^7.0.1",
-        "lodash": "^4.17.21"
-      },
-      "engines": {
-        "node": ">=16.13.0",
-        "npm": ">=8.1.0"
-      }
-    },
-    "node_modules/@balena/abstract-sql-to-typescript": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@balena/abstract-sql-to-typescript/-/abstract-sql-to-typescript-3.3.0.tgz",
-      "integrity": "sha512-ryXYdojBW/Kj8r50XlAMLjxgqfZpdus/mDbYYdmEyLyHccWV2O641rjhpFmi3TiYgDa71A8YL7eVb0AhRMNuOg==",
-      "dependencies": {
-        "@balena/abstract-sql-compiler": "^9.2.0",
-        "@balena/odata-to-abstract-sql": "^6.2.7",
-        "@balena/sbvr-types": "^7.1.3",
-        "@types/node": "^20.14.8",
-        "common-tags": "^1.8.2"
-      },
-      "engines": {
-        "node": ">=16.13.0",
-        "npm": ">=8.1.0"
-      }
-    },
     "node_modules/@balena/apple-plist": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/@balena/apple-plist/-/apple-plist-0.0.3.tgz",
@@ -1619,16 +1590,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/@balena/lint/node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
     "node_modules/@balena/lint/node_modules/yargs": {
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
@@ -1686,48 +1647,6 @@
       "dependencies": {
         "is-stream": "^1.1.0",
         "web-streams-polyfill": "^3.1.0"
-      }
-    },
-    "node_modules/@balena/odata-parser": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@balena/odata-parser/-/odata-parser-3.0.8.tgz",
-      "integrity": "sha512-EhC7uYZUTIeoBPSAHRfL2tz4H2pfe9vO9U4jf/84NVnh6GKApA8Gfo4QQWwL/SHuz+KJI0LkhjU9yNqKCPE0kg==",
-      "engines": {
-        "node": ">=16.13.0",
-        "npm": ">=8.1.0"
-      }
-    },
-    "node_modules/@balena/odata-to-abstract-sql": {
-      "version": "6.2.7",
-      "resolved": "https://registry.npmjs.org/@balena/odata-to-abstract-sql/-/odata-to-abstract-sql-6.2.7.tgz",
-      "integrity": "sha512-SfIxIAw5/60qux3xBT/pS29GZpKzMmAu0oZpdfnni/duhPQmKBs/peGqqF2rPcHp1rODiqRzNFDcJ7KkPq9Wrg==",
-      "dependencies": {
-        "@balena/abstract-sql-compiler": "^9.1.4",
-        "@balena/odata-parser": "^3.0.3",
-        "@types/lodash": "^4.14.202",
-        "@types/memoizee": "^0.4.11",
-        "@types/string-hash": "^1.1.3",
-        "lodash": "^4.17.21",
-        "memoizee": "^0.4.15",
-        "string-hash": "^1.1.3"
-      },
-      "engines": {
-        "node": ">=16.13.0",
-        "npm": ">=8.1.0"
-      }
-    },
-    "node_modules/@balena/sbvr-types": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/@balena/sbvr-types/-/sbvr-types-7.1.3.tgz",
-      "integrity": "sha512-kizk+ClfYJVJidMx69BiFSFqtDE97R4JXRYrn1Ff/vK+ycN7Mj3HVObFk5DvckresiBI9S2mvZsysW+RVNmJsg==",
-      "engines": {
-        "node": ">=16.13.0",
-        "npm": ">=8.1.0"
-      },
-      "optionalDependencies": {
-        "bcrypt": "^5.1.1",
-        "bcryptjs": "^2.4.3",
-        "sha.js": "^2.4.11"
       }
     },
     "node_modules/@balena/udif": {
@@ -2287,97 +2206,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
       "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw=="
-    },
-    "node_modules/@mapbox/node-pre-gyp": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz",
-      "integrity": "sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==",
-      "optional": true,
-      "dependencies": {
-        "detect-libc": "^2.0.0",
-        "https-proxy-agent": "^5.0.0",
-        "make-dir": "^3.1.0",
-        "node-fetch": "^2.6.7",
-        "nopt": "^5.0.0",
-        "npmlog": "^5.0.1",
-        "rimraf": "^3.0.2",
-        "semver": "^7.3.5",
-        "tar": "^6.1.11"
-      },
-      "bin": {
-        "node-pre-gyp": "bin/node-pre-gyp"
-      }
-    },
-    "node_modules/@mapbox/node-pre-gyp/node_modules/are-we-there-yet": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
-      "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
-      "deprecated": "This package is no longer supported.",
-      "optional": true,
-      "dependencies": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@mapbox/node-pre-gyp/node_modules/detect-libc": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
-      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
-      "optional": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@mapbox/node-pre-gyp/node_modules/gauge": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
-      "integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
-      "deprecated": "This package is no longer supported.",
-      "optional": true,
-      "dependencies": {
-        "aproba": "^1.0.3 || ^2.0.0",
-        "color-support": "^1.1.2",
-        "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.1",
-        "object-assign": "^4.1.1",
-        "signal-exit": "^3.0.0",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1",
-        "wide-align": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@mapbox/node-pre-gyp/node_modules/npmlog": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
-      "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
-      "deprecated": "This package is no longer supported.",
-      "optional": true,
-      "dependencies": {
-        "are-we-there-yet": "^2.0.0",
-        "console-control-strings": "^1.1.0",
-        "gauge": "^3.0.0",
-        "set-blocking": "^2.0.0"
-      }
-    },
-    "node_modules/@mapbox/node-pre-gyp/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "optional": true,
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -4348,11 +4176,6 @@
       "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw=="
     },
-    "node_modules/@types/memoizee": {
-      "version": "0.4.11",
-      "resolved": "https://registry.npmjs.org/@types/memoizee/-/memoizee-0.4.11.tgz",
-      "integrity": "sha512-2gyorIBZu8GoDr9pYjROkxWWcFtHCquF7TVbN2I+/OvgZhnIGQS0vX5KJz4lXNKb8XOSfxFOSG5OLru1ESqLUg=="
-    },
     "node_modules/@types/mime": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
@@ -4600,11 +4423,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/string-hash": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@types/string-hash/-/string-hash-1.1.3.tgz",
-      "integrity": "sha512-p6skq756fJWiA59g2Uss+cMl6tpoDGuCBuxG0SI1t0NwJmYOU66LAMS6QiCgu7cUh3/hYCaMl5phcCW1JP5wOA=="
     },
     "node_modules/@types/tar-stream": {
       "version": "2.2.2",
@@ -5132,12 +4950,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
       "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ=="
-    },
-    "node_modules/abbrev": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "optional": true
     },
     "node_modules/abortcontroller-polyfill": {
       "version": "1.7.5",
@@ -5860,15 +5672,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/balena-image-manager/node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
     "node_modules/balena-image-manager/node_modules/rimraf": {
       "version": "5.0.9",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.9.tgz",
@@ -6067,20 +5870,6 @@
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
       "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
     },
-    "node_modules/bcrypt": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-5.1.1.tgz",
-      "integrity": "sha512-AGBHOG5hPYZ5Xl9KXzU5iKq9516yEmvCKDg3ecP5kX2aB6UqTeXZxk2ELnDgDm6BQSMlLt9rDB4LoSMx0rYwww==",
-      "hasInstallScript": true,
-      "optional": true,
-      "dependencies": {
-        "@mapbox/node-pre-gyp": "^1.0.11",
-        "node-addon-api": "^5.0.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -6088,18 +5877,6 @@
       "dependencies": {
         "tweetnacl": "^0.14.3"
       }
-    },
-    "node_modules/bcrypt/node_modules/node-addon-api": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
-      "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==",
-      "optional": true
-    },
-    "node_modules/bcryptjs": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
-      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
-      "optional": true
     },
     "node_modules/before-after-hook": {
       "version": "2.2.2",
@@ -6889,15 +6666,6 @@
       "dependencies": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
-      }
-    },
-    "node_modules/color-support": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
-      "optional": true,
-      "bin": {
-        "color-support": "bin.js"
       }
     },
     "node_modules/colors": {
@@ -8903,15 +8671,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/etcher-sdk/node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
     "node_modules/etcher-sdk/node_modules/node-raspberrypi-usbboot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/node-raspberrypi-usbboot/-/node-raspberrypi-usbboot-1.1.0.tgz",
@@ -9741,18 +9500,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/fs-minipass": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-      "optional": true,
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/fs.realpath": {
@@ -12951,28 +12698,11 @@
       }
     },
     "node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "optional": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
       "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/minizlib": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-      "optional": true,
-      "dependencies": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/mkdirp": {
@@ -13665,21 +13395,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
       "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI="
-    },
-    "node_modules/nopt": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
-      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
-      "optional": true,
-      "dependencies": {
-        "abbrev": "1"
-      },
-      "bin": {
-        "nopt": "bin/nopt.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/normalize-package-data": {
       "version": "6.0.2",
@@ -14978,15 +14693,6 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
     },
-    "node_modules/path-scurry/node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
     "node_modules/path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
@@ -15077,31 +14783,18 @@
       }
     },
     "node_modules/pinejs-client-request": {
-      "version": "7.5.2",
-      "resolved": "https://registry.npmjs.org/pinejs-client-request/-/pinejs-client-request-7.5.2.tgz",
-      "integrity": "sha512-ihCO82Fh+56tx3QBl65jvMcO364T08x9825gDgDjUgfQEvFlf5FfID+1kcdrgpHsJjYe2o2e4RQEQwMyWxMbIQ==",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/pinejs-client-request/-/pinejs-client-request-7.4.2.tgz",
+      "integrity": "sha512-ltltWhsrZK2UiDfoWGF4AciOBW3YaHJWO9xuOEPK8LjkMBBVz5K6HKqguzV5ZqJ+8lLMgBvUtnF/9cSEMCMcbw==",
       "dependencies": {
-        "@types/lodash": "^4.17.5",
+        "@types/lodash": "^4.17.4",
         "@types/lru-cache": "^5.1.1",
         "@types/request": "^2.48.12",
         "lodash": "^4.17.21",
         "lru-cache": "^6.0.0",
-        "pinejs-client-core": "^6.15.2",
+        "pinejs-client-core": "^6.14.6",
         "request": "^2.88.2",
         "typed-error": "^3.2.2"
-      },
-      "engines": {
-        "node": ">=10.0.0",
-        "npm": ">=6.0.0"
-      }
-    },
-    "node_modules/pinejs-client-request/node_modules/pinejs-client-core": {
-      "version": "6.15.10",
-      "resolved": "https://registry.npmjs.org/pinejs-client-core/-/pinejs-client-core-6.15.10.tgz",
-      "integrity": "sha512-TSv3ZWDuy/kIse+kzto+aH4S6+rpXvAIWOvnV1XvmtfsjN+GJSlrNdcMmt+CnI9x9B19H71tHzSJO6c9NPzZnQ==",
-      "dependencies": {
-        "@balena/abstract-sql-to-typescript": "^3.2.3",
-        "@balena/es-version": "^1.0.3"
       },
       "engines": {
         "node": ">=10.0.0",
@@ -16056,15 +15749,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/resin-device-operations/node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
     "node_modules/resin-doodles": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/resin-doodles/-/resin-doodles-0.2.0.tgz",
@@ -16944,19 +16628,6 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
     },
-    "node_modules/sha.js": {
-      "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
-      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
-      "optional": true,
-      "dependencies": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
-      },
-      "bin": {
-        "sha.js": "bin.js"
-      }
-    },
     "node_modules/shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -17564,11 +17235,6 @@
         "safe-buffer": "~5.1.0"
       }
     },
-    "node_modules/string-hash": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
-      "integrity": "sha512-kJUvRUFK49aub+a7T1nNE66EJbZBMnBgoC1UbCZ5n6bsZKBRga4KgBRTMn/pFkeCZSYtNeSyMxPDM0AXWELk2A=="
-    },
     "node_modules/string-to-stream": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string-to-stream/-/string-to-stream-1.1.1.tgz",
@@ -17955,23 +17621,6 @@
         "node": ">= 0.4.0"
       }
     },
-    "node_modules/tar": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
-      "optional": true,
-      "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^5.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/tar-fs": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
@@ -18018,24 +17667,6 @@
       "dependencies": {
         "bluebird": "^3.7.2",
         "tar-stream": "^2.1.3"
-      }
-    },
-    "node_modules/tar/node_modules/chownr": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-      "optional": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/tar/node_modules/minipass": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-      "optional": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/temp": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -23,7 +23,7 @@
         "balena-image-fs": "^7.0.6",
         "balena-image-manager": "^10.0.1",
         "balena-preload": "^15.0.5",
-        "balena-sdk": "^19.5.5",
+        "balena-sdk": "^19.7.2",
         "balena-semver": "^2.3.0",
         "balena-settings-client": "^5.0.2",
         "balena-settings-storage": "^8.1.0",
@@ -5949,9 +5949,9 @@
       }
     },
     "node_modules/balena-sdk": {
-      "version": "19.5.5",
-      "resolved": "https://registry.npmjs.org/balena-sdk/-/balena-sdk-19.5.5.tgz",
-      "integrity": "sha512-uuk2NaUAssUKqs/lIxmK/Od1ShTcMxj1xOc1RsHOp1JgbSZyKT4CxAU1OWRl9XD98LWO3Ew6NgCDP5EFLkt+qw==",
+      "version": "19.7.2",
+      "resolved": "https://registry.npmjs.org/balena-sdk/-/balena-sdk-19.7.2.tgz",
+      "integrity": "sha512-RGqDr10S43kTVlGTaejK6WpEVvW25YP0lIeybIcXchmweg9Mgt/rGJv/gVyLJwdSiw/9Tdgfaul0DTR6nlkD2g==",
       "dependencies": {
         "@balena/es-version": "^1.0.0",
         "@types/json-schema": "^7.0.9",
@@ -5961,7 +5961,7 @@
         "balena-errors": "^4.9.0",
         "balena-hup-action-utils": "~6.1.0",
         "balena-register-device": "^9.0.2",
-        "balena-request": "^13.3.1",
+        "balena-request": "^13.3.2",
         "balena-semver": "^2.3.0",
         "balena-settings-client": "^5.0.0",
         "date-fns": "^3.0.5",
@@ -5971,7 +5971,7 @@
         "mime": "^3.0.0",
         "ndjson": "^2.0.0",
         "p-throttle": "^4.1.1",
-        "pinejs-client-core": "^6.12.0",
+        "pinejs-client-core": "~6.14.0",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -15065,11 +15065,10 @@
       }
     },
     "node_modules/pinejs-client-core": {
-      "version": "6.15.9",
-      "resolved": "https://registry.npmjs.org/pinejs-client-core/-/pinejs-client-core-6.15.9.tgz",
-      "integrity": "sha512-8nxCr8MP0jNPRNyFCP+r2+mAVVDVb/yUjpigpCEou6jfzkN1e89Jaa1WSAysJS6XzMBqV1JnkRGVX+maerreFA==",
+      "version": "6.14.13",
+      "resolved": "https://registry.npmjs.org/pinejs-client-core/-/pinejs-client-core-6.14.13.tgz",
+      "integrity": "sha512-Ca1kfbst+0C9UbvqrJFM2VZRAX/UDSgMDYiqSswzTsNoz/axOLMB3bmbrK8el+wSLb0TG2s/UsOZQTnN4MkOcQ==",
       "dependencies": {
-        "@balena/abstract-sql-to-typescript": "^3.2.3",
         "@balena/es-version": "^1.0.3"
       },
       "engines": {
@@ -15090,6 +15089,19 @@
         "pinejs-client-core": "^6.15.2",
         "request": "^2.88.2",
         "typed-error": "^3.2.2"
+      },
+      "engines": {
+        "node": ">=10.0.0",
+        "npm": ">=6.0.0"
+      }
+    },
+    "node_modules/pinejs-client-request/node_modules/pinejs-client-core": {
+      "version": "6.15.10",
+      "resolved": "https://registry.npmjs.org/pinejs-client-core/-/pinejs-client-core-6.15.10.tgz",
+      "integrity": "sha512-TSv3ZWDuy/kIse+kzto+aH4S6+rpXvAIWOvnV1XvmtfsjN+GJSlrNdcMmt+CnI9x9B19H71tHzSJO6c9NPzZnQ==",
+      "dependencies": {
+        "@balena/abstract-sql-to-typescript": "^3.2.3",
+        "@balena/es-version": "^1.0.3"
       },
       "engines": {
         "node": ">=10.0.0",

--- a/package.json
+++ b/package.json
@@ -211,7 +211,7 @@
     "balena-image-fs": "^7.0.6",
     "balena-image-manager": "^10.0.1",
     "balena-preload": "^15.0.5",
-    "balena-sdk": "^19.5.5",
+    "balena-sdk": "^19.7.2",
     "balena-semver": "^2.3.0",
     "balena-settings-client": "^5.0.2",
     "balena-settings-storage": "^8.1.0",


### PR DESCRIPTION
Also downgrades pinejs-client-request to 7.4.2 to result a single pinejs-client-core installation, and unblock the sdk update.

Change-type: patch