### PR TITLE
Bump balena-preload to 18.0.4

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -20,7 +20,7 @@
         "balena-device-init": "^8.1.3",
         "balena-errors": "^4.7.3",
         "balena-image-fs": "^7.5.2",
-        "balena-preload": "^18.0.3",
+        "balena-preload": "^18.0.4",
         "balena-sdk": "^21.3.0",
         "balena-semver": "^2.3.0",
         "balena-settings-client": "^5.0.2",
@@ -7447,9 +7447,9 @@
       }
     },
     "node_modules/balena-preload": {
-      "version": "18.0.3",
-      "resolved": "https://registry.npmjs.org/balena-preload/-/balena-preload-18.0.3.tgz",
-      "integrity": "sha512-uEd7oJ8quF9bjBRr/xQpZvadQ83VZtKvZ5dPRQJcHB3WbnL2krRLTp0JXt1eEGgoWkE5e293fVW+rrAB7LCAYw==",
+      "version": "18.0.4",
+      "resolved": "https://registry.npmjs.org/balena-preload/-/balena-preload-18.0.4.tgz",
+      "integrity": "sha512-yGmDtzy2vInG1o/kglRtlAOpTwvxe04O2/698qDQCxZfYT9qDBOy9e14NpZoV+XQlQzJI67jB6Btx9K/MDVBFg==",
       "license": "Apache-2.0",
       "dependencies": {
         "balena-sdk": "^21.2.1",

--- a/package.json
+++ b/package.json
@@ -200,7 +200,7 @@
     "balena-device-init": "^8.1.3",
     "balena-errors": "^4.7.3",
     "balena-image-fs": "^7.5.2",
-    "balena-preload": "^18.0.3",
+    "balena-preload": "^18.0.4",
     "balena-sdk": "^21.3.0",
     "balena-semver": "^2.3.0",
     "balena-settings-client": "^5.0.2",


### PR DESCRIPTION
Update balena-preload from 18.0.3 to 18.0.4

Change-type: patch

<!-- You can remove tags that do not apply. -->
Resolves: # <!-- Refer an issue of this repository that this PR fixes -->  
Change-type: major|minor|patch <!-- See https://semver.org/ -->  
Depends-on: <url> <!-- This change depends on a PR to get merged/deployed first -->  
See: <url> <!-- Refer to any external resource, like a PR, document or discussion -->  

---
Please check the CONTRIBUTING.md file for relevant information and some
guidance. Keep in mind that the CLI is a cross-platform application that runs
on Windows, macOS and Linux. Tests will be automatically run by balena CI on
all three operating systems, but this will only help if you have added test
code that exercises the modified or added feature code.

Note that each commit message (currently only the first line) will be
automatically copied to the CHANGELOG.md file, so try writing it in a way
that describes the feature or fix for CLI users.

If there isn't a linked issue or if the linked issue doesn't quite match the
PR, please add a PR description to explain its purpose or the features that it
implements. Adding PR comments to blocks of code that aren't self explanatory
usually helps with the review process.

If the PR introduces security considerations or affects the development, build
or release process, please be sure to highlight this in the PR description.

Thank you very much for your contribution!
