### PR TITLE
Stop manually inserting `help` flag per command since oclif includes it automatically

### DIFF
--- a/docs/balena-cli.md
+++ b/docs/balena-cli.md
@@ -339,8 +339,6 @@ Examples:
 
 the API key name
 
-### Options
-
 ## api-key revoke
 
 ### Description
@@ -360,8 +358,6 @@ Examples:
 #### IDS
 
 the API key ids
-
-### Options
 
 ## api-keys
 
@@ -1266,8 +1262,6 @@ Examples:
 
 the uuid of the device to identify
 
-### Options
-
 ## device
 
 ### Description
@@ -1568,8 +1562,6 @@ the uuid of the device to pin to a release
 
 the commit of the release for the device to get pinned to
 
-### Options
-
 ## device public-url
 
 ### Description
@@ -1625,8 +1617,6 @@ Examples:
 #### UUID
 
 comma-separated list (no blank spaces) of device UUIDs
-
-### Options
 
 ## device reboot
 
@@ -1713,8 +1703,6 @@ the uuid of the device to rename
 #### NEWNAME
 
 the new name for the device
-
-### Options
 
 ## device restart
 
@@ -1821,8 +1809,6 @@ comma-separated list (no blank spaces) of device UUIDs
 
 comma-separated list (no blank spaces) of service names
 
-### Options
-
 ## device stop-service
 
 ### Description
@@ -1847,8 +1833,6 @@ comma-separated list (no blank spaces) of device UUIDs
 
 comma-separated list (no blank spaces) of service names
 
-### Options
-
 ## device track-fleet
 
 ### Description
@@ -1864,8 +1848,6 @@ Examples:
 #### UUID
 
 the uuid of the device to make track the fleet's release
-
-### Options
 
 ## devices supported
 
@@ -2286,8 +2268,6 @@ the slug of the fleet to pin to a release
 
 the commit of the release for the fleet to get pinned to
 
-### Options
-
 ## fleet purge
 
 ### Description
@@ -2315,8 +2295,6 @@ Examples:
 #### FLEET
 
 fleet name or slug (preferred)
-
-### Options
 
 ## fleet rename
 
@@ -2353,8 +2331,6 @@ fleet name or slug (preferred)
 
 the new name for the fleet
 
-### Options
-
 ## fleet restart
 
 ### Description
@@ -2381,8 +2357,6 @@ Examples:
 #### FLEET
 
 fleet name or slug (preferred)
-
-### Options
 
 ## fleet rm
 
@@ -2437,8 +2411,6 @@ Examples:
 
 the slug of the fleet to make track the latest release
 
-### Options
-
 ## fleets
 
 ### Description
@@ -2476,8 +2448,6 @@ Examples:
 #### TARGET
 
 path of drive or image to configure
-
-### Options
 
 ## local flash
 
@@ -2768,8 +2738,6 @@ list all the organizations that you are a member of.
 Examples:
 
 	$ balena orgs
-
-### Options
 
 # OS
 
@@ -3141,8 +3109,6 @@ Examples:
 
 the device IP or hostname
 
-### Options
-
 # Preload
 
 ## preload
@@ -3510,8 +3476,6 @@ Examples:
 
 the commit or ID of the release to finalize
 
-### Options
-
 ## release
 
 ### Description
@@ -3565,8 +3529,6 @@ Examples:
 
 the commit or ID of the release to invalidate
 
-### Options
-
 ## release validate
 
 ### Description
@@ -3586,8 +3548,6 @@ Examples:
 #### COMMITORID
 
 the commit or ID of the release to validate
-
-### Options
 
 ## releases
 
@@ -3639,8 +3599,6 @@ Examples:
 
 	$ balena settings
 
-### Options
-
 # SSH Keys
 
 ## key add
@@ -3682,8 +3640,6 @@ the SSH key name
 
 the path to the public key file
 
-### Options
-
 ## key
 
 ### Description
@@ -3699,8 +3655,6 @@ Examples:
 #### ID
 
 balenaCloud ID for the SSH key
-
-### Options
 
 ## key rm
 
@@ -3736,8 +3690,6 @@ List all SSH keys registered in balenaCloud for the logged in user.
 Examples:
 
 	$ balena keys
-
-### Options
 
 # Support
 
@@ -3938,8 +3890,6 @@ release id
 
 List available drives which are usable for writing an OS image to.
 Does not list system drives.
-
-### Options
 
 # Version
 

--- a/package.json
+++ b/package.json
@@ -103,7 +103,8 @@
       "command_not_found": "./build/hooks/command-not-found/suggest"
     },
     "additionalHelpFlags": [
-      "help"
+      "help",
+      "-h"
     ],
     "macos": {
       "identifier": "io.balena.cli",

--- a/src/commands/api-key/generate.ts
+++ b/src/commands/api-key/generate.ts
@@ -18,7 +18,6 @@
 import { Args } from '@oclif/core';
 import Command from '../../command';
 import { ExpectedError } from '../../errors';
-import * as cf from '../../utils/common-flags';
 import { getBalenaSdk, stripIndent } from '../../utils/lazy';
 
 export default class GenerateCmd extends Command {
@@ -38,10 +37,6 @@ export default class GenerateCmd extends Command {
 			description: 'the API key name',
 			required: true,
 		}),
-	};
-
-	public static flags = {
-		help: cf.help,
 	};
 
 	public static authenticated = true;

--- a/src/commands/api-key/revoke.ts
+++ b/src/commands/api-key/revoke.ts
@@ -17,7 +17,6 @@
 
 import { Args } from '@oclif/core';
 import Command from '../../command';
-import * as cf from '../../utils/common-flags';
 import { getBalenaSdk, stripIndent } from '../../utils/lazy';
 
 export default class RevokeCmd extends Command {
@@ -39,10 +38,6 @@ export default class RevokeCmd extends Command {
 			description: 'the API key ids',
 			required: true,
 		}),
