### PR TITLE
Fix deploy progress feedback

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -753,13 +753,13 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudfront/node_modules/@smithy/util-utf8": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.4.0.tgz",
-      "integrity": "sha512-dMvQY14daYwEfKR+/ACROrUwJ5onUue7d9o4KJo4gaecn5eVzxlCbSeU9GSh0ojFpIiI1bpnJJxO1wY2VXDEtQ==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.4.1.tgz",
+      "integrity": "sha512-OCnvu9xJnNJf0kJHI4101r4bf2l4niSMOzeiN5AgE97RnbzmYKmixc95VpiRRU5QqEab8jq2Afpfs1xM86KRSw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.25.0",
+        "@smithy/core": "^3.25.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1227,13 +1227,13 @@
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@smithy/util-utf8": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.4.0.tgz",
-      "integrity": "sha512-dMvQY14daYwEfKR+/ACROrUwJ5onUue7d9o4KJo4gaecn5eVzxlCbSeU9GSh0ojFpIiI1bpnJJxO1wY2VXDEtQ==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.4.1.tgz",
+      "integrity": "sha512-OCnvu9xJnNJf0kJHI4101r4bf2l4niSMOzeiN5AgE97RnbzmYKmixc95VpiRRU5QqEab8jq2Afpfs1xM86KRSw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.25.0",
+        "@smithy/core": "^3.25.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1290,12 +1290,12 @@
       }
     },
     "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-utf8": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.4.0.tgz",
-      "integrity": "sha512-dMvQY14daYwEfKR+/ACROrUwJ5onUue7d9o4KJo4gaecn5eVzxlCbSeU9GSh0ojFpIiI1bpnJJxO1wY2VXDEtQ==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.4.1.tgz",
+      "integrity": "sha512-OCnvu9xJnNJf0kJHI4101r4bf2l4niSMOzeiN5AgE97RnbzmYKmixc95VpiRRU5QqEab8jq2Afpfs1xM86KRSw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.25.0",
+        "@smithy/core": "^3.25.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1353,12 +1353,12 @@
       }
     },
     "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-utf8": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.4.0.tgz",
-      "integrity": "sha512-dMvQY14daYwEfKR+/ACROrUwJ5onUue7d9o4KJo4gaecn5eVzxlCbSeU9GSh0ojFpIiI1bpnJJxO1wY2VXDEtQ==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.4.1.tgz",
+      "integrity": "sha512-OCnvu9xJnNJf0kJHI4101r4bf2l4niSMOzeiN5AgE97RnbzmYKmixc95VpiRRU5QqEab8jq2Afpfs1xM86KRSw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.25.0",
+        "@smithy/core": "^3.25.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1404,12 +1404,12 @@
       }
     },
     "node_modules/@aws-sdk/core/node_modules/@smithy/util-utf8": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.4.0.tgz",
