### PR TITLE
config generate: Deprecate the '--generate-device-api-key' flag

### DIFF
--- a/docs/balena-cli.md
+++ b/docs/balena-cli.md
@@ -615,7 +615,6 @@ environments).
 Examples:
 
 	$ balena config generate --device 7cf02a6 --version 2.12.7
-	$ balena config generate --device 7cf02a6 --version 2.12.7 --generate-device-api-key
 	$ balena config generate --device 7cf02a6 --version 2.12.7 --deviceApiKey <existingDeviceKey>
 	$ balena config generate --device 7cf02a6 --version 2.12.7 --output config.json
 	$ balena config generate --fleet myorg/fleet --version 2.12.7 --dev
@@ -656,7 +655,7 @@ device type slug (run 'balena device-type list' for possible values)
 
 #### --generate-device-api-key
 
-generate a fresh device key for the device
+generate a fresh device key for the device. No-op and deprecated since a key is always auto-generated unless --deviceApiKey is provided.
 
 #### -o, --output OUTPUT
 

--- a/src/commands/config/generate.ts
+++ b/src/commands/config/generate.ts
@@ -56,7 +56,6 @@ export default class ConfigGenerateCmd extends Command {
 
 	public static examples = [
 		'$ balena config generate --device 7cf02a6 --version 2.12.7',
-		'$ balena config generate --device 7cf02a6 --version 2.12.7 --generate-device-api-key',
 		'$ balena config generate --device 7cf02a6 --version 2.12.7 --deviceApiKey <existingDeviceKey>',
 		'$ balena config generate --device 7cf02a6 --version 2.12.7 --output config.json',
 		'$ balena config generate --fleet myorg/fleet --version 2.12.7 --dev',
@@ -91,8 +90,10 @@ export default class ConfigGenerateCmd extends Command {
 			description:
 				"device type slug (run 'balena device-type list' for possible values)",
 		}),
+		// TODO: Drop in next major, since atm it is always defaulted to true interally
 		'generate-device-api-key': Flags.boolean({
-			description: 'generate a fresh device key for the device',
+			description:
+				'generate a fresh device key for the device. No-op and deprecated since a key is always auto-generated unless --deviceApiKey is provided.',
 		}),
 		output: Flags.string({
 			description: 'path of output file',
@@ -227,7 +228,7 @@ export default class ConfigGenerateCmd extends Command {
 		if (device) {
 			config = await generateDeviceConfig(
 				device,
-				options.deviceApiKey || options['generate-device-api-key'] || undefined,
+				options.deviceApiKey,
 				answers,
 			);
 		} else if (application) {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -101,7 +101,7 @@ export async function generateDeviceConfig(
 	device: DeviceWithDeviceType & {
 		belongs_to__application: BalenaSdk.PineDeferred;
 	},
-	deviceApiKey: string | true | undefined,
+	deviceApiKey: string | undefined,
 	options: { version: string },
 ): Promise<ImgConfig> {
 	const sdk = getBalenaSdk();


### PR DESCRIPTION
This was originally added in https://github.com/balena-io/balena-cli/pull/921/files , but after later simplifications of the fleet & device generation code, this flat is atm an auto-inferred no-op flag. More details in zulip v

While checking retrospectively, it seems that back then (even before the code simplofications) we could have just changed v
```
				if resource.uuid?
					generateDeviceConfig(resource, options.deviceApiKey || options['generate-device-api-key'], answers)
				else
					generateApplicationConfig(resource, answers)
```
to v
```
				if resource.uuid?
					generateDeviceConfig(resource, options.deviceApiKey || true, answers)
				else
					generateApplicationConfig(resource, answers)
```
See: https://github.com/balena-io/balena-cli/blob/52f93f8f12bb1d466144c937ecc20dedbbc2219c/lib/actions/config.coffee#L312C72-L312C93


Change-type: patch
https://balena.fibery.io/Work/Project/1722