-	};
-
-	public static flags = {
-		help: cf.help,
 	};
 
 	public static authenticated = true;

--- a/src/commands/api-keys/index.ts
+++ b/src/commands/api-keys/index.ts
@@ -31,7 +31,6 @@ export default class ApiKeysCmd extends Command {
 	public static examples = ['$ balena api-keys'];
 
 	public static flags = {
-		help: cf.help,
 		user: Flags.boolean({
 			char: 'u',
 			description: 'show API keys for your user',

--- a/src/commands/app/create.ts
+++ b/src/commands/app/create.ts
@@ -18,7 +18,6 @@
 import { Flags, Args } from '@oclif/core';
 
 import Command from '../../command';
-import * as cf from '../../utils/common-flags';
 import { stripIndent } from '../../utils/lazy';
 
 export default class AppCreateCmd extends Command {
@@ -66,7 +65,6 @@ export default class AppCreateCmd extends Command {
 			description:
 				'app device type (Check available types with `balena devices supported`)',
 		}),
-		help: cf.help,
 	};
 
 	public static authenticated = true;

--- a/src/commands/block/create.ts
+++ b/src/commands/block/create.ts
@@ -18,7 +18,6 @@
 import { Flags, Args } from '@oclif/core';
 
 import Command from '../../command';
-import * as cf from '../../utils/common-flags';
 import { stripIndent } from '../../utils/lazy';
 
 export default class BlockCreateCmd extends Command {
@@ -66,7 +65,6 @@ export default class BlockCreateCmd extends Command {
 			description:
 				'block device type (Check available types with `balena devices supported`)',
 		}),
-		help: cf.help,
 	};
 
 	public static authenticated = true;

--- a/src/commands/config/generate.ts
+++ b/src/commands/config/generate.ts
@@ -118,7 +118,6 @@ export default class ConfigGenerateCmd extends Command {
 				'expiry date assigned to generated provisioning api key (format: YYYY-MM-DD)',
 			exclusive: ['device'],
 		}),
-		help: cf.help,
 	};
 
 	public static authenticated = true;

--- a/src/commands/config/inject.ts
+++ b/src/commands/config/inject.ts
@@ -45,7 +45,6 @@ export default class ConfigInjectCmd extends Command {
 
 	public static flags = {
 		drive: cf.driveOrImg,
-		help: cf.help,
 	};
 
 	public static root = true;

--- a/src/commands/config/read.ts
+++ b/src/commands/config/read.ts
@@ -38,7 +38,6 @@ export default class ConfigReadCmd extends Command {
 
 	public static flags = {
 		drive: cf.driveOrImg,
-		help: cf.help,
 		json: cf.json,
 	};
 

--- a/src/commands/config/reconfigure.ts
+++ b/src/commands/config/reconfigure.ts
@@ -45,7 +45,6 @@ export default class ConfigReconfigureCmd extends Command {
 			description: 'show advanced commands',
 			char: 'v',
 		}),
-		help: cf.help,
 		version: Flags.string({
 			description: 'balenaOS version, for example "2.32.0" or "2.44.0+rev1"',
 		}),

--- a/src/commands/config/write.ts
+++ b/src/commands/config/write.ts
@@ -50,7 +50,6 @@ export default class ConfigWriteCmd extends Command {
 
 	public static flags = {
 		drive: cf.driveOrImg,
-		help: cf.help,
 	};
 
 	public static root = true;

--- a/src/commands/device/deactivate.ts
+++ b/src/commands/device/deactivate.ts
@@ -43,7 +43,6 @@ export default class DeviceDeactivateCmd extends Command {
 
 	public static flags = {
 		yes: cf.yes,
-		help: cf.help,
 	};
 
 	public static authenticated = true;

--- a/src/commands/device/identify.ts
+++ b/src/commands/device/identify.ts
@@ -17,7 +17,6 @@
 
 import { Args } from '@oclif/core';
 import Command from '../../command';
-import * as cf from '../../utils/common-flags';
 import { getBalenaSdk, stripIndent } from '../../utils/lazy';
 import { ExpectedError } from '../../errors';
 
@@ -34,10 +33,6 @@ export default class DeviceIdentifyCmd extends Command {
 			description: 'the uuid of the device to identify',
 			required: true,
 		}),
-	};
-
-	public static flags = {
-		help: cf.help,
 	};
 
 	public static authenticated = true;

--- a/src/commands/device/index.ts
+++ b/src/commands/device/index.ts
@@ -64,7 +64,6 @@ export default class DeviceCmd extends Command {
 
 	public static flags = {
 		json: cf.json,
-		help: cf.help,
 		view: Flags.boolean({
 			default: false,
 			description: 'open device dashboard page',

--- a/src/commands/device/init.ts
+++ b/src/commands/device/init.ts
@@ -29,7 +29,6 @@ interface FlagsDef {
 	'os-version'?: string;
 	drive?: string;
 	config?: string;
-	help: void;
 	'provisioning-key-name'?: string;
 	'provisioning-key-expiry-date'?: string;
 }
@@ -101,7 +100,6 @@ export default class DeviceInitCmd extends Command {
 			description:
 				'expiry date assigned to generated provisioning api key (format: YYYY-MM-DD)',
 		}),
-		help: cf.help,
 	};
 
 	public static authenticated = true;

--- a/src/commands/device/list.ts
+++ b/src/commands/device/list.ts
@@ -58,7 +58,6 @@ export default class DeviceListCmd extends Command {
 	public static flags = {
 		fleet: cf.fleet,
 		json: cf.json,
-		help: cf.help,
 	};
 
 	public static primary = true;

--- a/src/commands/device/local-mode.ts
+++ b/src/commands/device/local-mode.ts
@@ -17,7 +17,6 @@
 
 import { Flags, Args } from '@oclif/core';
 import Command from '../../command';
-import * as cf from '../../utils/common-flags';
 import { getBalenaSdk, stripIndent } from '../../utils/lazy';
 
 export default class DeviceLocalModeCmd extends Command {
@@ -55,7 +54,6 @@ export default class DeviceLocalModeCmd extends Command {
 			description: 'output boolean indicating local mode status',
 			exclusive: ['enable', 'disable'],
 		}),
-		help: cf.help,
 	};
 
 	public static authenticated = true;

--- a/src/commands/device/move.ts
+++ b/src/commands/device/move.ts
@@ -56,7 +56,6 @@ export default class DeviceMoveCmd extends Command {
 
 	public static flags = {
 		fleet: cf.fleet,
-		help: cf.help,
 	};
 
 	public static authenticated = true;

--- a/src/commands/device/os-update.ts
+++ b/src/commands/device/os-update.ts
@@ -58,7 +58,6 @@ export default class DeviceOsUpdateCmd extends Command {
 			exclusive: ['version'],
 		}),
 		yes: cf.yes,
-		help: cf.help,
 	};
 
 	public static authenticated = true;

--- a/src/commands/device/pin.ts
+++ b/src/commands/device/pin.ts
@@ -17,7 +17,6 @@
 
 import { Args } from '@oclif/core';
 import Command from '../../command';
-import * as cf from '../../utils/common-flags';
 import { getBalenaSdk, stripIndent } from '../../utils/lazy';
 import { getExpandedProp } from '../../utils/pine';
 
@@ -42,10 +41,6 @@ export default class DevicePinCmd extends Command {
 		releaseToPinTo: Args.string({
 			description: 'the commit of the release for the device to get pinned to',
 		}),
-	};
-
-	public static flags = {
-		help: cf.help,
 	};
 
 	public static authenticated = true;

--- a/src/commands/device/public-url.ts
+++ b/src/commands/device/public-url.ts
@@ -18,7 +18,6 @@
 import { Flags, Args } from '@oclif/core';
 import Command from '../../command';
 import { ExpectedError } from '../../errors';
-import * as cf from '../../utils/common-flags';
 import { getBalenaSdk, stripIndent } from '../../utils/lazy';
 
 export default class DevicePublicUrlCmd extends Command {
@@ -57,7 +56,6 @@ export default class DevicePublicUrlCmd extends Command {
 			description: 'determine if public URL is enabled',
 			exclusive: ['enable', 'disable'],
 		}),
-		help: cf.help,
 	};
 
 	public static authenticated = true;

--- a/src/commands/device/purge.ts
+++ b/src/commands/device/purge.ts
@@ -17,7 +17,6 @@
 
 import { Args } from '@oclif/core';
 import Command from '../../command';
-import * as cf from '../../utils/common-flags';
 import { getBalenaSdk, getCliUx, stripIndent } from '../../utils/lazy';
 
 export default class DevicePurgeCmd extends Command {
@@ -40,10 +39,6 @@ export default class DevicePurgeCmd extends Command {
 			description: 'comma-separated list (no blank spaces) of device UUIDs',
 			required: true,
 		}),
-	};
-
-	public static flags = {
-		help: cf.help,
 	};
 
 	public static authenticated = true;