-      "integrity": "sha512-dMvQY14daYwEfKR+/ACROrUwJ5onUue7d9o4KJo4gaecn5eVzxlCbSeU9GSh0ojFpIiI1bpnJJxO1wY2VXDEtQ==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.4.1.tgz",
+      "integrity": "sha512-OCnvu9xJnNJf0kJHI4101r4bf2l4niSMOzeiN5AgE97RnbzmYKmixc95VpiRRU5QqEab8jq2Afpfs1xM86KRSw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.25.0",
+        "@smithy/core": "^3.25.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1561,12 +1561,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/util-utf8": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.4.0.tgz",
-      "integrity": "sha512-dMvQY14daYwEfKR+/ACROrUwJ5onUue7d9o4KJo4gaecn5eVzxlCbSeU9GSh0ojFpIiI1bpnJJxO1wY2VXDEtQ==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.4.1.tgz",
+      "integrity": "sha512-OCnvu9xJnNJf0kJHI4101r4bf2l4niSMOzeiN5AgE97RnbzmYKmixc95VpiRRU5QqEab8jq2Afpfs1xM86KRSw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.25.0",
+        "@smithy/core": "^3.25.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1633,13 +1633,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/util-utf8": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.4.0.tgz",
-      "integrity": "sha512-dMvQY14daYwEfKR+/ACROrUwJ5onUue7d9o4KJo4gaecn5eVzxlCbSeU9GSh0ojFpIiI1bpnJJxO1wY2VXDEtQ==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.4.1.tgz",
+      "integrity": "sha512-OCnvu9xJnNJf0kJHI4101r4bf2l4niSMOzeiN5AgE97RnbzmYKmixc95VpiRRU5QqEab8jq2Afpfs1xM86KRSw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.25.0",
+        "@smithy/core": "^3.25.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1773,12 +1773,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/util-utf8": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.4.0.tgz",
-      "integrity": "sha512-dMvQY14daYwEfKR+/ACROrUwJ5onUue7d9o4KJo4gaecn5eVzxlCbSeU9GSh0ojFpIiI1bpnJJxO1wY2VXDEtQ==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.4.1.tgz",
+      "integrity": "sha512-OCnvu9xJnNJf0kJHI4101r4bf2l4niSMOzeiN5AgE97RnbzmYKmixc95VpiRRU5QqEab8jq2Afpfs1xM86KRSw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.25.0",
+        "@smithy/core": "^3.25.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1914,13 +1914,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@smithy/util-utf8": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.4.0.tgz",
-      "integrity": "sha512-dMvQY14daYwEfKR+/ACROrUwJ5onUue7d9o4KJo4gaecn5eVzxlCbSeU9GSh0ojFpIiI1bpnJJxO1wY2VXDEtQ==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.4.1.tgz",
+      "integrity": "sha512-OCnvu9xJnNJf0kJHI4101r4bf2l4niSMOzeiN5AgE97RnbzmYKmixc95VpiRRU5QqEab8jq2Afpfs1xM86KRSw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.25.0",
+        "@smithy/core": "^3.25.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2067,13 +2067,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@smithy/util-utf8": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.4.0.tgz",
-      "integrity": "sha512-dMvQY14daYwEfKR+/ACROrUwJ5onUue7d9o4KJo4gaecn5eVzxlCbSeU9GSh0ojFpIiI1bpnJJxO1wY2VXDEtQ==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.4.1.tgz",
+      "integrity": "sha512-OCnvu9xJnNJf0kJHI4101r4bf2l4niSMOzeiN5AgE97RnbzmYKmixc95VpiRRU5QqEab8jq2Afpfs1xM86KRSw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.25.0",
+        "@smithy/core": "^3.25.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2356,13 +2356,13 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-utf8": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.4.0.tgz",
-      "integrity": "sha512-dMvQY14daYwEfKR+/ACROrUwJ5onUue7d9o4KJo4gaecn5eVzxlCbSeU9GSh0ojFpIiI1bpnJJxO1wY2VXDEtQ==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.4.1.tgz",
+      "integrity": "sha512-OCnvu9xJnNJf0kJHI4101r4bf2l4niSMOzeiN5AgE97RnbzmYKmixc95VpiRRU5QqEab8jq2Afpfs1xM86KRSw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.25.0",
+        "@smithy/core": "^3.25.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2485,12 +2485,12 @@
       }
     },
     "node_modules/@aws-sdk/token-providers/node_modules/@smithy/util-utf8": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.4.0.tgz",
-      "integrity": "sha512-dMvQY14daYwEfKR+/ACROrUwJ5onUue7d9o4KJo4gaecn5eVzxlCbSeU9GSh0ojFpIiI1bpnJJxO1wY2VXDEtQ==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.4.1.tgz",
+      "integrity": "sha512-OCnvu9xJnNJf0kJHI4101r4bf2l4niSMOzeiN5AgE97RnbzmYKmixc95VpiRRU5QqEab8jq2Afpfs1xM86KRSw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.25.0",
+        "@smithy/core": "^3.25.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6589,9 +6589,9 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.25.0.tgz",
-      "integrity": "sha512-TTD6el7tvKyafkXBf7XO3jLOE+qVxOTrLjp/fEGiV3BMfUHK/LfdYlQO9YgZvzxC7kqA3H/IhJXNqQgnbgjb7A==",
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.25.1.tgz",
+      "integrity": "sha512-zpDbpXBCBsxfLtG2GEUyfgvHvSFrw5CwDZSNzL0v52gx/c3oPlPbm+7W7num8xs6vyiUBn+bvYPHcQDOXZynCQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
@@ -6741,12 +6741,12 @@
       }
     },
     "node_modules/@smithy/hash-node/node_modules/@smithy/util-utf8": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.4.0.tgz",
