### PR TITLE
Restore ability to cat key into `ssh-key add`

### DIFF
--- a/src/commands/ssh-key/add.ts
+++ b/src/commands/ssh-key/add.ts
@@ -16,7 +16,6 @@
  */
 
 import { Args, Command } from '@oclif/core';
-import { ExpectedError } from '../../errors';
 import { getBalenaSdk, stripIndent } from '../../utils/lazy';
 
 export default class SSHKeyAddCmd extends Command {
@@ -59,6 +58,7 @@ export default class SSHKeyAddCmd extends Command {
 		}),
 		path: Args.string({
 			description: `the path to the public key file`,
+			required: true,
 		}),
 	};
 
@@ -67,12 +67,12 @@ export default class SSHKeyAddCmd extends Command {
 	public async run() {
 		const { args: params } = await this.parse(SSHKeyAddCmd);
 
+		const { readFile } = (await import('fs')).promises;
 		let key: string;
-		if (params.path != null) {
-			const { readFile } = (await import('fs')).promises;
+		try {
 			key = await readFile(params.path, 'utf8');
-		} else {
-			throw new ExpectedError('No public key file or path provided.');
+		} catch {
+			key = params.path;
 		}
 
 		await getBalenaSdk().models.key.create(params.name, key);


### PR DESCRIPTION
Restore ability to cat key into `ssh-key add`

Change-type: patch

---
Please check the CONTRIBUTING.md file for relevant information and some
guidance. Keep in mind that the CLI is a cross-platform application that runs
on Windows, macOS and Linux. Tests will be automatically run by balena CI on
all three operating systems, but this will only help if you have added test
code that exercises the modified or added feature code.

Note that each commit message (currently only the first line) will be
automatically copied to the CHANGELOG.md file, so try writing it in a way
that describes the feature or fix for CLI users.

If there isn't a linked issue or if the linked issue doesn't quite match the
PR, please add a PR description to explain its purpose or the features that it
implements. Adding PR comments to blocks of code that aren't self explanatory
usually helps with the review process.

If the PR introduces security considerations or affects the development, build
or release process, please be sure to highlight this in the PR description.

Thank you very much for your contribution!
