### PR TITLE
Fix build secrets serialization

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@balena/compose": "^7.0.1",
+        "@balena/compose": "^7.0.9",
         "@balena/dockerignore": "^1.0.2",
         "@balena/env-parsing": "^1.1.8",
         "@balena/es-version": "^1.0.1",
@@ -1282,9 +1282,9 @@
       "dev": true
     },
     "node_modules/@babel/parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.1.tgz",
-      "integrity": "sha512-I0dZ3ZpCrJ1c04OqlNsQcKiZlsrXf/kkE4FXzID9rIOYICsAbA8mMDzhW/luRNAHdCNt7os/u8wenklZDlUVUQ==",
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.2.tgz",
+      "integrity": "sha512-QYLs8299NA7WM/bZAdp+CviYYkVoYXlDW2rzliy3chxd1PQjej7JORuMJDJXJUb9g0TT+B99EwaVLKmX+sPXWw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1474,17 +1474,16 @@
       }
     },
     "node_modules/@balena/compose": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@balena/compose/-/compose-7.0.1.tgz",
-      "integrity": "sha512-Xic5WJg7i4D9y9TN+BnY8PYbQLLMewN8CR8i+fZ76GHWyBRfk9+tP3JUpmymvSaK9QTKC2UE2nFiadzbfyIFAg==",
+      "version": "7.0.9",
+      "resolved": "https://registry.npmjs.org/@balena/compose/-/compose-7.0.9.tgz",
+      "integrity": "sha512-fanVToln7hl0cL86X8lbwABxOb63sPRpPgK5An7ff/l2iVPhJ85hpUGC2NTQ83KUXX5yV6B55FVK0Ao84es2dw==",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^6.12.3",
         "docker-file-parser": "^1.0.7",
-        "docker-modem": "^5.0.3",
         "docker-progress": "^5.1.0",
-        "dockerfile-ast": "^0.2.1",
-        "dockerode": "^4.0.2",
+        "dockerfile-ast": "^0.7.0",
+        "dockerode": "^4.0.4",
         "duplexify": "^4.1.2",
         "event-stream": "^4.0.1",
         "fp-ts": "^2.8.1",
@@ -1665,9 +1664,9 @@
       }
     },
     "node_modules/@balena/lint/node_modules/@humanwhocodes/retry": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.2.tgz",
