### PR TITLE
deploy: register image profiles on release creation

### DIFF
--- a/src/utils/compose.ts
+++ b/src/utils/compose.ts
@@ -164,6 +164,7 @@ export const createRelease = async function (
 		is_final: !draft,
 		contract: contract ?? undefined,
 		imgDescriptors,
+		createImageProfiles: true,
 	});
 
 	for (const serviceImage of Object.values(serviceImages)) {


### PR DESCRIPTION
Opt in to `@balena/compose` release.create's `createImageProfiles` so that `balena deploy` registers an image_profile row per service profile. Other release-creating paths stay opt-out by default.

Does not typecheck until @balena/compose is bumped to a version that exposes the `createImageProfiles` request field; that dependency bump is intentionally deferred until it is published.

Change-type: minor
Depends-on: https://github.com/balena-io-modules/balena-compose/pull/134