--- a/src/commands/device/reboot.ts
+++ b/src/commands/device/reboot.ts
@@ -37,7 +37,6 @@ export default class DeviceRebootCmd extends Command {
 
 	public static flags = {
 		force: cf.force,
-		help: cf.help,
 	};
 
 	public static authenticated = true;

--- a/src/commands/device/register.ts
+++ b/src/commands/device/register.ts
@@ -17,7 +17,6 @@
 
 import { Flags } from '@oclif/core';
 import Command from '../../command';
-import * as cf from '../../utils/common-flags';
 import * as ca from '../../utils/common-args';
 import { getBalenaSdk, stripIndent } from '../../utils/lazy';
 import { applicationIdInfo } from '../../utils/messages';
@@ -53,7 +52,6 @@ export default class DeviceRegisterCmd extends Command {
 			description:
 				"device type slug (run 'balena devices supported' for possible values)",
 		}),
-		help: cf.help,
 	};
 
 	public static authenticated = true;

--- a/src/commands/device/rename.ts
+++ b/src/commands/device/rename.ts
@@ -17,7 +17,6 @@
 
 import { Args } from '@oclif/core';
 import Command from '../../command';
-import * as cf from '../../utils/common-flags';
 import { getBalenaSdk, stripIndent, getCliForm } from '../../utils/lazy';
 
 export default class DeviceRenameCmd extends Command {
@@ -41,10 +40,6 @@ export default class DeviceRenameCmd extends Command {
 		newName: Args.string({
 			description: 'the new name for the device',
 		}),
-	};
-
-	public static flags = {
-		help: cf.help,
 	};
 
 	public static authenticated = true;

--- a/src/commands/device/restart.ts
+++ b/src/commands/device/restart.ts
@@ -17,7 +17,6 @@
 
 import { Flags, Args } from '@oclif/core';
 import Command from '../../command';
-import * as cf from '../../utils/common-flags';
 import { getBalenaSdk, getCliUx, stripIndent } from '../../utils/lazy';
 import type {
 	BalenaSDK,
@@ -59,7 +58,6 @@ export default class DeviceRestartCmd extends Command {
 				'comma-separated list (no blank spaces) of service names to restart',
 			char: 's',
 		}),
-		help: cf.help,
 	};
 
 	public static authenticated = true;

