### PR TITLE
Add comment with example of signature file in a flasher image

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2682,9 +2682,9 @@
       }
     },
     "node_modules/@inquirer/core/node_modules/@types/node": {
-      "version": "22.13.14",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.14.tgz",
-      "integrity": "sha512-Zs/Ollc1SJ8nKUAgc7ivOEdIBM8JAKgrqqUYi2J997JuKO7/tpQC+WCetQ1sypiKCQWHdvdg9wBNpUPEWZae7w==",
+      "version": "22.13.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.17.tgz",
+      "integrity": "sha512-nAJuQXoyPj04uLgu+obZcSmsfOenUg6DxPKogeUy6yNCFwWaj5sBF8/G/pNo8EtBJjAfSVgfIlugR/BCOleO+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5829,9 +5829,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.17.28",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.28.tgz",
-      "integrity": "sha512-DHlH/fNL6Mho38jTy7/JT7sn2wnXI+wULR6PV4gy4VHLVvnrV/d3pHAMQHhc4gjdLmK2ZiPoMxzp6B3yRajLSQ==",
+      "version": "20.17.30",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.30.tgz",
+      "integrity": "sha512-7zf4YyHA+jvBNfVrk2Gtvs6x7E8V+YDW05bNfG2XkWDJfYRXrTiP/DsB2zSYTaHX0bGIujTBQdMVAhb+j7mwpg==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
@@ -16338,9 +16338,9 @@
       }
     },
     "node_modules/patch-package/node_modules/yaml": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
-      "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
+      "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/src/commands/preload/index.ts
+++ b/src/commands/preload/index.ts
@@ -162,8 +162,13 @@ Can be repeated to add multiple certificates.\
 			);
 		}
 
-		// Verify that image is not enabled for secure boot. First, confirm it
-		// is a secure boot image with an /opt/*.sig file in the rootA partition.
+		// Verify that image is not enabled for secure boot. First, confirm it is
+		// a secure boot image with a .sig file in the /opt directory of the rootA
+		// partition. For example, below are contents for generic-amd64 device type:
+		// $ ls -l opt
+		// total 864696
+		// -rw-r--r-- 1 root root 2378170368 Mar 26 09:14 balena-image-generic-amd64.balenaos-img
+		// -rw-r--r-- 1 root root        512 Mar  9  2018 balena-image-generic-amd64.balenaos-img.sig
 		const { explorePartition, BalenaPartition } = await import(
 			'../../utils/image-contents'
 		);


### PR DESCRIPTION
Follow up to #2914. Adds a comment to illustrate presence of signature file in a flash-rootA partition. The `preload` command must determine if this file is present.