-      "integrity": "sha512-xeO57FpIu4p1Ri3Jq/EXq4ClRm86dVF2z/+kvFnyqVYRavTZmaFaUBbWCOuuTh0o/g7DSsk6kc2vrS4Vl5oPOQ==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -2519,9 +2518,9 @@
       }
     },
     "node_modules/@inquirer/checkbox/node_modules/@inquirer/core": {
-      "version": "10.1.10",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.10.tgz",
-      "integrity": "sha512-roDaKeY1PYY0aCqhRmXihrHjoSW2A00pV3Ke5fTpMCkzcGF64R8e0lw3dK+eLEHwS4vB5RnW1wuQmvzoRul8Mw==",
+      "version": "10.1.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.11.tgz",
+      "integrity": "sha512-BXwI/MCqdtAhzNQlBEFE7CEflhPkl/BqvAuV/aK6lW3DClIfYVDWPP/kXuXHtBWC7/EEbNqd/1BGq2BGBBnuxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2684,9 +2683,9 @@
       }
     },
     "node_modules/@inquirer/core/node_modules/@types/node": {
-      "version": "22.15.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.12.tgz",
-      "integrity": "sha512-K0fpC/ZVeb8G9rm7bH7vI0KAec4XHEhBam616nVJCV51bKzJ6oA3luG4WdKoaztxe70QaNjS/xBmcDLmr4PiGw==",
+      "version": "22.15.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.18.tgz",
+      "integrity": "sha512-v1DKRfUdyW+jJhZNEI1PYy29S2YRxMV5AOO/x/SjKmW0acCIOqmbj6Haf9eHAhsPmrhlHSxEhv/1WszcLWV4cg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2789,9 +2788,9 @@
       }
     },
     "node_modules/@inquirer/editor/node_modules/@inquirer/core": {
-      "version": "10.1.10",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.10.tgz",
-      "integrity": "sha512-roDaKeY1PYY0aCqhRmXihrHjoSW2A00pV3Ke5fTpMCkzcGF64R8e0lw3dK+eLEHwS4vB5RnW1wuQmvzoRul8Mw==",
+      "version": "10.1.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.11.tgz",
+      "integrity": "sha512-BXwI/MCqdtAhzNQlBEFE7CEflhPkl/BqvAuV/aK6lW3DClIfYVDWPP/kXuXHtBWC7/EEbNqd/1BGq2BGBBnuxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2949,9 +2948,9 @@
       }
     },
     "node_modules/@inquirer/expand/node_modules/@inquirer/core": {
-      "version": "10.1.10",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.10.tgz",
-      "integrity": "sha512-roDaKeY1PYY0aCqhRmXihrHjoSW2A00pV3Ke5fTpMCkzcGF64R8e0lw3dK+eLEHwS4vB5RnW1wuQmvzoRul8Mw==",
+      "version": "10.1.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.11.tgz",
+      "integrity": "sha512-BXwI/MCqdtAhzNQlBEFE7CEflhPkl/BqvAuV/aK6lW3DClIfYVDWPP/kXuXHtBWC7/EEbNqd/1BGq2BGBBnuxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3105,9 +3104,9 @@
       }
     },
     "node_modules/@inquirer/number/node_modules/@inquirer/core": {
-      "version": "10.1.10",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.10.tgz",
-      "integrity": "sha512-roDaKeY1PYY0aCqhRmXihrHjoSW2A00pV3Ke5fTpMCkzcGF64R8e0lw3dK+eLEHwS4vB5RnW1wuQmvzoRul8Mw==",
+      "version": "10.1.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.11.tgz",
+      "integrity": "sha512-BXwI/MCqdtAhzNQlBEFE7CEflhPkl/BqvAuV/aK6lW3DClIfYVDWPP/kXuXHtBWC7/EEbNqd/1BGq2BGBBnuxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3239,9 +3238,9 @@
       }
     },
     "node_modules/@inquirer/password/node_modules/@inquirer/core": {
-      "version": "10.1.10",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.10.tgz",
-      "integrity": "sha512-roDaKeY1PYY0aCqhRmXihrHjoSW2A00pV3Ke5fTpMCkzcGF64R8e0lw3dK+eLEHwS4vB5RnW1wuQmvzoRul8Mw==",
+      "version": "10.1.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.11.tgz",
+      "integrity": "sha512-BXwI/MCqdtAhzNQlBEFE7CEflhPkl/BqvAuV/aK6lW3DClIfYVDWPP/kXuXHtBWC7/EEbNqd/1BGq2BGBBnuxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3380,13 +3379,13 @@
       }
     },
     "node_modules/@inquirer/prompts/node_modules/@inquirer/confirm": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.9.tgz",
-      "integrity": "sha512-NgQCnHqFTjF7Ys2fsqK2WtnA8X1kHyInyG+nMIuHowVTIgIuS10T4AznI/PvbqSpJqjCUqNBlKGh1v3bwLFL4w==",
+      "version": "5.1.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.10.tgz",
+      "integrity": "sha512-FxbQ9giWxUWKUk2O5XZ6PduVnH2CZ/fmMKMBkH71MHJvWr7WL5AHKevhzF1L5uYWB2P548o1RzVxrNd3dpmk6g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.10",
+        "@inquirer/core": "^10.1.11",
         "@inquirer/type": "^3.0.6"
       },
       "engines": {
@@ -3402,9 +3401,9 @@
       }
     },
     "node_modules/@inquirer/prompts/node_modules/@inquirer/core": {
-      "version": "10.1.10",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.10.tgz",
-      "integrity": "sha512-roDaKeY1PYY0aCqhRmXihrHjoSW2A00pV3Ke5fTpMCkzcGF64R8e0lw3dK+eLEHwS4vB5RnW1wuQmvzoRul8Mw==",
+      "version": "10.1.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.11.tgz",
+      "integrity": "sha512-BXwI/MCqdtAhzNQlBEFE7CEflhPkl/BqvAuV/aK6lW3DClIfYVDWPP/kXuXHtBWC7/EEbNqd/1BGq2BGBBnuxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3430,13 +3429,13 @@
       }
     },
     "node_modules/@inquirer/prompts/node_modules/@inquirer/input": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.1.9.tgz",
