### PR TITLE
Deny preload for an image with secure boot enabled

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -19,7 +19,7 @@
         "balena-config-json": "^4.2.2",
         "balena-device-init": "^8.1.3",
         "balena-errors": "^4.7.3",
-        "balena-image-fs": "^7.3.0",
+        "balena-image-fs": "^7.5.0",
         "balena-preload": "^18.0.1",
         "balena-sdk": "^21.3.0",
         "balena-semver": "^2.3.0",
@@ -7427,9 +7427,9 @@
       }
     },
     "node_modules/balena-image-fs": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/balena-image-fs/-/balena-image-fs-7.4.1.tgz",
-      "integrity": "sha512-md41m3Jo54EOj7ASrqCD2GJ+LtF9AmMT46dABIbaPvVerY1zUEW8rGfIfrgq4Tz3tL82y73spoVhcabtkaRj5A==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/balena-image-fs/-/balena-image-fs-7.5.0.tgz",
+      "integrity": "sha512-JVydPTG7hiaX6uAGxzc2HWlVASqXAnb1Ypg1zOU8M6H1US6cbcv3L2ZixHla9yzQnZOy4+SLgV4wc9A4T0CPcQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "ext2fs": "^4.2.4",

--- a/package.json
+++ b/package.json
@@ -199,7 +199,7 @@
     "balena-config-json": "^4.2.2",
     "balena-device-init": "^8.1.3",
     "balena-errors": "^4.7.3",
-    "balena-image-fs": "^7.3.0",
+    "balena-image-fs": "^7.5.0",
     "balena-preload": "^18.0.1",
     "balena-sdk": "^21.3.0",
     "balena-semver": "^2.3.0",

--- a/src/utils/image-contents.ts
+++ b/src/utils/image-contents.ts
@@ -1,0 +1,69 @@
+/**
+ * @license
+ * Copyright 2025 Balena Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Utilities to explore the contents in a balenaOS image.
+
+import * as imagefs from 'balena-image-fs';
+import * as filedisk from 'file-disk';
+import { getPartitions } from 'partitioninfo';
+import type * as Fs from 'fs';
+
+/**
+ * @summary IDs for the standard balenaOS partitions
+ * @description Values are the base name for a partition on disk
+ */
+export enum BalenaPartition {
+	BOOT = 'boot',
+	ROOTA = 'rootA',
+	ROOTB = 'rootB',
+	STATE = 'state',
+	DATA = 'data',
+}
+
+/**
+ * @summary Allow a provided function to explore the contents of one of the well-known
+ * partitions of a balenaOS image
+ *
+ * @param {string} imagePath - pathname of image for search
+ * @param {BalenaPartition} partitionId - partition to find
+ * @param {(fs) => Promise<T>} - function for exploration
+ * @returns {T}
+ */
+export async function explorePartition<T>(
+	imagePath: string,
+	partitionId: BalenaPartition,
+	exploreFn: (fs: typeof Fs) => Promise<T>,
+): Promise<T> {
+	return await filedisk.withOpenFile(imagePath, 'r', async (handle) => {
+		const disk = new filedisk.FileDisk(handle, true, false, false);
+		const partitionInfo = await getPartitions(disk, {
+			includeExtended: false,
+			getLogical: true,
+		});
+
+		const findResult = await imagefs.findPartition(disk, partitionInfo, [
+			`resin-${partitionId}`,
+			`flash-${partitionId}`,
+			`balena-${partitionId}`,
+		]);
+		if (findResult == null) {
+			throw new Error(`Can't find partition for ${partitionId}`);
+		}
+
+		return await imagefs.interact<T>(disk, findResult.index, exploreFn);
+	});
+}


### PR DESCRIPTION
Deny an attempt to preload an app into an image with secure boot enabled, and provide a message to the user. BalenaOS does not support this action.

Implementation includes a generic, callback-driven capability to explore a partition in `utils/explore-contents` module. Allows for the caller to determine success or failure.