### PR TITLE
Update @balena/compose to v8

### DIFF
--- a/automation/build-bin.ts
+++ b/automation/build-bin.ts
@@ -201,6 +201,22 @@ export async function signFilesForNotarization() {
 		'Developer ID Application: Balena Ltd (66H43P8FRG)',
 		'node_modules/macmount/bin/macmount',
 	]);
+	console.log('running command:', 'codesign', [
+		'-d',
+		'-f',
+		'--options=runtime',
+		'-s',
+		'Developer ID Application: Balena Ltd (66H43P8FRG)',
+		'node_modules/@balena/compose-parser/bin/balena-compose-parser',
+	]);
+	await whichSpawn('codesign', [
+		'-d',
+		'-f',
+		'--options=runtime',
+		'-s',
+		'Developer ID Application: Balena Ltd (66H43P8FRG)',
+		'node_modules/@balena/compose-parser/bin/balena-compose-parser',
+	]);
 }
 
 export async function runOclifCommand(cmd: string, opts: string[]) {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -10,7 +10,8 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@balena/compose": "^7.0.10",
+        "@balena/compose": "^8.0.1",
+        "@balena/compose-parser": "^0.2.0",
         "@balena/dockerignore": "^1.0.2",
         "@balena/env-parsing": "^1.1.8",
         "@balena/es-version": "^1.0.1",
@@ -2931,67 +2932,54 @@
       }
     },
     "node_modules/@balena/compose": {
-      "version": "7.0.10",
-      "resolved": "https://registry.npmjs.org/@balena/compose/-/compose-7.0.10.tgz",
-      "integrity": "sha512-uk7FHt2wfB0ItRZWYUqKcvBxNGzmdZdobOoO85SLyOoC13/Sequn3IUaI+R7atz/r9lT+7yPZ+jImrNpzoUxxw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@balena/compose/-/compose-8.0.1.tgz",
+      "integrity": "sha512-FOtpqCx8Q24/guVdarstdtuHjtaaUglMzYMVi6VhQ4+2/BQ+6D+Y+mJijVTt0J1FuFx8JCsbK09B18LuMU1M8A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "ajv": "^6.12.3",
+        "@balena/compose-parser": "^0.2.0",
+        "ajv": "^6.12.6",
         "docker-file-parser": "^1.0.7",
-        "docker-progress": "^5.1.0",
-        "dockerfile-ast": "^0.7.0",
-        "dockerode": "^4.0.4",
-        "duplexify": "^4.1.2",
-        "event-stream": "^4.0.1",
-        "fp-ts": "^2.8.1",
-        "io-ts": "^2.2.9",
+        "docker-progress": "^5.3.1",
+        "dockerfile-ast": "^0.7.1",
+        "dockerode": "^4.0.8",
+        "fp-ts": "^2.16.11",
+        "io-ts": "^2.2.22",
         "io-ts-reporters": "^1.2.2",
         "js-yaml": "^4.1.0",
-        "jsesc": "^3.0.2",
+        "jsesc": "^3.1.0",
         "JSONStream": "^1.3.5",
-        "klaw": "^4.0.1",
-        "lodash": "^4.17.19",
-        "memoizee": "^0.4.15",
-        "mz": "^2.7.0",
+        "klaw": "^4.1.0",
+        "lodash": "^4.17.21",
+        "memoizee": "^0.4.17",
         "p-map": "^4.0.0",
-        "semver": "^7.3.5",
-        "stream-to-promise": "^3.0.0",
-        "tar-stream": "^3.1.6",
-        "tar-utils": "^3.0.2",
-        "typed-error": "^3.2.1"
+        "semver": "^7.7.2",
+        "tar-stream": "^3.1.7",
+        "tar-utils": "^3.1.0",
+        "typed-error": "^3.2.2"
       },
       "engines": {
         "node": ">=20.6.0"
       },
       "peerDependencies": {
+        "balena-sdk": "^22.1.3 || ^23.0.0",
         "pinejs-client-core": "^6.14.13 || ^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/@balena/compose/node_modules/event-stream": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-4.0.1.tgz",
-      "integrity": "sha512-qACXdu/9VHPBzcyhdOWR5/IahhGMf0roTeZJfzz077GwylcDd90yOHLouhmv7GJ5XzPi6ekaQWd8AvPP2nOvpA==",
+    "node_modules/@balena/compose-parser": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@balena/compose-parser/-/compose-parser-0.2.0.tgz",
+      "integrity": "sha512-sWnTbZK4e0MQUoep0b2x9dG3EEwJgIRXrA/DVLc+QFA22cwdHQEpYKgIJ+/2OXjE3TXYSa2FPyJcBZyAZk174A==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "duplexer": "^0.1.1",
-        "from": "^0.1.7",
-        "map-stream": "0.0.7",
-        "pause-stream": "^0.0.11",
-        "split": "^1.0.1",
-        "stream-combiner": "^0.2.2",
-        "through": "^2.3.8"
-      }
-    },
-    "node_modules/@balena/compose/node_modules/stream-to-promise": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/stream-to-promise/-/stream-to-promise-3.0.0.tgz",
-      "integrity": "sha512-h+7wLeFiYegOdgTfTxjRsrT7/Op7grnKEIHWgaO1RTHwcwk7xRreMr3S8XpDfDMesSxzgM2V4CxNCFAGo6ssnA==",
-      "dependencies": {
-        "any-promise": "~1.3.0",
-        "end-of-stream": "~1.4.1",
-        "stream-to-array": "~2.3.0"
+        "semver": "^7.7.2",
+        "tar": "^7.5.1",
+        "typed-error": "^3.2.2"
       },
       "engines": {
-        "node": ">= 10"
+        "node": ">= 22.14.0",
+        "npm": ">= 11.5.1"
       }
     },
     "node_modules/@balena/compose/node_modules/tar-stream": {
@@ -4951,6 +4939,18 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -11437,9 +11437,9 @@
       }
     },
     "node_modules/dockerfile-ast": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.7.0.tgz",
-      "integrity": "sha512-HYpjuL0IEC2lYflTpWD0RLNSZYhQxLwYRYsoEjnCP7nu/OlFx1BVrU6X/Y8ETVsa2hojhG2OTJVxleH5Wrlq+Q==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.7.1.tgz",
+      "integrity": "sha512-oX/A4I0EhSkGqrFv0YuvPkBUSYp1XiY8O8zAKc8Djglx8ocz+JfOr8gP0ryRMC2myqvDLagmnZaU9ot1vG2ijw==",
       "license": "MIT",
       "dependencies": {
         "vscode-languageserver-textdocument": "^1.0.8",
@@ -11616,31 +11616,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
-    },
-    "node_modules/duplexify": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
-      "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
-      "license": "MIT",
-      "dependencies": {
-        "end-of-stream": "^1.4.1",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1",
-        "stream-shift": "^1.0.2"
-      }
-    },
-    "node_modules/duplexify/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -13436,9 +13411,10 @@
       "license": "MIT"
     },
     "node_modules/fp-ts": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.13.1.tgz",