-      "integrity": "sha512-dMvQY14daYwEfKR+/ACROrUwJ5onUue7d9o4KJo4gaecn5eVzxlCbSeU9GSh0ojFpIiI1bpnJJxO1wY2VXDEtQ==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.4.1.tgz",
+      "integrity": "sha512-OCnvu9xJnNJf0kJHI4101r4bf2l4niSMOzeiN5AgE97RnbzmYKmixc95VpiRRU5QqEab8jq2Afpfs1xM86KRSw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.25.0",
+        "@smithy/core": "^3.25.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6769,13 +6769,13 @@
       }
     },
     "node_modules/@smithy/hash-stream-node/node_modules/@smithy/util-utf8": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.4.0.tgz",
-      "integrity": "sha512-dMvQY14daYwEfKR+/ACROrUwJ5onUue7d9o4KJo4gaecn5eVzxlCbSeU9GSh0ojFpIiI1bpnJJxO1wY2VXDEtQ==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.4.1.tgz",
+      "integrity": "sha512-OCnvu9xJnNJf0kJHI4101r4bf2l4niSMOzeiN5AgE97RnbzmYKmixc95VpiRRU5QqEab8jq2Afpfs1xM86KRSw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.25.0",
+        "@smithy/core": "^3.25.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6796,12 +6796,12 @@
       }
     },
     "node_modules/@smithy/is-array-buffer": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.4.0.tgz",
-      "integrity": "sha512-EZ6yOBlyezpi9BaP1rBFL3+2R4oDq0aUlgmrlFRuckVH7UdP4/fnFma1ozc8Td33y7eVY/yHpQVh7phvddZ6Lw==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.4.1.tgz",
+      "integrity": "sha512-GCgtCtlrm686i1Zc2MCVSxLX9e1D9l+QA9N6LkDQqx+L0rn6uJcRc5wIfw1vt1X2XiX5zXA0gkd0usxbNFuBPg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.25.0",
+        "@smithy/core": "^3.25.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6824,13 +6824,13 @@
       }
     },
     "node_modules/@smithy/md5-js/node_modules/@smithy/util-utf8": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.4.0.tgz",
-      "integrity": "sha512-dMvQY14daYwEfKR+/ACROrUwJ5onUue7d9o4KJo4gaecn5eVzxlCbSeU9GSh0ojFpIiI1bpnJJxO1wY2VXDEtQ==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.4.1.tgz",
+      "integrity": "sha512-OCnvu9xJnNJf0kJHI4101r4bf2l4niSMOzeiN5AgE97RnbzmYKmixc95VpiRRU5QqEab8jq2Afpfs1xM86KRSw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.25.0",
+        "@smithy/core": "^3.25.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7046,12 +7046,12 @@
       }
     },
     "node_modules/@smithy/signature-v4/node_modules/@smithy/util-utf8": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.4.0.tgz",
-      "integrity": "sha512-dMvQY14daYwEfKR+/ACROrUwJ5onUue7d9o4KJo4gaecn5eVzxlCbSeU9GSh0ojFpIiI1bpnJJxO1wY2VXDEtQ==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.4.1.tgz",
+      "integrity": "sha512-OCnvu9xJnNJf0kJHI4101r4bf2l4niSMOzeiN5AgE97RnbzmYKmixc95VpiRRU5QqEab8jq2Afpfs1xM86KRSw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.25.0",
+        "@smithy/core": "^3.25.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7117,12 +7117,12 @@
       }
     },
     "node_modules/@smithy/util-base64/node_modules/@smithy/util-utf8": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.4.0.tgz",
