### PR TITLE
patch: change the name of the certificate

### DIFF
--- a/automation/build-bin.ts
+++ b/automation/build-bin.ts
@@ -366,7 +366,7 @@ export async function signFilesForNotarization() {
 						'-d',
 						'-f',
 						'-s',
-						'Developer ID Application: Balena Ltd (66H43P8FRG)',
+						'Developer ID Installer: Balena Ltd (66H43P8FRG)',
 						item.path,
 					]);
 					await whichSpawn('codesign', [

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3893,9 +3893,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.16.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.16.5.tgz",
-      "integrity": "sha512-VwYCweNo3ERajwy0IUlqqcyZ8/A7Zwa9ZP3MnENWcB11AejO+tLy3pu850goUW2FC/IJMdZUfKpX/yxL1gymCA==",
+      "version": "20.16.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.16.9.tgz",
+      "integrity": "sha512-rkvIVJxsOfBejxK7I0FO5sa2WxFmJCzoDwcd88+fq/CUfynNywTo/1/T6hyFz22CyztsnLS9nVlHOnTI36RH5w==",
       "dependencies": {
         "undici-types": "~6.19.2"
       }
@@ -5614,9 +5614,9 @@
       }
     },
     "node_modules/balena-sdk/node_modules/@types/node": {
-      "version": "18.19.50",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.50.tgz",
-      "integrity": "sha512-xonK+NRrMBRtkL1hVCc3G+uXtjh1Al4opBLjqVmipe5ZAaBYWW6cNAiBVZ1BvmkBhep698rP3UM3aRAdSALuhg==",
+      "version": "18.19.53",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.53.tgz",
+      "integrity": "sha512-GLxgUgHhDKO1Edw9Q0lvMbiO/IQXJwJlMaqxSGBXMpPy8uhkCs2iiPFaB2Q/gmobnFkckD3rqTBMVjXdwq+nKg==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -13014,9 +13014,9 @@
       }
     },
     "node_modules/nise/node_modules/path-to-regexp": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.1.0.tgz",
-      "integrity": "sha512-Bqn3vc8CMHty6zuD+tG23s6v2kwxslHEhTj4eYaVKGIEB+YX/2wd0/rgXLFD9G9id9KCtbVy/3ZgmvZjpa0UdQ==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
+      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
       "dev": true,
       "engines": {
         "node": ">=16"


### PR DESCRIPTION
Now that we use the new certs from Apple, we need an Installer cert to sign a pkg.
