### PR TITLE
test(device ssh): unset proxy env vars that break stderr assertions

### DIFF
--- a/tests/commands/device/ssh.spec.ts
+++ b/tests/commands/device/ssh.spec.ts
@@ -57,7 +57,19 @@ describe('balena device ssh', function () {
 		await server.stop();
 	});
 
+	let savedProxyVars: Record<string, string | undefined>;
+
 	beforeEach(async function () {
+		// Unset proxy env vars that may be set by npm security wrappers.
+		// These cause getProxyConfig() to detect a proxy, triggering a
+		// proxytunnel warning on stderr that breaks assertions.
+		savedProxyVars = {
+			HTTPS_PROXY: process.env.HTTPS_PROXY,
+			HTTP_PROXY: process.env.HTTP_PROXY,
+		};
+		delete process.env.HTTPS_PROXY;
+		delete process.env.HTTP_PROXY;
+
 		// Stub child_process.spawn for SSH mocking
 		const childProcess = await import('child_process');
 		spawnStub = sinon.stub(childProcess, 'spawn').callsFake(function (
@@ -76,6 +88,13 @@ describe('balena device ssh', function () {
 	});
 
 	afterEach(async function () {
+		for (const [key, value] of Object.entries(savedProxyVars)) {
+			if (value == null) {
+				delete process.env[key];
+			} else {
+				process.env[key] = value;
+			}
+		}
 		// Restore the stub
 		if (spawnStub) {
 			spawnStub.restore();


### PR DESCRIPTION

`device ssh` tests assert stderr is empty, but environments with npm security wrappers may inject `HTTPS_PROXY`, causing `getProxyConfig()` to detect a proxy and emit a `proxytunnel` warning that fails the assertion

Unset `HTTPS_PROXY` and `HTTP_PROXY` in `beforeEach` and restore in `afterEach` so the warnings are never emitted — keeps `expect(err).to.be.empty` as a strict assertion

See: https://balena.fibery.io/Work/Improvement/Update-balena-CLI-ssh-tests-to-unset-HTTPS_PROXY-4043