-      "integrity": "sha512-dMvQY14daYwEfKR+/ACROrUwJ5onUue7d9o4KJo4gaecn5eVzxlCbSeU9GSh0ojFpIiI1bpnJJxO1wY2VXDEtQ==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.4.1.tgz",
+      "integrity": "sha512-OCnvu9xJnNJf0kJHI4101r4bf2l4niSMOzeiN5AgE97RnbzmYKmixc95VpiRRU5QqEab8jq2Afpfs1xM86KRSw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.25.0",
+        "@smithy/core": "^3.25.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7154,12 +7154,12 @@
       }
     },
     "node_modules/@smithy/util-buffer-from": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.4.0.tgz",
-      "integrity": "sha512-C8u31V1di8HIs8azooCJ4XfG/RwmMZ5rJRfwYd0z/B3Yu1985KWouo9m2WuHNXXXh+5fLi+15Ut8jYlgBWETbA==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.4.1.tgz",
+      "integrity": "sha512-ZUdCO+tYTLHliCu5zTQUCpd+/dQdoJfgiV+S0zTi5cCWnZQ4G5TDnJx0rF33xzhr/vJE0cadhRWN8ZYNm2Vklg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.25.0",
+        "@smithy/core": "^3.25.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7284,12 +7284,12 @@
       }
     },
     "node_modules/@smithy/util-stream/node_modules/@smithy/util-utf8": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.4.0.tgz",