-      "integrity": "sha512-0eu5ULPS2c/jsa1lGFneEFFEdTbembJv8e4QKXeVJ3lm/5hyve06dlKZrpxmMwJt6rYen7sxmHHK2CLaXvWuWQ=="
+      "version": "2.16.11",
+      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.16.11.tgz",
+      "integrity": "sha512-LaI+KaX2NFkfn1ZGHoKCmcfv7yrZsC3b8NtWsTVQeHkq4F27vI5igUuO53sxqDEa2gNQMHFPmpojDw/1zmUK7w==",
+      "license": "MIT"
     },
     "node_modules/fresh": {
       "version": "0.5.2",
@@ -15056,9 +15032,10 @@
       }
     },
     "node_modules/io-ts": {
-      "version": "2.2.20",
-      "resolved": "https://registry.npmjs.org/io-ts/-/io-ts-2.2.20.tgz",
-      "integrity": "sha512-Rq2BsYmtwS5vVttie4rqrOCIfHCS9TgpRLFpKQCM1wZBBRY9nWVGmEvm2FnDbSE2un1UE39DvFpTR5UL47YDcA==",
+      "version": "2.2.22",
+      "resolved": "https://registry.npmjs.org/io-ts/-/io-ts-2.2.22.tgz",
+      "integrity": "sha512-FHCCztTkHoV9mdBsHpocLpdTAfh956ZQcIkWQxxS0U5HT53vtrcuYdQneEJKH6xILaLNzXVl2Cvwtoy8XNN0AA==",
+      "license": "MIT",
       "peerDependencies": {
         "fp-ts": "^2.5.0"
       }
@@ -16765,6 +16742,18 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/mkdirp": {
@@ -20925,6 +20914,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
       "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/stream-to-array": {
@@ -21350,6 +21340,22 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/tar": {
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
+      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tar-fs": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
@@ -21412,6 +21418,24 @@
         "bare-fs": "^4.5.5",
         "fast-fifo": "^1.2.0",
         "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/tar/node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/teex": {

--- a/package.json
+++ b/package.json
@@ -171,7 +171,8 @@
     "typescript": "^5.9.2"
   },
   "dependencies": {
-    "@balena/compose": "^7.0.10",
+    "@balena/compose": "^8.0.1",
+    "@balena/compose-parser": "^0.2.0",
     "@balena/dockerignore": "^1.0.2",
     "@balena/env-parsing": "^1.1.8",
     "@balena/es-version": "^1.0.1",

--- a/src/commands/deploy/index.ts
+++ b/src/commands/deploy/index.ts
@@ -16,7 +16,7 @@
  */
 
 import { Args, Flags, Command } from '@oclif/core';
-import type { ImageDescriptor } from '@balena/compose/dist/parse';
+import type { ImageDescriptor } from '@balena/compose-parser';
 import { ExpectedError } from '../../errors';
 import { getBalenaSdk, getCliUx, stripIndent } from '../../utils/lazy';
 import {

--- a/src/commands/deploy/index.ts
+++ b/src/commands/deploy/index.ts
@@ -263,7 +263,9 @@ ${dockerignoreHelp}
 					}
 					try {
 						await docker
-							.getImage((isBuildConfig(d.image) ? d.image.tag : d.image) ?? '')
+							.getImage(
+								(isBuildConfig(d.image) ? d.image.tags?.[0] : d.image) ?? '',
+							)
 							.inspect();
 
 						return d.serviceName;
@@ -309,7 +311,7 @@ ${dockerignoreHelp}
 				(d) =>
 					builtImagesByService[d.serviceName] ?? {
 						serviceName: d.serviceName,
-						name: (isBuildConfig(d.image) ? d.image.tag : d.image) ?? '',
+						name: (isBuildConfig(d.image) ? d.image.tags?.[0] : d.image) ?? '',
 						logs: 'Build skipped; image for service already exists.',
 						props: {},
 					},

--- a/src/utils/compose-types.d.ts
+++ b/src/utils/compose-types.d.ts
@@ -15,17 +15,12 @@
  * limitations under the License.
  */
 
-import type {
-	ImageModel,
-	ReleaseModel,
-} from '@balena/compose/dist/release/models';
-import type { Composition, ImageDescriptor } from '@balena/compose/dist/parse';
+import type { BalenaModel } from 'balena-sdk';
+import type { Composition, ImageDescriptor } from '@balena/compose-parser';
 import type { Pack } from 'tar-stream';
 
-interface Image {
-	context: string;
-	tag: string;
-}
+type ReleaseModel = BalenaModel['release']['Read'];
+type ImageModel = BalenaModel['image']['Read'];
 
 export interface BuiltImage {
 	logs: string;
@@ -42,7 +37,7 @@ export interface BuiltImage {
 
 export interface TaggedImage {
 	localImage: import('dockerode').Image;
-	serviceImage: import('@balena/compose/dist/release/models').ImageModel;
+	serviceImage: Omit<ImageModel, 'created_at' | 'is_a_build_of__service'>;
 	serviceName: string;
 	logs: string;
 	props: BuiltImage.props;

--- a/src/utils/compose.ts
+++ b/src/utils/compose.ts
@@ -19,7 +19,7 @@ import type { Renderer } from './compose_ts';
 import type * as SDK from 'balena-sdk';
 import type * as Dockerode from 'dockerode';
 import * as path from 'path';
-import type { Composition, ImageDescriptor } from '@balena/compose/dist/parse';
+import type { Composition, ImageDescriptor } from '@balena/compose-parser';
 import type { RetryParametersObj } from 'pinejs-client-core';
 import type {
 	BuiltImage,
@@ -128,7 +128,7 @@ export const createRelease = async function (
 	composition: Composition,
 	draft: boolean,
 	semver: string | undefined,
-	contract: import('@balena/compose/dist/release/models').ReleaseModel['contract'],
+	contract: Dictionary<any> | null,
 	imgDescriptors: ImageDescriptor[],
 ): Promise<Release> {
 	const crypto = require('crypto') as typeof import('crypto');
@@ -165,16 +165,17 @@ export const createRelease = async function (
 		commit: crypto.pseudoRandomBytes(16).toString('hex').toLowerCase(),
 		semver,
 		is_final: !draft,
-		contract,
+		contract: contract ?? undefined,
 		imgDescriptors,
 	});
 
 	for (const serviceImage of Object.values(serviceImages)) {
 		if ('created_at' in serviceImage) {
-			delete serviceImage.created_at;
+			delete (serviceImage as Partial<typeof serviceImage>).created_at;
 		}
 		if ('is_a_build_of__service' in serviceImage) {
-			delete serviceImage.is_a_build_of__service;
+			delete (serviceImage as Partial<typeof serviceImage>)
+				.is_a_build_of__service;
 		}
 	}
 

--- a/src/utils/compose.ts
+++ b/src/utils/compose.ts
@@ -54,37 +54,34 @@ export function generateOpts(options: {
 	}));
 }
 
-/** Parse the given composition and return a structure with info. Input is:
+/** Create a ComposeProject from a Composition object.
  * - composePath: the *absolute* path to the directory containing the compose file
- *  - composeStr: the contents of the compose file, as a string
+ * - composition: the parsed Composition object
  */
 export function createProject(
 	composePath: string,
-	composeStr: string,
+	composition: Composition,
 	projectName = '',
 	imageTag = '',
 ): ComposeProject {
-	const yml = require('js-yaml') as typeof import('js-yaml');
-	const compose =
-		require('@balena/compose/dist/parse') as typeof import('@balena/compose/dist/parse');
-
-	// both methods below may throw.
-	const rawComposition = yml.load(composeStr);
-	const composition = compose.normalize(rawComposition);
+	const { toImageDescriptors } =
+		require('@balena/compose-parser') as typeof import('@balena/compose-parser');
 
 	projectName ||= path.basename(composePath);
 
-	const descriptors = compose.parse(composition).map(function (descr) {
+	const descriptors = toImageDescriptors(composition).map(function (descr) {
 		// generate an image name based on the project and service names
 		// if one is not given and the service requires a build
 		if (
 			typeof descr.image !== 'string' &&
 			descr.image.context != null &&
-			descr.image.tag == null
+			!descr.image.tags?.length
 		) {
 			const { makeImageName } =
 				require('./compose_ts') as typeof import('./compose_ts');
-			descr.image.tag = makeImageName(projectName, descr.serviceName, imageTag);
+			descr.image.tags = [
+				makeImageName(projectName, descr.serviceName, imageTag),
+			];
 		}
 		return descr;
 	});

--- a/src/utils/compose_ts.ts
+++ b/src/utils/compose_ts.ts
@@ -106,6 +106,19 @@ export async function applyReleaseTagKeysAndValues(
 const LOG_LENGTH_MAX = 512 * 1024; // 512KB
 const compositionFileNames = ['docker-compose.yml', 'docker-compose.yaml'];
 
+export async function parseComposePaths(
+	paths: string | string[],
+): Promise<Composition> {
+	const composeParser = await import('@balena/compose-parser');
+	const pathStr = Array.isArray(paths) ? paths.join(', ') : paths;
+	try {
+		return await composeParser.parse(paths);
+	} catch (err: any) {
+		err.message = `Error parsing composition file "${pathStr}":\n${err.message}`;
+		throw err;
+	}
+}
+
 /**
  * high-level function resolving a project and creating a composition out
  * of it in one go. if image is given, it'll create a default project for
@@ -119,7 +132,6 @@ export async function loadProject(
 	imageTag?: string,
 ): Promise<ComposeProject> {
 	const composeMod = await import('@balena/compose/dist/parse');
-	const composeParser = await import('@balena/compose-parser');
 	const { createProject } = await import('./compose');
 	let composition: Composition;
 
@@ -151,15 +163,12 @@ export async function loadProject(
 					logger.logInfo(
 						'Docker compose dev overlay detected (docker-compose.dev.yml) - merging.',
 					);
-					composition = await composeParser.parse([
-						composePath,
-						devOverlayPath,
-					]);
+					composition = await parseComposePaths([composePath, devOverlayPath]);
 				} else {
-					composition = await composeParser.parse(composePath);
+					composition = await parseComposePaths(composePath);
 				}
 			} else {
-				composition = await composeParser.parse(composePath);
+				composition = await parseComposePaths(composePath);
 			}
 		} else {
 			logger.logInfo(
@@ -661,14 +670,13 @@ export async function getServiceDirsFromComposition(
 ): Promise<Dictionary<string>> {
 	const serviceDirs: Dictionary<string> = {};
 	if (!composition) {
-		const composeParser = await import('@balena/compose-parser');
 		const [, composePath] = await resolveProject(
 			Logger.getLogger(),
 			sourceDir,
 			true,
 		);
 		if (composePath) {
-			composition = await composeParser.parse(composePath);
+			composition = await parseComposePaths(composePath);
 		}
 	}
 	if (composition?.services) {

--- a/src/utils/compose_ts.ts
+++ b/src/utils/compose_ts.ts
@@ -118,19 +118,22 @@ export async function loadProject(
 	image?: string,
 	imageTag?: string,
 ): Promise<ComposeProject> {
-	const compose = await import('@balena/compose/dist/parse');
+	const composeMod = await import('@balena/compose/dist/parse');
+	const composeParser = await import('@balena/compose-parser');
 	const { createProject } = await import('./compose');
-	let composeName: string;
-	let composeStr: string;
+	let composition: Composition;
 
 	logger.logDebug('Loading project...');
 
 	if (image) {
 		logger.logInfo(`Creating default composition with image: "${image}"`);
-		composeStr = compose.defaultComposition(image);
+		composition = composeMod.defaultComposition(image);
 	} else {
 		logger.logDebug('Resolving project...');
-		[composeName, composeStr] = await resolveProject(logger, opts.projectPath);
+		const [composeName, composePath] = await resolveProject(
+			logger,
+			opts.projectPath,
+		);
 
 		if (composeName) {
 			if (opts.dockerfilePath) {
@@ -138,71 +141,48 @@ export async function loadProject(
 					`Ignoring alternative dockerfile "${opts.dockerfilePath}" because composition file "${composeName}" exists`,
 				);
 			}
+			// Parse the compose file (and dev overlay if local push)
+			if (opts.isLocal) {
+				const devOverlayPath = path.join(
+					opts.projectPath,
+					'docker-compose.dev.yml',
+				);
+				if (await exists(devOverlayPath)) {
+					logger.logInfo(
+						'Docker compose dev overlay detected (docker-compose.dev.yml) - merging.',
+					);
+					composition = await composeParser.parse([
+						composePath,
+						devOverlayPath,
+					]);
+				} else {
+					composition = await composeParser.parse(composePath);
+				}
+			} else {
+				composition = await composeParser.parse(composePath);
+			}
 		} else {
 			logger.logInfo(
 				`Creating default composition with source: "${opts.projectPath}"`,
 			);
-			composeStr = compose.defaultComposition(undefined, opts.dockerfilePath);
-		}
-
-		// If local push, merge dev compose overlay
-		if (opts.isLocal) {
-			composeStr = await mergeDevComposeOverlay(
-				logger,
-				composeStr,
-				opts.projectPath,
+			composition = composeMod.defaultComposition(
+				undefined,
+				opts.dockerfilePath,
 			);
 		}
 	}
 	logger.logDebug('Creating project...');
 	return createProject(
 		opts.projectPath,
-		composeStr,
+		composition!,
 		opts.projectName,
 		imageTag,
 	);
 }
 
 /**
- * Check for existence of docker-compose dev overlay file
- * and merge in services definitions.
- */
-async function mergeDevComposeOverlay(
-	logger: Logger,
-	composeStr: string,
-	projectRoot: string,
-) {
-	const devOverlayFilename = 'docker-compose.dev.yml';
-	const devOverlayPath = path.join(projectRoot, devOverlayFilename);
-
-	if (await exists(devOverlayPath)) {
-		logger.logInfo(
-			`Docker compose dev overlay detected (${devOverlayFilename}) - merging.`,
-		);
-		interface ComposeObj {
-			services?: object;
-		}
-		const loadObj = (inputStr: string): ComposeObj =>
-			// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-			(yaml.load(inputStr) || {}) as ComposeObj;
-		try {
-			const compose = loadObj(composeStr);
-			const devOverlay = loadObj(await fs.readFile(devOverlayPath, 'utf8'));
-			// We only want to merge the services section
-			compose.services = { ...compose.services, ...devOverlay.services };
-			composeStr = yaml.dump(compose, { styles: { '!!null': 'empty' } });
-		} catch (err) {
-			err.message = `Error merging docker compose dev overlay file "${devOverlayPath}":\n${err.message}`;
-			throw err;
-		}
-	}
-
-	return composeStr;
-}
-
-/**
  * Look into the given directory for valid compose files and return
- * the contents of the first one found.
+ * the name and full path of the first one found.
  */
 async function resolveProject(
 	logger: Logger,
@@ -210,18 +190,13 @@ async function resolveProject(
 	quiet = false,
 ): Promise<[string, string]> {
 	let composeFileName = '';
-	let composeFileContents = '';
+	let composeFilePath = '';
 	for (const fname of compositionFileNames) {
 		const fpath = path.join(projectRoot, fname);
 		if (await exists(fpath)) {
 			logger.logDebug(`${fname} file found at "${projectRoot}"`);
 			composeFileName = fname;
-			try {
-				composeFileContents = await fs.readFile(fpath, 'utf8');
-			} catch (err) {
-				logger.logError(`Error reading composition file "${fpath}":\n${err}`);
-				throw err;
-			}
+			composeFilePath = fpath;
 			break;
 		}
 	}
@@ -229,7 +204,7 @@ async function resolveProject(
 		logger.logInfo(`No "docker-compose.yml" file found at "${projectRoot}"`);
 	}
 
-	return [composeFileName, composeFileContents];
+	return [composeFileName, composeFilePath];
 }
 
 interface BuildTaskPlus extends MultiBuild.BuildTask {
@@ -262,8 +237,8 @@ export async function buildProject(
 	opts: BuildProjectOpts,
 ): Promise<BuiltImage[]> {
 	await checkBuildSecretsRequirements(opts.docker, opts.projectPath);
-	const compose = await import('@balena/compose/dist/parse');
-	const imageDescriptors = compose.parse(opts.composition);
+	const { toImageDescriptors } = await import('@balena/compose-parser');
+	const imageDescriptors = toImageDescriptors(opts.composition);
 	const renderer = await startRenderer({ imageDescriptors, ...opts });
 	let buildSummaryByService: Dictionary<string> | undefined;
 	try {
@@ -443,7 +418,7 @@ function setTaskAttributes({
 		// any tags we've set before are lost; re-assign them here
 		task.tag ??= makeImageName(projectName, task.serviceName, buildOpts.t);
 		if (isBuildConfig(d.image)) {
-			d.image.tag = task.tag;
+			d.image.tags = [task.tag];
 		}
 		// reassign task.args so that the `--buildArg` flag takes precedence
 		// over assignments in the docker-compose.yml file (service.build.args)
@@ -604,7 +579,7 @@ async function inspectBuiltImage({
 
 	const image: BuiltImage = {
 		serviceName: d.serviceName,
-		name: (isBuildConfig(d.image) ? d.image.tag : d.image) ?? '',
+		name: (isBuildConfig(d.image) ? d.image.tags?.[0] : d.image) ?? '',
 		logs: truncateString(task?.logBuffer?.join('\n') ?? '', LOG_LENGTH_MAX),
 		props: {
 			dockerfile: builtImage.dockerfile,
@@ -684,26 +659,23 @@ export async function getServiceDirsFromComposition(
 	sourceDir: string,
 	composition?: Composition,
 ): Promise<Dictionary<string>> {
-	const { createProject } = await import('./compose');
 	const serviceDirs: Dictionary<string> = {};
 	if (!composition) {
-		const [, composeStr] = await resolveProject(
+		const composeParser = await import('@balena/compose-parser');
+		const [, composePath] = await resolveProject(
 			Logger.getLogger(),
 			sourceDir,
 			true,
 		);
-		if (composeStr) {
-			composition = createProject(sourceDir, composeStr).composition;
+		if (composePath) {
+			composition = await composeParser.parse(composePath);
 		}
 	}
 	if (composition?.services) {
 		const relPrefix = '.' + path.sep;
 		for (const [serviceName, service] of Object.entries(composition.services)) {
-			let dir =
-				(typeof service.build === 'string'
-					? service.build
-					: // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-						service.build?.context) || '.';
+			const dirRaw = service.build?.context;
+			let dir = dirRaw || '.';
 			// Convert forward slashes to backslashes on Windows
 			dir = path.normalize(dir);
 			// Make sure the path is relative to the project directory
@@ -736,7 +708,7 @@ export async function getServiceDirsFromComposition(
  * This is why this implementation works when `services.service.build` is defined
  * as a string in the docker-compose.yml file.
  *
- * @param image The `ImageDescriptor.image` attribute parsed with `@balena/compose/parse`
+ * @param image The `ImageDescriptor.image` attribute from `@balena/compose-parser`
  */
 export function isBuildConfig(
 	image: string | BuildConfig,

--- a/src/utils/compose_ts.ts
+++ b/src/utils/compose_ts.ts
@@ -26,7 +26,7 @@ import type {
 	BuildConfig,
 	Composition,
 	ImageDescriptor,
-} from '@balena/compose/dist/parse';
+} from '@balena/compose-parser';
 import type * as MultiBuild from '@balena/compose/dist/multibuild';
 import * as semver from 'semver';
 import type { Duplex, Readable } from 'stream';
@@ -1278,7 +1278,7 @@ async function pushAndUpdateServiceImages(
 	token: string,
 	images: TaggedImage[],
 	afterEach: (
-		serviceImage: import('@balena/compose/dist/release/models').ImageModel,
+		serviceImage: import('./compose-types').TaggedImage['serviceImage'],
 		props: object,
 	) => Promise<void>,
 ) {
@@ -1342,7 +1342,7 @@ async function pushAndUpdateServiceImages(
 			if (props.endTime) {
 				serviceImage.end_timestamp = props.endTime;
 			}
-			serviceImage.push_timestamp = new Date();
+			serviceImage.push_timestamp = new Date().toISOString();
 			serviceImage.status = 'success';
 		} catch (error) {
 			serviceImage.error_message = '' + error;
@@ -1383,7 +1383,7 @@ async function pushServiceImages(
 				`Saving image ${serviceImage.is_stored_at__image_location}`,
 			);
 			if (skipLogUpload) {
-				delete serviceImage.build_log;
+				delete (serviceImage as Partial<typeof serviceImage>).build_log;
 			}
 
 			// These are the only update-able image fields in bC atm, and passing
@@ -1429,7 +1429,7 @@ export async function deployProject(
 	projectPath: string,
 	isDraft: boolean,
 	imgDescriptors: ImageDescriptor[],
-): Promise<import('@balena/compose/dist/release/models').ReleaseModel> {
+): Promise<import('./compose-types').Release['release']> {
 	const releaseMod = await import('@balena/compose/dist/release');
 	const { createRelease, tagServiceImages } = await import('./compose');
 	const tty = (await import('./tty'))(process.stdout);
@@ -1500,7 +1500,7 @@ export async function deployProject(
 		}
 	} finally {
 		await runSpinner(tty, spinner, `${prefix}Saving release...`, async () => {
-			release.end_timestamp = new Date();
+			release.end_timestamp = new Date().toISOString();
 			if (release.id != null) {
 				await releaseMod.updateRelease(pineClient, release.id, {
 					status: release.status,
@@ -1556,15 +1556,13 @@ export function createRunLoop(tick: (...args: any[]) => void) {
 
 async function getContractContent(
 	filePath: string,
-): Promise<
-	import('@balena/compose/dist/release/models').ReleaseModel['contract']
-> {
+): Promise<Dictionary<any> | null> {
 	let fileContentAsString;
 	try {
 		fileContentAsString = await fs.readFile(filePath, 'utf8');
 	} catch (e) {
 		if (e.code === 'ENOENT') {
-			return; // File does not exist
+			return null; // File does not exist
 		}
 		throw e;
 	}

--- a/src/utils/device/deploy.ts
+++ b/src/utils/device/deploy.ts
@@ -18,7 +18,7 @@
 import * as semver from 'balena-semver';
 import * as Docker from 'dockerode';
 import * as _ from 'lodash';
-import type { Composition } from '@balena/compose/dist/parse';
+import type { Composition } from '@balena/compose-parser';
 import type {
 	BuildTask,
 	LocalImage,

--- a/src/utils/device/live.ts
+++ b/src/utils/device/live.ts
@@ -168,7 +168,10 @@ export class LivepushManager {
 
 				// path.resolve() converts to an absolute path, removes trailing slashes,
 				// and also converts forward slashes to backslashes on Windows.
-				const context = path.resolve(rootContext, service.build.context);
+				const context = path.resolve(
+					rootContext,
+					service.build!.context ?? '.',
+				);
 
 				const livepush = await Livepush.init({
 					dockerfile,

--- a/src/utils/device/live.ts
+++ b/src/utils/device/live.ts
@@ -21,7 +21,7 @@ import * as fs from 'fs';
 import Livepush, { ContainerNotRunningError } from 'livepush';
 import * as _ from 'lodash';
 import * as path from 'path';
-import type { Composition } from '@balena/compose/dist/parse';
+import type { Composition } from '@balena/compose-parser';
 import type { BuildTask } from '@balena/compose/dist/multibuild';
 
 import { instanceOf } from '../../errors';

--- a/tests/commands/build.spec.ts
+++ b/tests/commands/build.spec.ts
@@ -74,6 +74,7 @@ const commonComposeQueryParams = {
 		MY_VAR_2: 'Also a variable',
 	},
 	labels: '',
+	dockerfile: 'Dockerfile',
 };
 
 const commonComposeQueryParamsIntel = {

--- a/tests/commands/build.spec.ts
+++ b/tests/commands/build.spec.ts
@@ -711,6 +711,139 @@ describe('balena build', function () {
 			tag,
 		});
 	});
+
+	it('should create the expected tar stream when using extensions, fragments, include compose features with no version field', async () => {
+		const projectPath = path.join(
+			repoPath,
+			'tests',
+			'test-data',
+			'projects',
+			'docker-compose',
+			'compose-frag-ext-includes',
+		);
+		const expectedFilesByService: ExpectedTarStreamFilesByService = {
+			service1: {
+				Dockerfile: { fileSize: 31, type: 'file' },
+			},
+			service2: {
+				'Dockerfile-alt': { fileSize: 31, type: 'file' },
+			},
+		};
+		const responseFilename = 'build-POST.json';
+		const responseBody = await fs.readFile(
+			path.join(dockerResponsePath, responseFilename),
+			'utf8',
+		);
+		const expectedQueryParamsByService = {
+			service1: Object.entries({
+				t: '${tag}',
+				buildargs: {
+					SHARED_ARG: 'shared_value',
+					SERVICE1_ARG: 's1_value',
+				},
+				labels: '',
+				dockerfile: 'Dockerfile',
+				platform: 'linux/amd64',
+			}),
+			service2: Object.entries({
+				t: '${tag}',
+				buildargs: {
+					SHARED_ARG: 'shared_value',
+					SERVICE2_ARG: 's2_value',
+				},
+				labels: '',
+				dockerfile: 'Dockerfile-alt',
+				platform: 'linux/amd64',
+			}),
+		};
+		const expectedResponseLines: string[] = [
+			...commonResponseLines[responseFilename],
+			...[
+				'[Build] service1 Step 1/4 : FROM busybox',
+				'[Build] service2 Step 1/4 : FROM busybox',
+			],
+		];
+		await docker.expectGetInfo({});
+		await docker.expectGetManifestBusybox();
+		await docker.expectGetManifestBusybox();
+		await testDockerBuildStream({
+			commandLine: `build ${projectPath} --deviceType nuc --arch amd64`,
+			dockerMock: docker,
+			expectedFilesByService,
+			expectedQueryParamsByService,
+			expectedResponseLines,
+			projectPath,
+			responseBody,
+			responseCode: 200,
+			services: ['service1', 'service2'],
+		});
+	});
+
+	it('should create the expected tar stream when using compose spec v2 service and network fields', async () => {
+		const projectPath = path.join(
+			repoPath,
+			'tests',
+			'test-data',
+			'projects',
+			'docker-compose',
+			'compose-fields',
+		);
+		const expectedFilesByService: ExpectedTarStreamFilesByService = {
+			service1: {
+				Dockerfile: { fileSize: 31, type: 'file' },
+			},
+			service2: {
+				'Dockerfile-alt': { fileSize: 31, type: 'file' },
+			},
+		};
+		const responseFilename = 'build-POST.json';
+		const responseBody = await fs.readFile(
+			path.join(dockerResponsePath, responseFilename),
+			'utf8',
+		);
+		const expectedQueryParamsByService = {
+			service1: Object.entries({
+				t: '${tag}',
+				buildargs: {},
+				labels: '',
+				dockerfile: 'Dockerfile',
+				platform: 'linux/amd64',
+			}),
+			service2: Object.entries({
+				t: '${tag}',
+				buildargs: {},
+				labels: '',
+				dockerfile: 'Dockerfile-alt',
+				platform: 'linux/amd64',
+			}),
+		};
+		const expectedResponseLines: string[] = [
+			...commonResponseLines[responseFilename],
+			...[
+				'[Build] service1 Step 1/4 : FROM busybox',
+				'[Build] service2 Step 1/4 : FROM busybox',
+			],
+		];
+		await docker.expectGetInfo({});
+		await docker.expectGetManifestBusybox();
+		await docker.expectGetManifestBusybox();
+		const expectedErrorLines = [
+			'Service "service1" uses compose fields that may not be supported on legacy Supervisor versions',
+			'Service "service2" uses compose fields that may not be supported on legacy Supervisor versions',
+		];
+		await testDockerBuildStream({
+			commandLine: `build ${projectPath} --deviceType nuc --arch amd64`,
+			dockerMock: docker,
+			expectedErrorLines,
+			expectedFilesByService,
+			expectedQueryParamsByService,
+			expectedResponseLines,
+			projectPath,
+			responseBody,
+			responseCode: 200,
+			services: ['service1', 'service2'],
+		});
+	});
 });
 
 describe('balena build: project validation', function () {
@@ -747,5 +880,186 @@ describe('balena build: project validation', function () {
 		);
 		expect(cleanOutput(err, true)).to.include.members(expectedErrorLines);
 		expect(out).to.be.empty;
+	});
+});
+
+describe('balena build: compose field rejections', function () {
+	this.timeout(90_000);
+	let server: MockHttpServer;
+
+	const rejectionsPath = path.join(
+		projectsPath,
+		'docker-compose',
+		'rejections',
+	);
+	const composeFilePath = path.join(rejectionsPath, 'docker-compose.yml');
+
+	before(async () => {
+		server = new MockHttpServer();
+		await server.start();
+	});
+
+	after(async () => {
+		await server.stop();
+	});
+
+	afterEach(async () => {
+		await fs.unlink(composeFilePath).catch(() => {
+			/* noop */
+		});
+	});
+
+	async function expectRejection(composeFile: string, expectedError: string) {
+		await fs.copyFile(path.join(rejectionsPath, composeFile), composeFilePath);
+		// Prevent exiting test process on expected error
+		const exitStub = sinon.stub(process, 'exit');
+		// Silence logs from build process
+		const stdoutStub = sinon.stub(process.stdout, 'write').returns(true);
+		const stderrStub = sinon.stub(process.stderr, 'write').returns(true);
+		try {
+			const { out, err } = await runCommand(
+				`build ${rejectionsPath} -A amd64 -d nuc`,
+			);
+			const allOutput = cleanOutput([...err, ...out], true);
+			expect(allOutput).to.include.members([expectedError]);
+		} finally {
+			stderrStub.restore();
+			stdoutStub.restore();
+			exitStub.restore();
+		}
+	}
+
+	it('should reject top-level secrets', async () => {
+		await expectRejection(
+			'secrets.yml',
+			'Top-level secrets and/or configs are not supported',
+		);
+	});
+
+	it('should reject top-level configs', async () => {
+		await expectRejection(
+			'configs.yml',
+			'Top-level secrets and/or configs are not supported',
+		);
+	});
+
+	it('should reject service fields in SERVICE_CONFIG_DENY_LIST', async () => {
+		await expectRejection(
+			'service-deny-list.yml',
+			'service.blkio_config is not allowed',
+		);
+	});
+
+	it('should reject build fields in BUILD_CONFIG_DENY_LIST', async () => {
+		await expectRejection(
+			'build-deny-list.yml',
+			'service.build.isolation is not allowed',
+		);
+	});
+
+	it('should reject network_mode container:containerId', async () => {
+		await expectRejection(
+			'network-mode-container.yml',
+			'service.network_mode container:${containerId} is not allowed',
+		);
+	});
+
+	it('should reject pid container:containerId', async () => {
+		await expectRejection(
+			'pid-container.yml',
+			'service.pid container:${containerId} is not allowed',
+		);
+	});
+
+	it('should reject volumes_from referencing a container', async () => {
+		await expectRejection(
+			'volumes-from-container.yml',
+			'service.volumes_from which references a containerId is not allowed',
+		);
+	});
+
+	it('should reject security_opt other than no-new-privileges', async () => {
+		await expectRejection(
+			'security-opt.yml',
+			'Only no-new-privileges is allowed for service.security_opt',
+		);
+	});
+
+	it('should reject ipc referencing service:serviceName', async () => {
+		await expectRejection(
+			'ipc-service.yml',
+			'service.ipc which references service:${serviceName} is not supported',
+		);
+	});
+
+	it('should reject negative pids_limit', async () => {
+		await expectRejection(
+			'negative-pids-limit.yml',
+			'negative service.pids_limit is not supported',
+		);
+	});
+
+	it('should reject network.attachable', async () => {
+		await expectRejection(
+			'network-attachable.yml',
+			'network.attachable is not allowed',
+		);
+	});
+
+	it('should reject network.external', async () => {
+		await expectRejection(
+			'network-external.yml',
+			'network.external is not allowed',
+		);
+	});
+
+	it('should reject unsupported network.driver', async () => {
+		await expectRejection(
+			'network-driver.yml',
+			'Only "bridge" and "default" are supported for network.driver, got "overlay"',
+		);
+	});
+
+	it('should reject volume.external', async () => {
+		await expectRejection(
+			'volume-external.yml',
+			'volume.external is not allowed',
+		);
+	});
+
+	it('should reject unsupported volume.driver', async () => {
+		await expectRejection(
+			'volume-driver.yml',
+			'Only "local" and "default" are supported for volume.driver, got "nfs"',
+		);
+	});
+
+	it('should reject bind mount volumes not in allowedBindMounts', async () => {
+		await expectRejection(
+			'volume-bind-mount.yml',
+			'service.volumes cannot be of type "bind"',
+		);
+	});
+
+	it('should reject network.link_local_ips', async () => {
+		await expectRejection(
+			'network-link-local-ips.yml',
+			'service.network.link_local_ips is not supported',
+		);
+	});
+
+	it('should reject network.ipam.config.aux_addresses', async () => {
+		await expectRejection(
+			'network-aux-addresses.yml',
+			'network.ipam.config.aux_addresses is not supported',
+		);
+	});
+
+	it('should reject enable_ipv4', async () => {
+		await expectRejection('enable-ipv4.yml', 'enable_ipv4 is not supported');
+	});
+
+	it('should reject enable_ipv6', async () => {
+		await expectRejection('enable-ipv6.yml', 'enable_ipv6 is not supported');
 	});
 });

--- a/tests/commands/deploy.spec.ts
+++ b/tests/commands/deploy.spec.ts
@@ -67,6 +67,7 @@ const commonComposeQueryParams = {
 		MY_VAR_2: 'Also a variable',
 	},
 	labels: '',
+	dockerfile: 'Dockerfile',
 };
 
 const commonComposeQueryParamsArmV7 = {

--- a/tests/commands/deploy.spec.ts
+++ b/tests/commands/deploy.spec.ts
@@ -311,7 +311,7 @@ describe('balena deploy', function () {
 			times: maxRequestRetries,
 			inspectRequest: (_uri, requestBody) => {
 				const imageBody = requestBody as Partial<
-					import('@balena/compose/dist/release/models').ImageModel
+					import('balena-sdk').BalenaModel['image']['Write']
 				>;
 				// Don't use expect here - just track the count
 				if (imageBody.status === 'success') {
@@ -324,7 +324,7 @@ describe('balena deploy', function () {
 		await api.expectPatchRelease({
 			inspectRequest: (_uri, requestBody) => {
 				const releaseBody = requestBody as Partial<
-					import('@balena/compose/dist/release/models').ReleaseModel
+					import('balena-sdk').BalenaModel['release']['Write']
 				>;
 				// Don't use expect here - just store the status
 				releaseStatus = releaseBody.status;
@@ -406,7 +406,7 @@ describe('balena deploy', function () {
 			times: maxRequestRetries,
 			inspectRequest: (_uri, requestBody) => {
 				const imageBody = requestBody as Partial<
-					import('@balena/compose/dist/release/models').ImageModel
+					import('balena-sdk').BalenaModel['image']['Write']
 				>;
 				// Don't use expect here as it can throw and prevent custom response
 				if (imageBody.status !== 'success') {

--- a/tests/test-data/projects/docker-compose/compose-fields/.env
+++ b/tests/test-data/projects/docker-compose/compose-fields/.env
@@ -1,0 +1,1 @@
+ENV_VAR=env_value

--- a/tests/test-data/projects/docker-compose/compose-fields/base.yml
+++ b/tests/test-data/projects/docker-compose/compose-fields/base.yml
@@ -1,0 +1,3 @@
+services:
+  base:
+    restart: always

--- a/tests/test-data/projects/docker-compose/compose-fields/docker-compose.yml
+++ b/tests/test-data/projects/docker-compose/compose-fields/docker-compose.yml
@@ -1,0 +1,57 @@
+services:
+  service1:
+    build:
+      context: ./service1
+    extends:
+      file: base.yml
+      service: base
+    annotations:
+      com.example.foo: bar
+    attach: false
+    cgroup: host
+    cpu_rt_runtime: 400
+    cpu_rt_period: 1000
+    cpus: 0.5
+    device_cgroup_rules:
+      - 'c 1:3 mr'
+    env_file:
+      - .env
+    healthcheck:
+      test: ["CMD", "echo", "ok"]
+      start_interval: 5s
+      start_period: 30s
+    ipc: shareable
+    label_file:
+      - labels.txt
+    pids_limit: 100
+    post_start:
+      - command: echo post-start
+    pre_stop:
+      - command: echo pre-stop
+    read_only: true
+    uts: host
+    networks:
+      custom_network:
+        aliases:
+          - alias1
+        ipv4_address: 172.16.0.10
+        ipv6_address: "fd00::10"
+        mac_address: "02:42:ac:11:00:02"
+        driver_opts:
+          com.docker.network.endpoint: "0.0.0.0"
+        gw_priority: 100
+        priority: 1000
+  service2:
+    build:
+      context: ./service2
+      dockerfile: Dockerfile-alt
+    network_mode: "service:service1"
+    pid: "service:service1"
+    volumes_from:
+      - service1
+
+networks:
+  custom_network:
+    ipam:
+      config:
+        - subnet: 172.16.0.0/24

--- a/tests/test-data/projects/docker-compose/compose-fields/labels.txt
+++ b/tests/test-data/projects/docker-compose/compose-fields/labels.txt
@@ -1,0 +1,1 @@
+com.example.label=value

--- a/tests/test-data/projects/docker-compose/compose-fields/service1/Dockerfile
+++ b/tests/test-data/projects/docker-compose/compose-fields/service1/Dockerfile
@@ -1,0 +1,2 @@
+FROM busybox
+CMD echo service1

--- a/tests/test-data/projects/docker-compose/compose-fields/service2/Dockerfile-alt
+++ b/tests/test-data/projects/docker-compose/compose-fields/service2/Dockerfile-alt
@@ -1,0 +1,2 @@
+FROM busybox
+CMD echo service2

--- a/tests/test-data/projects/docker-compose/compose-frag-ext-includes/compose-service2.yml
+++ b/tests/test-data/projects/docker-compose/compose-frag-ext-includes/compose-service2.yml
@@ -1,0 +1,14 @@
+services:
+  service2:
+    restart: always
+    build:
+      context: ./service2
+      dockerfile: Dockerfile-alt
+      args:
+        SHARED_ARG: shared_value
+        SERVICE2_ARG: s2_value
+    volumes:
+      - 'resin-data:/data'
+
+volumes:
+  resin-data:

--- a/tests/test-data/projects/docker-compose/compose-frag-ext-includes/docker-compose.yml
+++ b/tests/test-data/projects/docker-compose/compose-frag-ext-includes/docker-compose.yml
@@ -1,0 +1,22 @@
+x-common: &common
+  restart: always
+  volumes:
+    - 'resin-data:/data'
+
+x-build-args: &common-args
+  SHARED_ARG: shared_value
+
+include:
+  - compose-service2.yml
+
+volumes:
+  resin-data:
+
+services:
+  service1:
+    <<: *common
+    build:
+      context: ./service1
+      args:
+        <<: *common-args
+        SERVICE1_ARG: s1_value

--- a/tests/test-data/projects/docker-compose/compose-frag-ext-includes/service1/Dockerfile
+++ b/tests/test-data/projects/docker-compose/compose-frag-ext-includes/service1/Dockerfile
@@ -1,0 +1,2 @@
+FROM busybox
+CMD echo service1

--- a/tests/test-data/projects/docker-compose/compose-frag-ext-includes/service2/Dockerfile-alt
+++ b/tests/test-data/projects/docker-compose/compose-frag-ext-includes/service2/Dockerfile-alt
@@ -1,0 +1,2 @@
+FROM busybox
+CMD echo service2

--- a/tests/test-data/projects/docker-compose/dev-overlay/docker-compose.dev.yml
+++ b/tests/test-data/projects/docker-compose/dev-overlay/docker-compose.dev.yml
@@ -1,0 +1,6 @@
+services:
+  service1:
+    environment:
+      - DEBUG=1
+  service2:
+    build: ./service2

--- a/tests/test-data/projects/docker-compose/dev-overlay/docker-compose.yml
+++ b/tests/test-data/projects/docker-compose/dev-overlay/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '2'
+volumes:
+  resin-data:
+services:
+  service1:
+    volumes:
+      - 'resin-data:/data'
+    build: ./service1

--- a/tests/test-data/projects/docker-compose/rejections/build-deny-list.yml
+++ b/tests/test-data/projects/docker-compose/rejections/build-deny-list.yml
@@ -1,0 +1,5 @@
+services:
+  service1:
+    build:
+      context: ./service1
+      isolation: default

--- a/tests/test-data/projects/docker-compose/rejections/configs.yml
+++ b/tests/test-data/projects/docker-compose/rejections/configs.yml
@@ -1,0 +1,8 @@
+services:
+  service1:
+    build:
+      context: ./service1
+
+configs:
+  my_config:
+    file: ./config.txt

--- a/tests/test-data/projects/docker-compose/rejections/enable-ipv4.yml
+++ b/tests/test-data/projects/docker-compose/rejections/enable-ipv4.yml
@@ -1,0 +1,8 @@
+services:
+  service1:
+    build:
+      context: ./service1
+
+networks:
+  default:
+    enable_ipv4: true

--- a/tests/test-data/projects/docker-compose/rejections/enable-ipv6.yml
+++ b/tests/test-data/projects/docker-compose/rejections/enable-ipv6.yml
@@ -1,0 +1,8 @@
+services:
+  service1:
+    build:
+      context: ./service1
+
+networks:
+  default:
+    enable_ipv6: true

--- a/tests/test-data/projects/docker-compose/rejections/ipc-service.yml
+++ b/tests/test-data/projects/docker-compose/rejections/ipc-service.yml
@@ -1,0 +1,8 @@
+services:
+  service1:
+    build:
+      context: ./service1
+  service2:
+    build:
+      context: ./service1
+    ipc: "service:service1"

--- a/tests/test-data/projects/docker-compose/rejections/negative-pids-limit.yml
+++ b/tests/test-data/projects/docker-compose/rejections/negative-pids-limit.yml
@@ -1,0 +1,5 @@
+services:
+  service1:
+    build:
+      context: ./service1
+    pids_limit: -1

--- a/tests/test-data/projects/docker-compose/rejections/network-attachable.yml
+++ b/tests/test-data/projects/docker-compose/rejections/network-attachable.yml
@@ -1,0 +1,10 @@
+services:
+  service1:
+    build:
+      context: ./service1
+    networks:
+      custom_net:
+
+networks:
+  custom_net:
+    attachable: true

--- a/tests/test-data/projects/docker-compose/rejections/network-aux-addresses.yml
+++ b/tests/test-data/projects/docker-compose/rejections/network-aux-addresses.yml
@@ -1,0 +1,12 @@
+services:
+  service1:
+    build:
+      context: ./service1
+
+networks:
+  default:
+    ipam:
+      config:
+        - subnet: 172.16.0.0/24
+          aux_addresses:
+            host1: 172.16.0.2

--- a/tests/test-data/projects/docker-compose/rejections/network-driver.yml
+++ b/tests/test-data/projects/docker-compose/rejections/network-driver.yml
@@ -1,0 +1,10 @@
+services:
+  service1:
+    build:
+      context: ./service1
+    networks:
+      custom_net:
+
+networks:
+  custom_net:
+    driver: overlay

--- a/tests/test-data/projects/docker-compose/rejections/network-external.yml
+++ b/tests/test-data/projects/docker-compose/rejections/network-external.yml
@@ -1,0 +1,10 @@
+services:
+  service1:
+    build:
+      context: ./service1
+    networks:
+      custom_net:
+
+networks:
+  custom_net:
+    external: true

--- a/tests/test-data/projects/docker-compose/rejections/network-link-local-ips.yml
+++ b/tests/test-data/projects/docker-compose/rejections/network-link-local-ips.yml
@@ -1,0 +1,11 @@
+services:
+  service1:
+    build:
+      context: ./service1
+    networks:
+      custom_net:
+        link_local_ips:
+          - 169.254.0.10
+
+networks:
+  custom_net:

--- a/tests/test-data/projects/docker-compose/rejections/network-mode-container.yml
+++ b/tests/test-data/projects/docker-compose/rejections/network-mode-container.yml
@@ -1,0 +1,5 @@
+services:
+  service1:
+    build:
+      context: ./service1
+    network_mode: "container:abc123"

--- a/tests/test-data/projects/docker-compose/rejections/pid-container.yml
+++ b/tests/test-data/projects/docker-compose/rejections/pid-container.yml
@@ -1,0 +1,5 @@
+services:
+  service1:
+    build:
+      context: ./service1
+    pid: "container:abc123"

--- a/tests/test-data/projects/docker-compose/rejections/secrets.yml
+++ b/tests/test-data/projects/docker-compose/rejections/secrets.yml
@@ -1,0 +1,8 @@
+services:
+  service1:
+    build:
+      context: ./service1
+
+secrets:
+  my_secret:
+    file: ./secret.txt

--- a/tests/test-data/projects/docker-compose/rejections/security-opt.yml
+++ b/tests/test-data/projects/docker-compose/rejections/security-opt.yml
@@ -1,0 +1,6 @@
+services:
+  service1:
+    build:
+      context: ./service1
+    security_opt:
+      - seccomp:unconfined

--- a/tests/test-data/projects/docker-compose/rejections/service-deny-list.yml
+++ b/tests/test-data/projects/docker-compose/rejections/service-deny-list.yml
@@ -1,0 +1,6 @@
+services:
+  service1:
+    build:
+      context: ./service1
+    blkio_config:
+      weight: 300

--- a/tests/test-data/projects/docker-compose/rejections/service1/Dockerfile
+++ b/tests/test-data/projects/docker-compose/rejections/service1/Dockerfile
@@ -1,0 +1,2 @@
+FROM busybox
+CMD echo service1

--- a/tests/test-data/projects/docker-compose/rejections/volume-bind-mount.yml
+++ b/tests/test-data/projects/docker-compose/rejections/volume-bind-mount.yml
@@ -1,0 +1,8 @@
+services:
+  service1:
+    build:
+      context: ./service1
+    volumes:
+      - type: bind
+        source: /tmp/data
+        target: /data

--- a/tests/test-data/projects/docker-compose/rejections/volume-driver.yml
+++ b/tests/test-data/projects/docker-compose/rejections/volume-driver.yml
@@ -1,0 +1,10 @@
+services:
+  service1:
+    build:
+      context: ./service1
+    volumes:
+      - 'myvolume:/data'
+
+volumes:
+  myvolume:
+    driver: nfs

--- a/tests/test-data/projects/docker-compose/rejections/volume-external.yml
+++ b/tests/test-data/projects/docker-compose/rejections/volume-external.yml
@@ -1,0 +1,10 @@
+services:
+  service1:
+    build:
+      context: ./service1
+    volumes:
+      - 'myvolume:/data'
+
+volumes:
+  myvolume:
+    external: true

--- a/tests/test-data/projects/docker-compose/rejections/volumes-from-container.yml
+++ b/tests/test-data/projects/docker-compose/rejections/volumes-from-container.yml
@@ -1,0 +1,6 @@
+services:
+  service1:
+    build:
+      context: ./service1
+    volumes_from:
+      - "container:abc123"

--- a/tests/utils/compose_ts.spec.ts
+++ b/tests/utils/compose_ts.spec.ts
@@ -43,4 +43,26 @@ describe('parseComposePaths()', function () {
 			expect(err.message).to.include(badPath);
 		}
 	});
+
+	it('should merge a dev overlay with the base compose file', async function () {
+		const basePath = path.join(
+			projectsPath,
+			'dev-overlay',
+			'docker-compose.yml',
+		);
+		const devPath = path.join(
+			projectsPath,
+			'dev-overlay',
+			'docker-compose.dev.yml',
+		);
+		const composition = await parseComposePaths([basePath, devPath]);
+		expect(composition.services).to.have.property('service1');
+		expect(composition.services).to.have.property('service2');
+		// service1 should have the environment from the dev overlay merged in
+		expect(composition.services.service1.environment).to.deep.include({
+			DEBUG: '1',
+		});
+		// service1 should still have its build context from the base file
+		expect(composition.services.service1.build).to.have.property('context');
+	});
 });

--- a/tests/utils/compose_ts.spec.ts
+++ b/tests/utils/compose_ts.spec.ts
@@ -1,0 +1,46 @@
+import { expect } from 'chai';
+import * as path from 'path';
+
+import { parseComposePaths } from '../../build/utils/compose_ts';
+
+const projectsPath = path.join(
+	__dirname,
+	'..',
+	'test-data',
+	'projects',
+	'docker-compose',
+);
+
+describe('parseComposePaths()', function () {
+	it('should parse a valid compose file', async function () {
+		const composePath = path.join(projectsPath, 'basic', 'docker-compose.yml');
+		const composition = await parseComposePaths(composePath);
+		expect(composition).to.have.property('services');
+		expect(composition.services).to.have.property('service1');
+		expect(composition.services).to.have.property('service2');
+	});
+
+	it('should include the file path in the error when parsing fails', async function () {
+		const badPath = '/nonexistent/docker-compose.yml';
+		try {
+			await parseComposePaths(badPath);
+			expect.fail('should have thrown');
+		} catch (err: any) {
+			expect(err.message).to.include(
+				`Error parsing composition file "${badPath}"`,
+			);
+		}
+	});
+
+	it('should include all file paths in the error for multi-file parsing', async function () {
+		const validPath = path.join(projectsPath, 'basic', 'docker-compose.yml');
+		const badPath = '/nonexistent/docker-compose.dev.yml';
+		try {
+			await parseComposePaths([validPath, badPath]);
+			expect.fail('should have thrown');
+		} catch (err: any) {
+			expect(err.message).to.include(validPath);
+			expect(err.message).to.include(badPath);
+		}
+	});
+});

--- a/tests/utils/compose_ts.spec.ts
+++ b/tests/utils/compose_ts.spec.ts
@@ -1,7 +1,8 @@
 import { expect } from 'chai';
 import * as path from 'path';
 
-import { parseComposePaths } from '../../build/utils/compose_ts';
+import { isBuildConfig, parseComposePaths } from '../../build/utils/compose_ts';
+import { createProject } from '../../build/utils/compose';
 
 const projectsPath = path.join(
 	__dirname,
@@ -41,6 +42,18 @@ describe('parseComposePaths()', function () {
 		} catch (err: any) {
 			expect(err.message).to.include(validPath);
 			expect(err.message).to.include(badPath);
+		}
+	});
+
+	it('should populate tags on build config descriptors in createProject', async function () {
+		const composePath = path.join(projectsPath, 'basic', 'docker-compose.yml');
+		const composition = await parseComposePaths(composePath);
+		const project = createProject(composePath, composition);
+		for (const d of project.descriptors) {
+			if (isBuildConfig(d.image)) {
+				expect(d.image.tags).to.be.an('array').that.is.not.empty;
+				expect(d.image.tags![0]).to.be.a('string').that.is.not.empty;
+			}
 		}
 	});
 

--- a/tests/utils/device/live.spec.ts
+++ b/tests/utils/device/live.spec.ts
@@ -78,7 +78,7 @@ describeSS('LivepushManager::setupFilesystemWatcher', function () {
 
 	async function createMonitors(
 		projectPath: string,
-		composition: import('@balena/compose/dist/parse').Composition,
+		composition: import('@balena/compose-parser').Composition,
 		multiDockerignore: boolean,
 		changedPathHandler: (serviceName: string, changedPath: string) => void,
 	): Promise<ByService<chokidar.FSWatcher>> {
@@ -102,7 +102,7 @@ describeSS('LivepushManager::setupFilesystemWatcher', function () {
 
 		for (const serviceName of Object.keys(composition.services)) {
 			const service = composition.services[serviceName];
-			const serviceContext = path.resolve(rootContext, service.build!.context);
+			const serviceContext = path.resolve(rootContext, service.build!.context!);
 
 			const monitor = manager.testSetupFilesystemWatcher(
 				serviceName,


### PR DESCRIPTION
This update switches to using [@balena/compose-parser](https://github.com/balena-io-modules/balena-compose-parser) directly for compose file parsing. See [here](https://github.com/balena-io-modules/balena-compose-parser/pull/1) for compose features that are now supported with the switch to compose-parser.

Some compose features enabled by compose-parser are not implemented with this bump, as they are separate features:

* [Multiple compose file merging](https://docs.docker.com/reference/compose-file/merge/). Pass the files as an array to `parse`, with later files overriding earlier files.
* Build-time variable interpolation from shell env
    * **TODO compose-parser**: Variables from .env file in the same dir as the compose file aren't being picked up

## Release Notes
This release adds CLI support for a number of compose fields in the latest docker compose spec. The fields are listed below, however note that balena Supervisor support needs to be added for the fields to be fully supported by balena. These fields will be rejected by the Supervisor via the container contract mechanism until Supervisor support is implemented. See https://github.com/balena-io-modules/balena-compose-parser/pull/19 where the compose container contract is injected if new fields are detected.

### Dev overlay file merging
While in local mode, all top-level fields in `docker-compose.dev.yml` are merged into the main compose file. Before, only top-level `service` fields were merged. A bare Dockerfile with no docker-compose.yml will no longer apply docker-compose.dev.yml as an overlay, so make sure to create a docker-compose file if you wish for dev overlays to be applied.

### Add support for compose fields:

#### Compose features:
* [Fragments](https://docs.docker.com/reference/compose-file/fragments/), [extensions](https://docs.docker.com/reference/compose-file/extension/) (pre-v8 balena-compose already supported this, but using a custom implementation. balena-compose v8 moves to the official implementation used by docker compose (compose-go)
* [`include`](https://docs.docker.com/reference/compose-file/include/) directive

#### `services.${serviceName}`:

NOTE: "logged / not logged" refers to Supervisor logging `Ignoring unsupported or unknown compose fields`

| field | SV behavior |
| --- | --- |
| annotations | ignored, logged |
| attach | ignored, logged |
| cgroup | ignored, logged |
| cpu_rt_runtime | ignored, logged |
| cpu_rt_period | ignored, logged |
| cpus | ignored, not logged |
| device_cgroup_rules | ignored, logged |
| env_file | N/A - compose-go folds this into `environment` during parsing |
| extends | N/A - compose-go folds this into the composition during parsing |
| healthcheck.start_interval | ignored, not logged |
| healthcheck.start_period | supported |
| ipc | **conditional error loop** if `ipc: service:${serviceName}`, supports `ipc: shareable` |
| label_file | N/A - compose-go folds this into `labels` during parsing |
| network_mode=service:${serviceName} | supported (this was supported before but compose-go adds a depends_on dependency which wasn't present before) |
| networks.aliases | supported |
| networks.ipv4_address | supported |
| networks.ipv6_address | ignored, not logged |
| networks.link_local_ips | **error loop** |
| networks.mac_address | ignored; Supervisor configures it in the wrong place, `Config.MacAddress`, instead of `NetworkSettings.MacAddress` |
| networks.driver_opts | ignored, not logged |
| networks.gw_priority | ignored, not logged |
| networks.priority | ignored, not logged |
| pid=service:${serviceName} | ignored, not logged |
| pids_limit | **conditional error loop** if negative `pids_limit` |
| post_start | ignored, logged |
| pre_stop | ignored, logged |
| read_only | supported |
| uts | ignored, logged |
| volumes_from | ignored, logged |

#### Reject unsupported fields with clear messages:

* Top-level `secrets` & `configs`
* Service fields defined in [SERVICE_CONFIG_DENY_LIST](https://github.com/balena-io-modules/balena-compose-parser/blob/e5a71ebb8c7a7b70ad62d73501456e8f03c74e36/lib/compose.ts#L198)
* Service.build fields defined in [BUILD_CONFIG_DENY_LIST](https://github.com/balena-io-modules/balena-compose-parser/blob/e5a71ebb8c7a7b70ad62d73501456e8f03c74e36/lib/compose.ts#L445)
* `container:${containerId}` for service.network_mode
* `container:${containerId}` for service.pid
* `container:${containerId}` for service.volumes_from
* All service.security_opt as unsupported except `no-new-privileges`
* Network subfields `attachable`, `external`, `name`, `driver` that's not `bridge` or `default`, `enable_ipv4`, `enable_ipv6`, `ipam.config.aux_addresses`
* Volume subfields `external`, `name`, `driver` that's not `local` or `default`
* Long syntax volumes of type `bind`, `npipe`, `cluster`, `image`, unless specified bind mount is in [allowedBindMounts](https://github.com/balena-io-modules/balena-compose-parser/blob/e5a71ebb8c7a7b70ad62d73501456e8f03c74e36/lib/compose.ts#L231) (corresponding to balena's supported [labels](https://docs.balena.io/reference/supervisor/docker-compose/#labels))
* Labels using balena namespace `io.balena.private`

#### Ignore fields that are required in balena-compose:

* Top-level `version` is now optional and won't throw an error if not present and equal to one of
  `2.0`, `2.1`, `2.2`, `2.3`, or `2.4`

#### Normalize fields parsed by compose-go to be more compatible with balena or in line with current balena-compose behavior:

* Remove null entrypoint, which in Docker means that the default entrypoint from the image is used,
  but in balena, overrides any ENTRYPOINT directive in the Dockerfile.
* Convert long syntax ports to short syntax, as all port definitions are converted to long syntax by compose-go,
  but aren't supported by the Supervisor. For similar reasons, also convert long syntax depends_on, devices, and volumes.
* Compose converts relative context paths to absolute paths, convert back to relative paths to be compatible with our build system.
* For any allowed bind mount specified in service.volumes, remove them from volumes and add to feature labels.
* Add image as build tag if image & build both present. However, uncertain if this behavior is necessary.
* Move `service.volumes` of type `tmpfs` to `service.tmpfs`
* Reject service.volume where:
        * `source` or `target` are not defined
        * volume is not defined in top-level volumes
        * it specifies volume [options](https://docs.docker.com/reference/compose-file/services/#long-syntax-6) (long syntax only)
* Reject service.tmpfs if it defines tmpfs [options](https://docs.docker.com/reference/compose-file/services/#long-syntax-6) (long syntax only)
* Allow short syntax tmpfs with options (not supported in Supervisor however, this is in line with previous balena-compose behavior, however is likely an erroneous allowance)
* Reject `build.network` that's not defined at top-level

#### Log warnings:

* service.expose is informational only, warn & remove it from composition
* Warn if oom_score_adj is set to a value under OOM_SCORE_ADJ_WARN_THRESHOLD (-900)
* `com.docker.network.bridge.name` network.driver_opt which may interfere with current Supervisor firewall implementation, which relies on default naming scheme


Change-type: major
Depends-on: https://github.com/balena-io-modules/balena-compose/pull/97
See: https://balena.fibery.io/Work/Project/Integrate-compose-go-using-Go-binary-into-balena-compose,-CLI,-and-builder-1746