-      "integrity": "sha512-mshNG24Ij5KqsQtOZMgj5TwEjIf+F2HOESk6bjMwGWgcH5UBe8UoljwzNFHqdMbGYbgAf6v2wU/X9CAdKJzgOA==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.1.10.tgz",
+      "integrity": "sha512-kV3BVne3wJ+j6reYQUZi/UN9NZGZLxgc/tfyjeK3mrx1QI7RXPxGp21IUTv+iVHcbP4ytZALF8vCHoxyNSC6qg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.10",
+        "@inquirer/core": "^10.1.11",
         "@inquirer/type": "^3.0.6"
       },
       "engines": {
@@ -3452,13 +3451,13 @@
       }
     },
     "node_modules/@inquirer/prompts/node_modules/@inquirer/select": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.2.0.tgz",
-      "integrity": "sha512-KkXQ4aSySWimpV4V/TUJWdB3tdfENZUU765GjOIZ0uPwdbGIG6jrxD4dDf1w68uP+DVtfNhr1A92B+0mbTZ8FA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.2.1.tgz",
+      "integrity": "sha512-gt1Kd5XZm+/ddemcT3m23IP8aD8rC9drRckWoP/1f7OL46Yy2FGi8DSmNjEjQKtPl6SV96Kmjbl6p713KXJ/Jg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.10",
+        "@inquirer/core": "^10.1.11",
         "@inquirer/figures": "^1.0.11",
         "@inquirer/type": "^3.0.6",
         "ansi-escapes": "^4.3.2",
@@ -3589,9 +3588,9 @@
       }
     },
     "node_modules/@inquirer/rawlist/node_modules/@inquirer/core": {
-      "version": "10.1.10",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.10.tgz",
-      "integrity": "sha512-roDaKeY1PYY0aCqhRmXihrHjoSW2A00pV3Ke5fTpMCkzcGF64R8e0lw3dK+eLEHwS4vB5RnW1wuQmvzoRul8Mw==",
+      "version": "10.1.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.11.tgz",
+      "integrity": "sha512-BXwI/MCqdtAhzNQlBEFE7CEflhPkl/BqvAuV/aK6lW3DClIfYVDWPP/kXuXHtBWC7/EEbNqd/1BGq2BGBBnuxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3724,9 +3723,9 @@
       }
     },
     "node_modules/@inquirer/search/node_modules/@inquirer/core": {
-      "version": "10.1.10",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.10.tgz",
-      "integrity": "sha512-roDaKeY1PYY0aCqhRmXihrHjoSW2A00pV3Ke5fTpMCkzcGF64R8e0lw3dK+eLEHwS4vB5RnW1wuQmvzoRul8Mw==",
+      "version": "10.1.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.11.tgz",
+      "integrity": "sha512-BXwI/MCqdtAhzNQlBEFE7CEflhPkl/BqvAuV/aK6lW3DClIfYVDWPP/kXuXHtBWC7/EEbNqd/1BGq2BGBBnuxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6228,9 +6227,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.17.41",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.41.tgz",
-      "integrity": "sha512-bOB0a6u/e7Ey/Gyc+ghRg+xoXFGYug4I7pdvwxudh+Ewmk93Z4wTudn4NIKiIRYQyujf9jm2uTBzQK8tg8oUeQ==",
+      "version": "20.17.47",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.47.tgz",
+      "integrity": "sha512-3dLX0Upo1v7RvUimvxLeXqwrfyKxUINk0EAM83swP2mlSUcwV73sZy8XhNz8bcZ3VbsfQyC/y6jRdL5tgCNpDQ==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
@@ -9537,9 +9536,10 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -9918,11 +9918,13 @@
       }
     },
     "node_modules/dockerfile-ast": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.2.1.tgz",