-      "integrity": "sha512-dMvQY14daYwEfKR+/ACROrUwJ5onUue7d9o4KJo4gaecn5eVzxlCbSeU9GSh0ojFpIiI1bpnJJxO1wY2VXDEtQ==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.4.1.tgz",
+      "integrity": "sha512-OCnvu9xJnNJf0kJHI4101r4bf2l4niSMOzeiN5AgE97RnbzmYKmixc95VpiRRU5QqEab8jq2Afpfs1xM86KRSw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.25.0",
+        "@smithy/core": "^3.25.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -18879,9 +18879,9 @@
       }
     },
     "node_modules/pinejs-client-core/node_modules/@balena/odata-to-abstract-sql": {
-      "version": "10.0.25",
-      "resolved": "https://registry.npmjs.org/@balena/odata-to-abstract-sql/-/odata-to-abstract-sql-10.0.25.tgz",
-      "integrity": "sha512-J3eVrYxodJKxSu+lC35Qw5g/Cns78jnoakiBxpjl02+BzgGNlCMMmoVorPr67eYOeCQO7mItHJh9/bMO5PEf5A==",
+      "version": "10.0.26",
+      "resolved": "https://registry.npmjs.org/@balena/odata-to-abstract-sql/-/odata-to-abstract-sql-10.0.26.tgz",
+      "integrity": "sha512-oRr9J18IN3kXocD3WDpsbUgFtPpCqrpGGRWkxvf3vvdjdGL+ZDkrFUO0R1NjXpMxoDSZVxGgdu6R+ZoPVJHmjg==",
       "license": "BSD",
       "dependencies": {
         "@balena/abstract-sql-compiler": "^11.2.0",

--- a/src/utils/compose.ts
+++ b/src/utils/compose.ts
@@ -315,27 +315,50 @@ const formatDuration = (seconds: number): string => {
 };
 
 const renderProgressBar = function (percentage: number, stepCount: number) {
-	percentage = Math.max(Math.min(percentage, 0), 100);
+	percentage = Math.min(Math.max(percentage, 0), 100);
 	const barCount = Math.floor((stepCount * percentage) / 100);
 	const spaceCount = stepCount - barCount;
 	const bar = `[${'='.repeat(barCount)}>${' '.repeat(spaceCount)}]`;
 	return `${bar} ${`${percentage}`.padStart(3)}%`;
 };
 
+/**
+ * Creates a progress callback for image push operations.
+ * Supports both TTY (in-place line replacement) and non-TTY (throttled newline output).
+ */
 export const pushProgressRenderer = function (
 	tty: ReturnType<typeof import('./tty')>,
 	prefix: string,
 ): ProgressCallback & { end: () => void } {
+	const startTime = Date.now();
+	const isTTY = process.stdout.isTTY;
+	const NON_TTY_THROTTLE_MS = 5000;
+	let lastNonTtyOutput = 0;
+
 	const fn: ProgressCallback & { end: () => void } = function (e) {
 		const { error, percentage } = e;
 		if (error != null) {
 			throw new Error(error);
 		}
 		const bar = renderProgressBar(percentage, 40);
-		return tty.replaceLine(`${prefix}${bar}\r`);
+		const elapsed = (Date.now() - startTime) / 1000;
+		const elapsedStr = ` (${formatDuration(elapsed)})`;
+
+		if (isTTY) {
+			return tty.replaceLine(`${prefix}${bar}${elapsedStr}\r`);
+		}
+
+		// Non-TTY: throttle output to avoid flooding logs
+		const now = Date.now();
+		if (now - lastNonTtyOutput >= NON_TTY_THROTTLE_MS) {
+			lastNonTtyOutput = now;
+			return tty.writeLine(`${prefix}${bar}${elapsedStr}`);
+		}
 	};
 	fn.end = () => {
-		tty.clearLine();
+		if (isTTY) {
+			tty.clearLine();
+		}
 	};
 	return fn;
 };

--- a/src/utils/compose_ts.ts
+++ b/src/utils/compose_ts.ts
@@ -1359,8 +1359,8 @@ async function pushServiceImages(
 		token,
 		taggedImages,
 		async function (serviceImage) {
-			logger.logDebug(
-				`Saving image ${serviceImage.is_stored_at__image_location}`,
+			logger.logInfo(
+				`Saving image details for ${serviceImage.is_stored_at__image_location}`,
 			);
 			if (skipLogUpload) {
 				delete (serviceImage as Partial<typeof serviceImage>).build_log;

--- a/tests/commands/deploy.spec.ts
+++ b/tests/commands/deploy.spec.ts
@@ -47,6 +47,7 @@ const commonResponseLines = {
 		// '[Build] main Step 1/4 : FROM busybox',
 		'[Info] Creating release...',
 		'[Info] Pushing images to registry...',
+		'[Info] Saving image details for registry2.balena-cloud.com/v2/c089c421fb2336d0475166fbf3d0f9fa',
 		'[Info] Saving release...',
 		'[Success] Deploy succeeded!',
 		'[Success] Release: 09f7c3e1fdec609be818002299edfc2a',

--- a/tests/utils/compose_ts.spec.ts
+++ b/tests/utils/compose_ts.spec.ts
@@ -1,8 +1,9 @@
 import { expect } from 'chai';
+import * as sinon from 'sinon';
 import * as path from 'path';
 
 import { isBuildConfig, parseComposePaths } from '../../build/utils/compose_ts';
-import { createProject } from '../../build/utils/compose';
+import { createProject, pushProgressRenderer } from '../../build/utils/compose';
 
 const projectsPath = path.join(
 	__dirname,
@@ -77,5 +78,102 @@ describe('parseComposePaths()', function () {
 		});
 		// service1 should still have its build context from the base file
 		expect(composition.services.service1.build).to.have.property('context');
+	});
+});
+
+describe('pushProgressRenderer()', function () {
+	function createMockTty() {
+		return {
+			replaceLine: sinon.stub(),
+			clearLine: sinon.stub(),
+			writeLine: sinon.stub(),
+			write: sinon.stub(),
+			currentWindowSize: sinon.stub().returns({ width: 80, height: 24 }),
+			hideCursor: sinon.stub(),
+			showCursor: sinon.stub(),
+			cursorUp: sinon.stub(),
+			cursorDown: sinon.stub(),
+			deleteToEnd: sinon.stub(),
+			stream: process.stdout,
+		};
+	}
+
+	let clock: sinon.SinonFakeTimers;
+	let originalIsTTY: boolean | undefined;
+
+	beforeEach(function () {
+		clock = sinon.useFakeTimers({ now: Date.now(), shouldAdvanceTime: false });
+		originalIsTTY = process.stdout.isTTY;
+		Object.defineProperty(process.stdout, 'isTTY', {
+			value: true,
+			writable: true,
+			configurable: true,
+		});
+	});
+
+	afterEach(function () {
+		clock.restore();
+		Object.defineProperty(process.stdout, 'isTTY', {
+			value: originalIsTTY,
+			writable: true,
+			configurable: true,
+		});
+	});
+
+	it('should render prefix and percentage', function () {
+		const mockTty = createMockTty();
+		const renderer = pushProgressRenderer(mockTty as any, '[Push] ');
+		renderer({ percentage: 50 });
+		const line = mockTty.replaceLine.firstCall.args[0] as string;
+		expect(line).to.include('[Push] ');
+		expect(line).to.include('50%');
+	});
+
+	it('should clamp percentage above 100 to 100%', function () {
+		const mockTty = createMockTty();
+		const renderer = pushProgressRenderer(mockTty as any, '[Push] ');
+		renderer({ percentage: 150 });
+		const line = mockTty.replaceLine.firstCall.args[0] as string;
+		expect(line).to.include('100%');
+		expect(line).to.not.include('150%');
+	});
+
+	it('should show elapsed time', function () {
+		const mockTty = createMockTty();
+		const renderer = pushProgressRenderer(mockTty as any, '[Push] ');
+		clock.tick(10000);
+		renderer({ percentage: 50 });
+		const line = mockTty.replaceLine.firstCall.args[0] as string;
+		expect(line).to.include('(0:10)');
+	});
+
+	it('should show M:SS format for long uploads', function () {
+		const mockTty = createMockTty();
+		const renderer = pushProgressRenderer(mockTty as any, '[Push] ');
+		clock.tick(90000);
+		renderer({ percentage: 75 });
+		const line = mockTty.replaceLine.firstCall.args[0] as string;
+		expect(line).to.include('(1:30)');
+	});
+
+	it('should use writeLine in non-TTY mode', function () {
+		Object.defineProperty(process.stdout, 'isTTY', {
+			value: undefined,
+			writable: true,
+			configurable: true,
+		});
+		const mockTty = createMockTty();
+		const renderer = pushProgressRenderer(mockTty as any, '[Push] ');
+		renderer({ percentage: 50 });
+		expect(mockTty.writeLine.called).to.be.true;
+		expect(mockTty.replaceLine.called).to.be.false;
+	});
+
+	it('should throw on error event', function () {
+		const mockTty = createMockTty();
+		const renderer = pushProgressRenderer(mockTty as any, '[Push] ');
+		expect(() => {
+			renderer({ error: 'push failed' });
+		}).to.throw('push failed');
 	});
 });


### PR DESCRIPTION
While working on the Nvidia hostapp-extension PoC, I noticed there are a few issues with the UX of `balena deploy` that are very ugly when pushing large AI images. The most notable is the bug for when the images are pushed to the registry. The progress bar there jumps immediately to 100% because the logic is backwards and then the user is left staring at 100% for 30+ minutes (I often thought the process had failed/hung)

I also added a elapsed time counter to the progress bar to improve the UX, this way the user knows that the process is still ticking along and hasn't failed.

Finally, this PR also changes the log after Pushing images to registry... which says `Saving image details for registry2.balena-cloud.com/v2/c089c421fb2336d0475166fbf3d0f9fa'` from debug to info, because it is useful to know that things are being finalized.

This is what the new UX looks like
<img width="624" height="416" alt="Screenshot 2026-06-18 at 11 55 45" src="https://github.com/user-attachments/assets/0fcce480-3d1c-4036-aa28-13e44bf34aa8" />


