### PR TITLE
Handle broken symlinks gracefully.

### DIFF
--- a/src/utils/ignore.ts
+++ b/src/utils/ignore.ts
@@ -54,9 +54,18 @@ async function listFiles(projectDir: string): Promise<string[]> {
 					const _files = await fs.readdir(dir, { withFileTypes: true });
 					for (const entry of _files) {
 						const fpath = path.join(dir, entry.name);
-						const isDirectory =
-							entry.isDirectory() ||
-							(entry.isSymbolicLink() && (await fs.stat(fpath)).isDirectory());
+						let isDirectory = false;
+						if (entry.isSymbolicLink()) {
+							try {
+								const stats = await fs.stat(fpath);
+								isDirectory = stats.isDirectory();
+							} catch (err) {
+								console.error('Could not stat path ', fpath, err);
+								isDirectory = false;
+							}
+						} else {
+							isDirectory = entry.isDirectory();
+						}
 
 						if (isDirectory) {
 							foundDirs.push(fpath);


### PR DESCRIPTION
Resolves: # 2593  
Change-type: patch
---

Handles possible error from fs.stat and ignores broken symlinks when checking for directories in ignore.ts.