-      "integrity": "sha512-ut04CVM1G6zIITTcYPDIXhPZk9mCa21m4dfW8FcDDGxwgTQhYyHDu6U7M8klZ7QsjqVcJhryKi+TGOX6bjgKdQ==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.7.0.tgz",
+      "integrity": "sha512-HYpjuL0IEC2lYflTpWD0RLNSZYhQxLwYRYsoEjnCP7nu/OlFx1BVrU6X/Y8ETVsa2hojhG2OTJVxleH5Wrlq+Q==",
+      "license": "MIT",
       "dependencies": {
-        "vscode-languageserver-types": "^3.16.0"
+        "vscode-languageserver-textdocument": "^1.0.8",
+        "vscode-languageserver-types": "^3.17.3"
       },
       "engines": {
         "node": "*"
@@ -16781,15 +16783,15 @@
       }
     },
     "node_modules/patch-package/node_modules/yaml": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
-      "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
+      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 14.6"
       }
     },
     "node_modules/path-case": {
@@ -18273,9 +18275,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -20335,10 +20337,17 @@
         "extsprintf": "^1.2.0"
       }
     },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "license": "MIT"
+    },
     "node_modules/vscode-languageserver-types": {
-      "version": "3.17.3",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.3.tgz",
-      "integrity": "sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA=="
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "license": "MIT"
     },
     "node_modules/wcwidth": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -190,7 +190,7 @@
     "typescript": "^5.8.2"
   },
   "dependencies": {
-    "@balena/compose": "^7.0.1",
+    "@balena/compose": "^7.0.9",
     "@balena/dockerignore": "^1.0.2",
     "@balena/env-parsing": "^1.1.8",
     "@balena/es-version": "^1.0.1",


### PR DESCRIPTION
balena-cli recently updated dockerode/docker-modem dependencies, which requires a change to how array-based build arguments are provided (#2930). The error below manifests that error with build-time secrets.

This PR incorporates a change in @balena/compose (balena-io-modules/balena-compose#79) to avoid this error.

```
SecretPopulationError: (HTTP code 500) server error - invalid character '/' looking for beginning of value 
    at populateSecrets (/snapshot/balena-cli/node_modules/@balena/compose/dist/multibuild/build-secrets/index.js:90:15)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async initializeBuildMetadata (/snapshot/balena-cli/node_modules/@balena/compose/dist/multibuild/index.js:171:9)
    at async Object.performBuilds (/snapshot/balena-cli/node_modules/@balena/compose/dist/multibuild/index.js:142:80)
    at async performBuilds (/snapshot/balena-cli/build/utils/device/deploy.js:225:25)
    at async awaitInterruptibleTask (/snapshot/balena-cli/build/utils/helpers.js:283:16)
    at async Object.deployToDevice (/snapshot/balena-cli/build/utils/device/deploy.js:127:24)
    at async PushCmd.pushToDevice (/snapshot/balena-cli/build/commands/push/index.js:96:13)
    at async PushCmd.run (/snapshot/balena-cli/build/commands/push/index.js:35:17)
    at async PushCmd._run (/snapshot/balena-cli/node_modules/@oclif/core/lib/command.js:312:22)
    at async Config.runCommand (/snapshot/balena-cli/node_modules/@oclif/core/lib/config/config.js:435:25)
    at async run (/snapshot/balena-cli/node_modules/@oclif/core/lib/main.js:95:16)
    at async /snapshot/balena-cli/build/app.js:78:13
    at async Promise.all (index 2)
    at async oclifRun (/snapshot/balena-cli/build/app.js:97:5)
    at async Object.run (/snapshot/balena-cli/build/app.js:110:9)
```