### PR TITLE
renovate: Clean node_modules and npm cache before dedupe

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,6 +7,8 @@
       "matchPackageNames": ["*"],
       "postUpgradeTasks": {
         "commands": [
+		  "rm -rf node_modules",
+		  "npm cache clean --force",
           "npm install",
 		  "npm dedupe"
         ],


### PR DESCRIPTION
Change-type: patch

Hopefully fixes this: https://github.com/balena-io/balena-cli/pull/3014#issuecomment-3529735457

Depends-on: https://github.com/balena-io/.github/pull/1340