### PR TITLE
Update balena-preload to 17.0.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -20,7 +20,7 @@
         "balena-device-init": "^8.1.0",
         "balena-errors": "^4.7.3",
         "balena-image-fs": "^7.0.6",
-        "balena-preload": "^16.0.0",
+        "balena-preload": "^17.0.0",
         "balena-sdk": "^20.8.0",
         "balena-semver": "^2.3.0",
         "balena-settings-client": "^5.0.2",
@@ -7131,12 +7131,12 @@
       }
     },
     "node_modules/balena-preload": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/balena-preload/-/balena-preload-16.0.0.tgz",
-      "integrity": "sha512-IP+4Op6LHJW5ip/oomQmERjbNroKqi5atDI3s07aokgv/mH8J7jy4BOOW6JwnrHb560IQy/oPf4yM4h3qQlLEA==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/balena-preload/-/balena-preload-17.0.0.tgz",
+      "integrity": "sha512-J0pduyqFFsPC70jgLdw7nANILW5nUGuShKayZauVuGs18NuYKlu7UT7w/b6QOMYtDK+YGjMWEf0uHTdiSzKZQQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "balena-sdk": "^20.1.3",
-        "bluebird": "^3.7.2",
         "compare-versions": "^3.6.0",
         "docker-progress": "^5.0.0",
         "dockerode": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -199,7 +199,7 @@
     "balena-device-init": "^8.1.0",
     "balena-errors": "^4.7.3",
     "balena-image-fs": "^7.0.6",
-    "balena-preload": "^16.0.0",
+    "balena-preload": "^17.0.0",
     "balena-sdk": "^20.8.0",
     "balena-semver": "^2.3.0",
     "balena-settings-client": "^5.0.2",


### PR DESCRIPTION
Update balena-preload from 16.0.0 to 17.0.0

Change-type: patch
See: https://github.com/balena-io-modules/balena-preload/pull/298

<!-- You can remove tags that do not apply. -->
Resolves: # <!-- Refer an issue of this repository that this PR fixes -->  
Change-type: major|minor|patch <!-- See https://semver.org/ -->  
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->  
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->  

---
Please check the CONTRIBUTING.md file for relevant information and some
guidance. Keep in mind that the CLI is a cross-platform application that runs
on Windows, macOS and Linux. Tests will be automatically run by balena CI on
all three operating systems, but this will only help if you have added test
code that exercises the modified or added feature code.

Note that each commit message (currently only the first line) will be
automatically copied to the CHANGELOG.md file, so try writing it in a way
that describes the feature or fix for CLI users.

If there isn't a linked issue or if the linked issue doesn't quite match the
PR, please add a PR description to explain its purpose or the features that it
implements. Adding PR comments to blocks of code that aren't self explanatory
usually helps with the review process.

If the PR introduces security considerations or affects the development, build
or release process, please be sure to highlight this in the PR description.

Thank you very much for your contribution!