--- a/src/commands/device/rm.ts
+++ b/src/commands/device/rm.ts
@@ -45,7 +45,6 @@ export default class DeviceRmCmd extends Command {
 
 	public static flags = {
 		yes: cf.yes,
-		help: cf.help,
 	};
 
 	public static authenticated = true;

--- a/src/commands/device/shutdown.ts
+++ b/src/commands/device/shutdown.ts
@@ -38,7 +38,6 @@ export default class DeviceShutdownCmd extends Command {
 
 	public static flags = {
 		force: cf.force,
-		help: cf.help,
 	};
 
 	public static authenticated = true;

--- a/src/commands/device/start-service.ts
+++ b/src/commands/device/start-service.ts
@@ -17,7 +17,6 @@
 
 import { Args } from '@oclif/core';
 import Command from '../../command';
-import * as cf from '../../utils/common-flags';
 import { getBalenaSdk, getCliUx, stripIndent } from '../../utils/lazy';
 import type { BalenaSDK } from 'balena-sdk';
 
@@ -44,10 +43,6 @@ export default class DeviceStartServiceCmd extends Command {
 			description: 'comma-separated list (no blank spaces) of service names',
 			required: true,
 		}),
-	};
-
-	public static flags = {
-		help: cf.help,
 	};
 
 	public static authenticated = true;

--- a/src/commands/device/stop-service.ts
+++ b/src/commands/device/stop-service.ts
@@ -17,7 +17,6 @@
 
 import { Args } from '@oclif/core';
 import Command from '../../command';
-import * as cf from '../../utils/common-flags';
 import { getBalenaSdk, getCliUx, stripIndent } from '../../utils/lazy';
 import type { BalenaSDK } from 'balena-sdk';
 
@@ -44,10 +43,6 @@ export default class DeviceStopServiceCmd extends Command {
 			description: 'comma-separated list (no blank spaces) of service names',
 			required: true,
 		}),
-	};
-
-	public static flags = {
-		help: cf.help,
 	};
 
 	public static authenticated = true;

--- a/src/commands/device/track-fleet.ts
+++ b/src/commands/device/track-fleet.ts
@@ -17,7 +17,6 @@
 
 import { Args } from '@oclif/core';
 import Command from '../../command';
-import * as cf from '../../utils/common-flags';
 import { getBalenaSdk, stripIndent } from '../../utils/lazy';
 
 export default class DeviceTrackFleetCmd extends Command {
@@ -33,10 +32,6 @@ export default class DeviceTrackFleetCmd extends Command {
 			description: "the uuid of the device to make track the fleet's release",
 			required: true,
 		}),
-	};
-
-	public static flags = {
-		help: cf.help,
 	};
 
 	public static authenticated = true;

--- a/src/commands/devices/supported.ts
+++ b/src/commands/devices/supported.ts
@@ -18,8 +18,6 @@ import { Flags } from '@oclif/core';
 import type * as BalenaSdk from 'balena-sdk';
 import * as _ from 'lodash';
 import Command from '../../command';
