### PR TITLE
patch: Debug print total tar pack size for upload

### DIFF
--- a/src/utils/compose_ts.ts
+++ b/src/utils/compose_ts.ts
@@ -790,6 +790,30 @@ export async function tarDirectory(
 }
 
 /**
+ * Calculates the total size of a readable stream.
+ *
+ * @param stream A readable stream, such as the one returned by tarDirectory.
+ * @returns A promise that resolves to the total size of the stream in bytes.
+ */
+export async function getTarPackSize(stream: Readable): Promise<number> {
+	return new Promise((resolve, reject) => {
+		let totalSize = 0;
+
+		stream.on('data', (chunk: Buffer) => {
+			totalSize += chunk.length;
+		});
+
+		stream.on('end', () => {
+			resolve(totalSize);
+		});
+
+		stream.on('error', (err) => {
+			reject(err);
+		});
+	});
+}
+
+/**
  * Print warning messages for unused .dockerignore files, and info messages if
  * the --multi-dockerignore (-m) option is used in certain circumstances.
  * @param dockerignoreFiles All .dockerignore files found in the project

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -512,3 +512,25 @@ export function pickAndRename<T extends Dictionary<any>>(
 	});
 	return _.mapKeys(_.pick(obj, fields), (_val, key) => rename[key]);
 }
+
+/**
+ * Converts a size in bytes to a human-readable string.
+ *
+ * @param {number} bytes The size in bytes.
+ * @returns {string} A formatted string with the appropriate unit (e.g., "1.4 MB").
+ */
+export function humanizeSize(bytes: number): string {
+	if (bytes == null || bytes === 0) {
+		return '0 Bytes';
+	}
+
+	const units = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB'];
+	const i = Math.floor(Math.log(bytes) / Math.log(1024));
+
+	if (i === 0) {
+		return `${bytes} ${units[i]}`;
+	}
+
+	const value = bytes / Math.pow(1024, i);
+	return `${parseFloat(value.toFixed(1))} ${units[i]}`;
+}

--- a/src/utils/remote-build.ts
+++ b/src/utils/remote-build.ts
@@ -20,11 +20,11 @@ import type { PlainResponse } from 'got';
 import type got from 'got';
 import type { RegistrySecrets } from '@balena/compose/dist/multibuild';
 import type * as Stream from 'stream';
+import { PassThrough } from 'stream';
 import streamToPromise = require('stream-to-promise');
 import type { Pack } from 'tar-stream';
-
 import { ExpectedError, SIGINTError } from '../errors';
-import { tarDirectory } from './compose_ts';
+import { tarDirectory, getTarPackSize } from './compose_ts';
 import { getVisuals, stripIndent } from './lazy';
 import Logger = require('./logger');
 
@@ -326,10 +326,17 @@ async function getTarStream(build: RemoteBuild): Promise<Stream.Readable> {
 			convertEol: build.opts.convertEol,
 			multiDockerignore: build.opts.multiDockerignore,
 		});
+		const passthrough = new PassThrough();
+		tarStream.pipe(passthrough);
+		const tarPackSize = await getTarPackSize(tarStream);
 		globalLogger.logDebug(
 			`Tarring complete in ${Date.now() - tarStartTime} ms`,
 		);
-		return tarStream;
+		const { humanizeSize } = await import('./helpers');
+		globalLogger.logDebug(
+			`The total size of the upload is ${humanizeSize(tarPackSize)}.`,
+		);
+		return passthrough;
 	} finally {
 		tarSpinner.stop();
 	}


### PR DESCRIPTION
> print the total upload size when `--debug` is used

```
...
Packaging the project source...
[Debug]   Tarring all non-ignored files...
[Debug]   Tarring complete in 8 ms
>>> [Debug]   The total size of the upload is 23 KB. <<<
```