### PR TITLE
Update package used to find image manifest

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -17,7 +17,7 @@
         "@oclif/core": "^4.0.31",
         "@sentry/node": "^6.16.1",
         "balena-config-json": "^4.2.0",
-        "balena-device-init": "^7.0.1",
+        "balena-device-init": "8.0.0-build-decaffeinate-67ac7d853a63cde2d4a89347889b2ee42748cd5c-1",
         "balena-errors": "^4.7.3",
         "balena-image-fs": "^7.0.6",
         "balena-preload": "^16.0.0",
@@ -5887,13 +5887,13 @@
       }
     },
     "node_modules/balena-device-init": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/balena-device-init/-/balena-device-init-7.0.1.tgz",
-      "integrity": "sha512-C3p1VNmeMNtkTTgs5xFvBQFdeOMxVzv0EL53nhnUx4WsNXQYQitlTwTmaQ96pBjHnZ4q+w4w3/Ubebjhan8bnQ==",
+      "version": "8.0.0-build-decaffeinate-67ac7d853a63cde2d4a89347889b2ee42748cd5c-1",
+      "resolved": "https://registry.npmjs.org/balena-device-init/-/balena-device-init-8.0.0-build-decaffeinate-67ac7d853a63cde2d4a89347889b2ee42748cd5c-1.tgz",
+      "integrity": "sha512-PN/yUbIBrRAZ+ztkUm/hRUgwyaLyjQuEhVC2k4J5zsQogBjijS/der995RyZ5gaKV/itu+FQADr+LBsGxpZmDg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "balena-image-fs": "^7.0.6",
         "balena-semver": "^2.2.0",
-        "bluebird": "^3.7.2",
         "lodash": "^4.17.15",
         "reconfix": "1.0.0-v0-1-0-fork-46760acff4d165f5238bfac5e464256ef1944476",
         "resin-device-operations": "^2.0.0",
@@ -5901,7 +5901,7 @@
         "string-to-stream": "^1.1.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20.6.0"
       }
     },
     "node_modules/balena-device-init/node_modules/string-to-stream": {

--- a/package.json
+++ b/package.json
@@ -196,7 +196,7 @@
     "@oclif/core": "^4.0.31",
     "@sentry/node": "^6.16.1",
     "balena-config-json": "^4.2.0",
-    "balena-device-init": "^7.0.1",
+    "balena-device-init": "8.0.0-build-decaffeinate-67ac7d853a63cde2d4a89347889b2ee42748cd5c-1",
     "balena-errors": "^4.7.3",
     "balena-image-fs": "^7.0.6",
     "balena-preload": "^16.0.0",


### PR DESCRIPTION
Plan is to update balena-device-init and balena-config-json to lookup up boot partition, rather than use hardcoded value of 1st partition

Change-type: patch

<!-- You can remove tags that do not apply. -->
Resolves: # <!-- Refer an issue of this repository that this PR fixes -->  
Change-type: major|minor|patch <!-- See https://semver.org/ -->  
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->  
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->  

---
Please check the CONTRIBUTING.md file for relevant information and some
guidance. Keep in mind that the CLI is a cross-platform application that runs
on Windows, macOS and Linux. Tests will be automatically run by balena CI on
all three operating systems, but this will only help if you have added test
code that exercises the modified or added feature code.

Note that each commit message (currently only the first line) will be
automatically copied to the CHANGELOG.md file, so try writing it in a way
that describes the feature or fix for CLI users.

If there isn't a linked issue or if the linked issue doesn't quite match the
PR, please add a PR description to explain its purpose or the features that it
implements. Adding PR comments to blocks of code that aren't self explanatory
usually helps with the review process.

If the PR introduces security considerations or affects the development, build
or release process, please be sure to highlight this in the PR description.

Thank you very much for your contribution!