-
-import * as cf from '../../utils/common-flags';
 import { getBalenaSdk, getVisuals, stripIndent } from '../../utils/lazy';
 
 export default class DevicesSupportedCmd extends Command {
@@ -40,7 +38,6 @@ export default class DevicesSupportedCmd extends Command {
 	];
 
 	public static flags = {
-		help: cf.help,
 		json: Flags.boolean({
 			char: 'j',
 			description: 'produce JSON output instead of tabular output',

--- a/src/commands/env/add.ts
+++ b/src/commands/env/add.ts
@@ -26,7 +26,6 @@ import { applicationIdInfo } from '../../utils/messages';
 interface FlagsDef {
 	fleet?: string;
 	device?: string; // device UUID
-	help: void;
 	quiet: boolean;
 	service?: string; // service name
 }
@@ -96,7 +95,6 @@ export default class EnvAddCmd extends Command {
 	public static flags = {
 		fleet: { ...cf.fleet, exclusive: ['device'] },
 		device: { ...cf.device, exclusive: ['fleet'] },
-		help: cf.help,
 		quiet: cf.quiet,
 		service: cf.service,
 	};

--- a/src/commands/env/rename.ts
+++ b/src/commands/env/rename.ts
@@ -16,8 +16,6 @@
  */
 import { Args } from '@oclif/core';
 import Command from '../../command';
-
-import * as cf from '../../utils/common-flags';
 import * as ec from '../../utils/env-common';
 import { getBalenaSdk, stripIndent } from '../../utils/lazy';
 import { parseAsInteger } from '../../utils/validation';
@@ -57,7 +55,6 @@ export default class EnvRenameCmd extends Command {
 		config: ec.booleanConfig,
 		device: ec.booleanDevice,
 		service: ec.booleanService,
-		help: cf.help,
 	};
 
 	public async run() {

--- a/src/commands/envs/index.ts
+++ b/src/commands/envs/index.ts
@@ -103,7 +103,6 @@ export default class EnvsCmd extends Command {
 			exclusive: ['service'],
 		}),
 		device: { ...cf.device, exclusive: ['fleet'] },
-		help: cf.help,
 		json: cf.json,
 		service: { ...cf.service, exclusive: ['config'] },
 	};

--- a/src/commands/fleet/create.ts
+++ b/src/commands/fleet/create.ts
@@ -18,7 +18,6 @@
 import { Flags, Args } from '@oclif/core';
 
 import Command from '../../command';
-import * as cf from '../../utils/common-flags';
 import { stripIndent } from '../../utils/lazy';
 
 export default class FleetCreateCmd extends Command {
@@ -66,7 +65,6 @@ export default class FleetCreateCmd extends Command {
 			description:
 				'fleet device type (Check available types with `balena devices supported`)',
 		}),
-		help: cf.help,
 	};
 
 	public static authenticated = true;

--- a/src/commands/fleet/index.ts
+++ b/src/commands/fleet/index.ts
@@ -42,7 +42,6 @@ export default class FleetCmd extends Command {
 	};
 
 	public static flags = {
-		help: cf.help,
 		view: Flags.boolean({
 			default: false,
 			description: 'open fleet dashboard page',

--- a/src/commands/fleet/pin.ts
+++ b/src/commands/fleet/pin.ts
@@ -17,7 +17,6 @@
 
 import { Args } from '@oclif/core';
 import Command from '../../command';
-import * as cf from '../../utils/common-flags';
 import { getBalenaSdk, stripIndent } from '../../utils/lazy';
 import { getExpandedProp } from '../../utils/pine';
 
@@ -42,10 +41,6 @@ export default class FleetPinCmd extends Command {
 		releaseToPinTo: Args.string({
 			description: 'the commit of the release for the fleet to get pinned to',
 		}),
-	};
-
-	public static flags = {
-		help: cf.help,
 	};
 
 	public static authenticated = true;

--- a/src/commands/fleet/purge.ts
+++ b/src/commands/fleet/purge.ts
@@ -16,7 +16,6 @@
  */
 
 import Command from '../../command';
-import * as cf from '../../utils/common-flags';
 import * as ca from '../../utils/common-args';
 import { getBalenaSdk, stripIndent } from '../../utils/lazy';
 import { applicationIdInfo } from '../../utils/messages';
@@ -38,10 +37,6 @@ export default class FleetPurgeCmd extends Command {
 
 	public static args = {
 		fleet: ca.fleetRequired,
-	};
-
-	public static flags = {
-		help: cf.help,
 	};
 
 	public static authenticated = true;

--- a/src/commands/fleet/rename.ts
+++ b/src/commands/fleet/rename.ts
@@ -16,9 +16,7 @@
  */
 
 import { Args } from '@oclif/core';
-
 import Command from '../../command';
-import * as cf from '../../utils/common-flags';
 import * as ca from '../../utils/common-args';
 import { getBalenaSdk, stripIndent, getCliForm } from '../../utils/lazy';
 import { applicationIdInfo } from '../../utils/messages';
@@ -46,10 +44,6 @@ export default class FleetRenameCmd extends Command {
 		newName: Args.string({
 			description: 'the new name for the fleet',
 		}),
-	};
-
-	public static flags = {
-		help: cf.help,
 	};
 
 	public static authenticated = true;

--- a/src/commands/fleet/restart.ts
+++ b/src/commands/fleet/restart.ts
@@ -16,7 +16,6 @@
  */
 
 import Command from '../../command';
-import * as cf from '../../utils/common-flags';
 import * as ca from '../../utils/common-args';
 import { getBalenaSdk, stripIndent } from '../../utils/lazy';
 import { applicationIdInfo } from '../../utils/messages';
@@ -37,10 +36,6 @@ export default class FleetRestartCmd extends Command {
 
 	public static args = {
 		fleet: ca.fleetRequired,
-	};
-
-	public static flags = {
-		help: cf.help,
 	};
 
 	public static authenticated = true;

--- a/src/commands/fleet/rm.ts
+++ b/src/commands/fleet/rm.ts
@@ -44,7 +44,6 @@ export default class FleetRmCmd extends Command {
 
 	public static flags = {
 		yes: cf.yes,
-		help: cf.help,
 	};
 
 	public static authenticated = true;

--- a/src/commands/fleet/track-latest.ts
+++ b/src/commands/fleet/track-latest.ts
@@ -17,7 +17,6 @@
 
 import { Args } from '@oclif/core';
 import Command from '../../command';
-import * as cf from '../../utils/common-flags';
 import { getBalenaSdk, stripIndent } from '../../utils/lazy';
 
 export default class FleetTrackLatestCmd extends Command {
@@ -36,10 +35,6 @@ export default class FleetTrackLatestCmd extends Command {
 			description: 'the slug of the fleet to make track the latest release',
 			required: true,
 		}),
-	};
-
-	public static flags = {
-		help: cf.help,
 	};
 
 	public static authenticated = true;

--- a/src/commands/fleets/index.ts
+++ b/src/commands/fleets/index.ts
@@ -40,7 +40,6 @@ export default class FleetsCmd extends Command {
 	public static examples = ['$ balena fleets'];
 
 	public static flags = {
-		help: cf.help,
 		json: cf.json,
 	};
 

--- a/src/commands/join/index.ts
+++ b/src/commands/join/index.ts
@@ -66,7 +66,6 @@ export default class JoinCmd extends Command {
 			description: 'the interval in minutes to check for updates',
 			char: 'i',
 		}),
-		help: cf.help,
 	};
 
 	public static authenticated = true;

--- a/src/commands/key/add.ts
+++ b/src/commands/key/add.ts
@@ -18,7 +18,6 @@
 import { Args } from '@oclif/core';
 import Command from '../../command';
 import { ExpectedError } from '../../errors';
-import * as cf from '../../utils/common-flags';
 import { getBalenaSdk, stripIndent } from '../../utils/lazy';
 
 export default class KeyAddCmd extends Command {
@@ -59,10 +58,6 @@ export default class KeyAddCmd extends Command {
 		path: Args.string({
 			description: `the path to the public key file`,
 		}),
-	};
-
-	public static flags = {
-		help: cf.help,
 	};
 
 	public static authenticated = true;

--- a/src/commands/key/index.ts
+++ b/src/commands/key/index.ts
@@ -17,7 +17,6 @@
 
 import { Args } from '@oclif/core';
 import Command from '../../command';
-import * as cf from '../../utils/common-flags';
 import { getBalenaSdk, getVisuals, stripIndent } from '../../utils/lazy';
 import { parseAsInteger } from '../../utils/validation';
 
@@ -36,10 +35,6 @@ export default class KeyCmd extends Command {
 			parse: async (x) => parseAsInteger(x, 'id'),
 			required: true,
 		}),
-	};
-
-	public static flags = {
-		help: cf.help,
 	};
 
 	public static authenticated = true;

--- a/src/commands/key/rm.ts
+++ b/src/commands/key/rm.ts
@@ -42,7 +42,6 @@ export default class KeyRmCmd extends Command {
 
 	public static flags = {
 		yes: cf.yes,
-		help: cf.help,
 	};
 
 	public static authenticated = true;

--- a/src/commands/keys/index.ts
+++ b/src/commands/keys/index.ts
@@ -16,7 +16,6 @@
  */
 
 import Command from '../../command';
-import * as cf from '../../utils/common-flags';
 import { getBalenaSdk, getVisuals, stripIndent } from '../../utils/lazy';
 
 export default class KeysCmd extends Command {
@@ -26,10 +25,6 @@ export default class KeysCmd extends Command {
 		List all SSH keys registered in balenaCloud for the logged in user.
 	`;
 	public static examples = ['$ balena keys'];
-
-	public static flags = {
-		help: cf.help,
-	};
 
 	public static authenticated = true;
 

--- a/src/commands/leave/index.ts
+++ b/src/commands/leave/index.ts
@@ -17,7 +17,6 @@
 
 import { Args } from '@oclif/core';
 import Command from '../../command';
-import * as cf from '../../utils/common-flags';
 import { stripIndent } from '../../utils/lazy';
 import { parseAsLocalHostnameOrIp } from '../../utils/validation';
 
@@ -48,10 +47,6 @@ export default class LeaveCmd extends Command {
 			description: 'the device IP or hostname',
 			parse: parseAsLocalHostnameOrIp,
 		}),
-	};
-
-	public static flags = {
-		help: cf.help,
 	};
 
 	public static authenticated = true;

--- a/src/commands/local/configure.ts
+++ b/src/commands/local/configure.ts
@@ -18,7 +18,6 @@
 import { Args } from '@oclif/core';
 import { promisify } from 'util';
 import Command from '../../command';
-import * as cf from '../../utils/common-flags';
 import { stripIndent } from '../../utils/lazy';
 
 export default class LocalConfigureCmd extends Command {
@@ -38,10 +37,6 @@ export default class LocalConfigureCmd extends Command {
 			description: 'path of drive or image to configure',
 			required: true,
 		}),
-	};
-
-	public static flags = {
-		help: cf.help,
 	};
 
 	public static root = true;

--- a/src/commands/local/flash.ts
+++ b/src/commands/local/flash.ts
@@ -49,7 +49,6 @@ export default class LocalFlashCmd extends Command {
 	public static flags = {
 		drive: cf.drive,
 		yes: cf.yes,
-		help: cf.help,
 	};
 
 	public static offlineCompatible = true;

--- a/src/commands/login/index.ts
+++ b/src/commands/login/index.ts
@@ -17,7 +17,6 @@
 
 import { Flags, Args } from '@oclif/core';
 import Command from '../../command';
-import * as cf from '../../utils/common-flags';
 import { getBalenaSdk, stripIndent, getCliForm } from '../../utils/lazy';
 import { ExpectedError } from '../../errors';
 import type { WhoamiResult } from 'balena-sdk';
@@ -30,7 +29,6 @@ interface FlagsDef {
 	user?: string;
 	password?: string;
 	port?: number;
-	help: void;
 	hideExperimentalWarning: boolean;
 }
 
@@ -112,7 +110,6 @@ export default class LoginCmd extends Command {
 			default: false,
 			description: 'Hides warning for experimental features',
 		}),
-		help: cf.help,
 	};
 
 	public static primary = true;

--- a/src/commands/logs/index.ts
+++ b/src/commands/logs/index.ts
@@ -17,7 +17,6 @@
 
 import { Flags, Args } from '@oclif/core';
 import Command from '../../command';
-import * as cf from '../../utils/common-flags';
 import { getBalenaSdk, stripIndent } from '../../utils/lazy';
 import type { LogMessage } from 'balena-sdk';
 
@@ -85,7 +84,6 @@ export default class LogsCmd extends Command {
 				'Only show system logs. This can be used in combination with --service.',
 			char: 'S',
 		}),
-		help: cf.help,
 	};
 
 	public static primary = true;

--- a/src/commands/notes/index.ts
+++ b/src/commands/notes/index.ts
@@ -48,7 +48,6 @@ export default class NoteCmd extends Command {
 			exclusive: ['device'],
 			hidden: true,
 		}),
-		help: cf.help,
 	};
 
 	public static authenticated = true;

--- a/src/commands/orgs/index.ts
+++ b/src/commands/orgs/index.ts
@@ -16,7 +16,6 @@
  */
 
 import Command from '../../command';
-import * as cf from '../../utils/common-flags';
 import { getBalenaSdk, getVisuals, stripIndent } from '../../utils/lazy';
 
 export default class OrgsCmd extends Command {
@@ -26,10 +25,6 @@ export default class OrgsCmd extends Command {
 		list all the organizations that you are a member of.
 `;
 	public static examples = ['$ balena orgs'];
-
-	public static flags = {
-		help: cf.help,
-	};
 
 	public static authenticated = true;
 

--- a/src/commands/os/build-config.ts
+++ b/src/commands/os/build-config.ts
@@ -17,7 +17,6 @@
 
 import { Flags, Args } from '@oclif/core';
 import Command from '../../command';
-import * as cf from '../../utils/common-flags';
 import { getCliForm, stripIndent } from '../../utils/lazy';
 import * as _ from 'lodash';
 import type { DeviceTypeJson } from 'balena-sdk';
@@ -56,7 +55,6 @@ export default class OsBuildConfigCmd extends Command {
 			char: 'o',
 			required: true,
 		}),
-		help: cf.help,
 	};
 
 	public static authenticated = true;

--- a/src/commands/os/configure.ts
+++ b/src/commands/os/configure.ts
@@ -155,7 +155,6 @@ export default class OsConfigureCmd extends Command {
 				'expiry date assigned to generated provisioning api key (format: YYYY-MM-DD)',
 			exclusive: ['config', 'device'],
 		}),
-		help: cf.help,
 	};
 
 	public static authenticated = true;

--- a/src/commands/os/download.ts
+++ b/src/commands/os/download.ts
@@ -17,7 +17,6 @@
 
 import { Flags, Args } from '@oclif/core';
 import Command from '../../command';
-import * as cf from '../../utils/common-flags';
 import { stripIndent } from '../../utils/lazy';
 
 export default class OsDownloadCmd extends Command {
@@ -79,7 +78,6 @@ export default class OsDownloadCmd extends Command {
 				or 'menu-esr' (interactive menu, ESR versions)
 				`,
 		}),
-		help: cf.help,
 	};
 
 	public async run() {

--- a/src/commands/os/initialize.ts
+++ b/src/commands/os/initialize.ts
@@ -52,7 +52,6 @@ export default class OsInitializeCmd extends Command {
 		type: cf.deviceType,
 		drive: cf.drive,
 		yes: cf.yes,
-		help: cf.help,
 	};
 
 	public static authenticated = true;

--- a/src/commands/os/versions.ts
+++ b/src/commands/os/versions.ts
@@ -17,7 +17,6 @@
 
 import { Flags, Args } from '@oclif/core';
 import Command from '../../command';
-import * as cf from '../../utils/common-flags';
 import { stripIndent } from '../../utils/lazy';
 
 export default class OsVersionsCmd extends Command {
@@ -41,7 +40,6 @@ export default class OsVersionsCmd extends Command {
 	};
 
 	public static flags = {
-		help: cf.help,
 		esr: Flags.boolean({
 			description: 'select balenaOS ESR versions',
 			default: false,

--- a/src/commands/push/index.ts
+++ b/src/commands/push/index.ts
@@ -18,7 +18,6 @@
 import { Flags, Args } from '@oclif/core';
 import type { Interfaces } from '@oclif/core';
 import Command from '../../command';
-import * as cf from '../../utils/common-flags';
 import { getBalenaSdk, stripIndent } from '../../utils/lazy';
 import { dockerignoreHelp, registrySecretsHelp } from '../../utils/messages';
 import type { BalenaSDK } from 'balena-sdk';
@@ -219,7 +218,6 @@ export default class PushCmd extends Command {
 			default: false,
 		}),
 		note: Flags.string({ description: 'The notes for this release' }),
-		help: cf.help,
 	};
 
 	public static primary = true;

--- a/src/commands/release/finalize.ts
+++ b/src/commands/release/finalize.ts
@@ -17,7 +17,6 @@
 
 import { commitOrIdArg } from '.';
 import Command from '../../command';
-import * as cf from '../../utils/common-flags';
 import { getBalenaSdk, stripIndent } from '../../utils/lazy';
 
 export default class ReleaseFinalizeCmd extends Command {
@@ -39,10 +38,6 @@ export default class ReleaseFinalizeCmd extends Command {
 		'$ balena release finalize a777f7345fe3d655c1c981aa642e5555',
 		'$ balena release finalize 1234567',
 	];
-
-	public static flags = {
-		help: cf.help,
-	};
 
 	public static args = {
 		commitOrId: commitOrIdArg({

--- a/src/commands/release/index.ts
+++ b/src/commands/release/index.ts
@@ -44,7 +44,6 @@ export default class ReleaseCmd extends Command {
 
 	public static flags = {
 		json: cf.json,
-		help: cf.help,
 		composition: Flags.boolean({
 			default: false,
 			char: 'c',

--- a/src/commands/release/invalidate.ts
+++ b/src/commands/release/invalidate.ts
@@ -17,7 +17,6 @@
 
 import { commitOrIdArg } from '.';
 import Command from '../../command';
-import * as cf from '../../utils/common-flags';
 import { getBalenaSdk, stripIndent } from '../../utils/lazy';
 
 export default class ReleaseInvalidateCmd extends Command {
@@ -34,10 +33,6 @@ export default class ReleaseInvalidateCmd extends Command {
 		'$ balena release invalidate a777f7345fe3d655c1c981aa642e5555',
 		'$ balena release invalidate 1234567',
 	];
-
-	public static flags = {
-		help: cf.help,
-	};
 
 	public static args = {
 		commitOrId: commitOrIdArg({

--- a/src/commands/release/validate.ts
+++ b/src/commands/release/validate.ts
@@ -17,7 +17,6 @@
 
 import { commitOrIdArg } from '.';
 import Command from '../../command';
-import * as cf from '../../utils/common-flags';
 import { getBalenaSdk, stripIndent } from '../../utils/lazy';
 
 export default class ReleaseValidateCmd extends Command {
@@ -33,10 +32,6 @@ export default class ReleaseValidateCmd extends Command {
 		'$ balena release validate a777f7345fe3d655c1c981aa642e5555',
 		'$ balena release validate 1234567',
 	];
-
-	public static flags = {
-		help: cf.help,
-	};
 
 	public static args = {
 		commitOrId: commitOrIdArg({

--- a/src/commands/releases/index.ts
+++ b/src/commands/releases/index.ts
@@ -40,7 +40,6 @@ export default class ReleasesCmd extends Command {
 
 	public static flags = {
 		json: cf.json,
-		help: cf.help,
 	};
 
 	public static args = {

--- a/src/commands/scan/index.ts
+++ b/src/commands/scan/index.ts
@@ -17,7 +17,6 @@
 
 import { Flags } from '@oclif/core';
 import Command from '../../command';
-import * as cf from '../../utils/common-flags';
 import { getCliUx, stripIndent } from '../../utils/lazy';
 
 export default class ScanCmd extends Command {
@@ -48,7 +47,6 @@ export default class ScanCmd extends Command {
 			char: 't',
 			description: 'scan timeout in seconds',
 		}),
-		help: cf.help,
 		json: Flags.boolean({
 			default: false,
 			char: 'j',

--- a/src/commands/settings/index.ts
+++ b/src/commands/settings/index.ts
@@ -16,7 +16,6 @@
  */
 
 import Command from '../../command';
-import * as cf from '../../utils/common-flags';
 import { getBalenaSdk, stripIndent } from '../../utils/lazy';
 
 export default class SettingsCmd extends Command {
@@ -26,10 +25,6 @@ export default class SettingsCmd extends Command {
 		Use this command to display the current balena CLI settings.
 `;
 	public static examples = ['$ balena settings'];
-
-	public static flags = {
-		help: cf.help,
-	};
 
 	public async run() {
 		await this.parse(SettingsCmd);

--- a/src/commands/ssh/index.ts
+++ b/src/commands/ssh/index.ts
@@ -17,7 +17,6 @@
 
 import { Flags, Args } from '@oclif/core';
 import Command from '../../command';
-import * as cf from '../../utils/common-flags';
 import { getBalenaSdk, stripIndent } from '../../utils/lazy';
 import {
 	parseAsInteger,
@@ -98,7 +97,6 @@ export default class SshCmd extends Command {
 			default: false,
 			description: 'bypass global proxy configuration for the ssh connection',
 		}),
-		help: cf.help,
 	};
 
 	public static primary = true;

--- a/src/commands/support/index.ts
+++ b/src/commands/support/index.ts
@@ -67,7 +67,6 @@ export default class SupportCmd extends Command {
 				'length of time to enable support for, in (h)ours or (d)ays, e.g. 12h, 2d',
 			char: 't',
 		}),
-		help: cf.help,
 	};
 
 	public static authenticated = true;

--- a/src/commands/tag/rm.ts
+++ b/src/commands/tag/rm.ts
@@ -58,7 +58,6 @@ export default class TagRmCmd extends Command {
 			...cf.release,
 			exclusive: ['fleet', 'device'],
 		},
-		help: cf.help,
 	};
 
 	public static authenticated = true;

--- a/src/commands/tag/set.ts
+++ b/src/commands/tag/set.ts
@@ -72,7 +72,6 @@ export default class TagSetCmd extends Command {
 			...cf.release,
 			exclusive: ['fleet', 'device'],
 		},
-		help: cf.help,
 	};
 
 	public static authenticated = true;

--- a/src/commands/tags/index.ts
+++ b/src/commands/tags/index.ts
@@ -51,7 +51,6 @@ export default class TagsCmd extends Command {
 			...cf.release,
 			exclusive: ['fleet', 'device'],
 		},
-		help: cf.help,
 	};
 
 	public static authenticated = true;

--- a/src/commands/tunnel/index.ts
+++ b/src/commands/tunnel/index.ts
@@ -22,7 +22,6 @@ import {
 	InvalidPortMappingError,
 	ExpectedError,
 } from '../../errors';
-import * as cf from '../../utils/common-flags';
 import { getBalenaSdk, stripIndent } from '../../utils/lazy';
 import { lowercaseIfSlug } from '../../utils/normalization';
 
@@ -85,7 +84,6 @@ export default class TunnelCmd extends Command {
 			char: 'p',
 			multiple: true,
 		}),
-		help: cf.help,
 	};
 
 	public static primary = true;

