### PR TITLE
os configure: Validate that the provided image & config file paths exist

### DIFF
--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+import * as fs from 'fs/promises';
 import { ExpectedError } from '../errors';
 
 // Sufficiently good email regex in order not to bring in another dependency.
@@ -121,4 +122,18 @@ export async function parseAsLocalHostnameOrIp(input: string) {
 
 export function looksLikeFleetSlug(input: string) {
 	return input.includes('/');
+}
+
+export async function validateFilePath(filePath: string) {
+	try {
+		const stats = await fs.stat(filePath);
+		if (!stats.isFile() && !stats.isSymbolicLink()) {
+			throw new ExpectedError(`Path is not pointing to a file: ${filePath}`);
+		}
+	} catch (err) {
+		if (err instanceof Error && 'code' in err && err.code === 'ENOENT') {
+			throw new ExpectedError(`No such file: ${filePath}`);
+		}
+		throw err;
+	}
 }

--- a/tests/commands/os/configure.spec.ts
+++ b/tests/commands/os/configure.spec.ts
@@ -108,6 +108,54 @@ if (process.platform !== 'win32') {
 			await fs.unlink(tmpNonMatchingDtJsonPartitionPath);
 		});
 
+		it('should fail when the provided image path does not exist', async () => {
+			const tmpInvalidImagePath = `${tmpMatchingDtJsonPartitionPath}wrong.img`;
+			const command: string[] = [
+				`os configure ${tmpInvalidImagePath}`,
+				'--device-type jetson-nano',
+				'--fleet testApp',
+			];
+
+			const { err } = await runCommand(command.join(' '));
+			expect(
+				err.flatMap((line) => line.split('\n')).filter((line) => line !== ''),
+			).to.deep.equal([`No such file: ${tmpInvalidImagePath}`]);
+		});
+
+		it('should fail when the provided image path is a directory', async () => {
+			const tmpInvalidImagePath = tmpMatchingDtJsonPartitionPath.replace(
+				/\/[^/]+$/,
+				'',
+			);
+			const command: string[] = [
+				`os configure ${tmpInvalidImagePath}`,
+				'--device-type jetson-nano',
+				'--fleet testApp',
+			];
+
+			const { err } = await runCommand(command.join(' '));
+			expect(
+				err.flatMap((line) => line.split('\n')).filter((line) => line !== ''),
+			).to.deep.equal([
+				`Path is not pointing to a file: ${tmpInvalidImagePath}`,
+			]);
+		});
+
+		it('should fail when the provided config path does not exist', async () => {
+			const tmpInvalidConfigJsonPath = `${tmpMatchingDtJsonPartitionPath}wrong-config.json`;
+			const command: string[] = [
+				`os configure ${tmpMatchingDtJsonPartitionPath}`,
+				'--device-type jetson-nano',
+				'--fleet testApp',
+				`--config ${tmpInvalidConfigJsonPath}`,
+			];
+
+			const { err } = await runCommand(command.join(' '));
+			expect(
+				err.flatMap((line) => line.split('\n')).filter((line) => line !== ''),
+			).to.deep.equal([`No such file: ${tmpInvalidConfigJsonPath}`]);
+		});
+
 		it('should detect the OS version and inject a valid config.json file to a 6.0.13 image with partition 12 as boot & matching device-type.json', async () => {
 			api.expectGetApplication();
 			api.expectGetDeviceTypes();


### PR DESCRIPTION
It seems that b/c atm balena-image-fs is just returning null when the path doesn't exist, we are blindly raising to users that we can't read the version from the provided image and ask them to use `--version` only to fail at a later step while writing the config to the image.
Since we will need this check for `--config` anyway, I went ahead and created a standardized validator that we can use in other places as well, and plan to make a major in balena-image-fs to start throwing more specific errors instead of silently returning null for any kind of issue.

Change-type: patch
See: https://balena.fibery.io/Work/Project/1722