--- a/src/commands/util/available-drives.ts
+++ b/src/commands/util/available-drives.ts
@@ -16,7 +16,6 @@
  */
 
 import Command from '../../command';
-import * as cf from '../../utils/common-flags';
 import { stripIndent, getChalk, getVisuals } from '../../utils/lazy';
 
 export default class UtilAvailableDrivesCmd extends Command {
@@ -26,10 +25,6 @@ export default class UtilAvailableDrivesCmd extends Command {
 		List available drives which are usable for writing an OS image to.
 		Does not list system drives.
 	`;
-
-	public static flags = {
-		help: cf.help,
-	};
 
 	public static offlineCompatible = true;
 

--- a/src/utils/application-create.ts
+++ b/src/utils/application-create.ts
@@ -4,7 +4,6 @@ import { getBalenaSdk } from './lazy';
 export interface FlagsDef {
 	organization?: string;
 	type?: string; // application device type
-	help: void;
 }
 
 export interface ArgsDef {

--- a/src/utils/common-flags.ts
+++ b/src/utils/common-flags.ts
@@ -30,8 +30,6 @@ export const device = Flags.string({
 	description: 'device UUID',
 });
 
-export const help = Flags.help({ char: 'h' });
-
 export const quiet = Flags.boolean({
 	char: 'q',
 	description: 'suppress warning messages',


### PR DESCRIPTION
Stop manually inserting `help` flag per command since oclif includes it automatically

Change-type: patch

---
Please check the CONTRIBUTING.md file for relevant information and some
guidance. Keep in mind that the CLI is a cross-platform application that runs
on Windows, macOS and Linux. Tests will be automatically run by balena CI on
all three operating systems, but this will only help if you have added test
code that exercises the modified or added feature code.

Note that each commit message (currently only the first line) will be
automatically copied to the CHANGELOG.md file, so try writing it in a way
that describes the feature or fix for CLI users.

If there isn't a linked issue or if the linked issue doesn't quite match the
PR, please add a PR description to explain its purpose or the features that it
implements. Adding PR comments to blocks of code that aren't self explanatory
usually helps with the review process.

If the PR introduces security considerations or affects the development, build
or release process, please be sure to highlight this in the PR description.

Thank you very much for your contribution!
